### PR TITLE
Better Burning Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ All changes are toggleable via the config file.
 * Bed Obstruction Replacement: Replaces bed obstruction checks with an improved version
 * Better Burning
     * Fixes some edge cases where fire damage sources won't cause mobs to drop their cooked items
-    * Allows skeletons to shoot flaming arrows when on fire (70% chance)
+    * Allows skeletons to shoot flaming arrows when on fire (30% chance * regional difficulty)
     * If entities have fire resistance, they get extinguished right away when on fire
-    * Allows fire to spread from entity to entity (30% chance)
+    * Allows fire to spread from entity to entity (30% chance * regional difficulty)
+    * Prevents the fire animation overlay from being displayed when the player is immune to fire
 * Better Harvest: Prevents breaking lower parts of sugar cane and cacti as well as unripe crops, unless sneaking
 * Better Ignition: Enables ignition of entities by right-clicking instead of awkwardly lighting the block under them
 * Block Placement Click Delay: Sets the delay in ticks between placing blocks

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -275,9 +275,10 @@ public class UTConfig
         @Config.Comment
             ({
                 "Fixes some edge cases where fire damage sources won't cause mobs to drop their cooked items",
-                "Allows skeletons to shoot flaming arrows when on fire (70% chance)",
+                "Allows skeletons to shoot flaming arrows when on fire (30% chance * regional difficulty)",
                 "If entities have fire resistance, they get extinguished right away when on fire",
-                "Allows fire to spread from entity to entity (30% chance)"
+                "Allows fire to spread from entity to entity (30% chance * regional difficulty)",
+                "Prevents the fire animation overlay from being displayed when the player is immune to fire"
             })
         public boolean utBetterBurningToggle = true;
 


### PR DESCRIPTION
First time figuring out how PRs properly work!
* All entities that spread fire are now also affected by regional difficulty. This is to be consistent with how vanilla zombies work.
* Chance for burning skeletons to fire flaming arrows has been changed from 70% to (30% * regional difficulty). I found this to be a lot more fair.
* New Feature: The fire animation overlay won't display when the player is immune to fire! (backported from the 1.16.5 version of Better Burning)