### PR TITLE
fix storage drawers not taking items at all or in the first slot

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerItemHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerItemHandlerMixin.java
@@ -27,7 +27,7 @@ public abstract class UTDrawerItemHandlerMixin
             cir.setReturnValue(stack);
             return;
         }
-        cir.setReturnValue(this.insertItemInternal(slot, stack, simulate));
+        cir.setReturnValue(this.insertItemInternal(--slot, stack, simulate));
     }
 
     @Shadow


### PR DESCRIPTION
Storage drawers expose a "virtual slot" as slot 0 to external item handlers. I guess this was done in a attempt to wrap a "Slotted" Item handler with the "Slotless" version. but this is not compatible with all implementations.
The "real slots" are shifted by 1 to external handlers due this.
This PR corrects this shift, as is done in the code originally.