### PR TITLE
check if the TE in the cached coord is in not null and a controller

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTControllerDataMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTControllerDataMixin.java
@@ -37,7 +37,17 @@ public class UTControllerDataMixin
             controller = null;
             host.markDirty();
         }
-        if (controllerCoord != null) controller = (TileEntityController) host.getWorld().getTileEntity(controllerCoord);
+
+        if (controllerCoord != null) {
+            TileEntity te = host.getWorld().getTileEntity(controllerCoord);
+            if (!(te instanceof TileEntityController)) {
+                controllerCoord = null;
+                controller = null;
+            } else {
+                controller = (TileEntityController) te;
+            }
+            host.markDirty();
+        }
         cir.setReturnValue(controller);
     }
 


### PR DESCRIPTION
Should fix the crash presented in Discord earlier:
```
Description: Ticking block entity

java.lang.ClassCastException: com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave cannot be cast to com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController
    at com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.ControllerData.handler$zic000$utGetController(ControllerData.java:540)
    at com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.ControllerData.getController(ControllerData.java)
    at com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave.getController(TileEntitySlave.java:49)
    at com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave.getDrawerCount(TileEntitySlave.java:64)
    at com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler.getSlots(DrawerItemHandler.java:26)
    at net.minecraftforge.items.ItemHandlerHelper.insertItemStacked(ItemHandlerHelper.java:114)
    at lumien.randomthings.tileentity.TileEntityBlockBreaker.TickCentral_TrueITickableUpdate(TileEntityBlockBreaker.java:155)
    at com.github.terminatornl.tickcentral.api.TickHub.trueUpdate(TickHub.java:48)
    at com.github.terminatornl.laggoggles.Main.redirectUpdate(Main.java:91)
    at lumien.randomthings.tileentity.TileEntityBlockBreaker.update(TileEntityBlockBreaker.java)
    at com.zeitheron.hammercore.asm.McHooks.tickTile(McHooks.java:38)
```