### PR TITLE
No Leftover Breath Tweak + Typo Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All changes are toggleable via the config file.
 * Mob Despawn Improvement: Mobs carrying picked up items will drop their equipment and despawn properly
 * No Attack Cooldown: Disables the 1.9 combat update attack cooldown
 * No Golems: Disables the manual creation of golems and withers
-* No Leftover Breath Bottles: Disables Dragon's Breath from being a container item and leaving off empty bottles when brewed with
+* No Leftover Breath Bottles: Disables Dragon's Breath from leaving off empty bottles when a stack is brewed with
 * No Lightning Flash: Disables the flashing of skybox and ground brightness on lightning strikes
 * No Night Vision Flash: Disables the flashing effect when the night vision potion effect is about to run out
 * No Potion Shift: Disables the inventory shift when potion effects are active

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All changes are toggleable via the config file.
 * Mob Despawn Improvement: Mobs carrying picked up items will drop their equipment and despawn properly
 * No Attack Cooldown: Disables the 1.9 combat update attack cooldown
 * No Golems: Disables the manual creation of golems and withers
+* No Leftover Breath Bottles: Disables Dragon's Breath from being a container item and leaving off empty bottles when brewed with
 * No Lightning Flash: Disables the flashing of skybox and ground brightness on lightning strikes
 * No Night Vision Flash: Disables the flashing effect when the night vision potion effect is about to run out
 * No Potion Shift: Disables the inventory shift when potion effects are active

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -19,6 +19,7 @@ import mod.acgaming.universaltweaks.mods.botania.UTBotaniaFancySkybox;
 import mod.acgaming.universaltweaks.mods.tconstruct.oredictcache.UTOreDictCache;
 import mod.acgaming.universaltweaks.tweaks.UTAttributes;
 import mod.acgaming.universaltweaks.tweaks.UTBetterPlacement;
+import mod.acgaming.universaltweaks.tweaks.UTNoLeftoverBreath;
 import mod.acgaming.universaltweaks.tweaks.UTLoadSound;
 import mod.acgaming.universaltweaks.tweaks.UTTutorialHints;
 import mod.acgaming.universaltweaks.tweaks.breakablebedrock.UTBreakableBedrock;
@@ -73,6 +74,7 @@ public class UniversalTweaks
         if (UTConfig.TWEAKS_BLOCKS.BREAKABLE_BEDROCK.utBreakableBedrockToggle) UTBreakableBedrock.initToolList();
         if (UTConfig.TWEAKS_MISC.SWING_THROUGH_GRASS.utSwingThroughGrassToggle) UTSwingThroughGrassLists.initLists();
         if (UTConfig.TWEAKS_MISC.INCURABLE_POTIONS.utIncurablePotionsToggle) UTIncurablePotions.initPotionList();
+		if (UTConfig.TWEAKS_ITEMS.utLeftoverBreathBottleToggle) UTNoLeftoverBreath.postInit();
         LOGGER.info(NAME + " post-initialized");
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -649,7 +649,7 @@ public class UTConfig
         public boolean utAttackCooldownToggle = false;
 		
 		@Config.Name("No Leftover Breath Bottles")
-        @Config.Comment("Disables Dragon's Breath from being a container item and leaving off empty bottles when brewed with")
+        @Config.Comment("Disables Dragon's Breath from being a container item and leaving off empty bottles when a stack is brewed with")
         public boolean utLeftoverBreathBottleToggle = true;
 
         @Config.Name("Bow Infinity")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -526,7 +526,7 @@ public class UTConfig
             public boolean utBBOverlayToggle = true;
 
             @Config.Name("[4] Flaming Arrows")
-            @Config.Comment("Allows skeletons to shoot flaming arrows when on fire (30% chance * regional difficulty")
+            @Config.Comment("Allows skeletons to shoot flaming arrows when on fire (30% chance * regional difficulty)")
             public boolean utBBArrowsToggle = true;
 
             @Config.Name("[5] Spreading Fire")
@@ -647,6 +647,10 @@ public class UTConfig
         @Config.Name("No Attack Cooldown")
         @Config.Comment("Disables the 1.9 combat update attack cooldown")
         public boolean utAttackCooldownToggle = false;
+		
+		@Config.Name("No Leftover Breath Bottles")
+        @Config.Comment("Disables Dragon's Breath from being a container item and leaving off empty bottles when brewed with")
+        public boolean utLeftoverBreathBottleToggle = true;
 
         @Config.Name("Bow Infinity")
         @Config.Comment("Bows enchanted with Infinity no longer require arrows")

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/UTBetterBurning.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/UTBetterBurning.java
@@ -85,7 +85,7 @@ public class UTBetterBurning
         }
     }
 
-    // Prevents the first person fire overlay from displaying when user is resisted to fire, has fire resistance, or is in creative mode (backported)
+    // Prevents the first person fire overlay from displaying when the player is immune to fire, has fire resistance, or is in creative mode (backported)
     @SubscribeEvent
     public static void utBlockOverlay(RenderBlockOverlayEvent event)
     {

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/UTNoLeftoverBreath.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/UTNoLeftoverBreath.java
@@ -1,0 +1,11 @@
+package mod.acgaming.universaltweaks.tweaks;
+
+import net.minecraft.init.Items;
+
+public class UTNoLeftoverBreath
+{
+    public static void postInit()
+    {
+        Items.DRAGON_BREATH.setContainerItem(null);
+    }
+}


### PR DESCRIPTION
A new tweak which disables Dragon's breath from leaving off empty bottles when brewed with a stack. This is similar to a tweak in Quark but it's simple enough to be very useful for those who don't want to use that mod. 

In vanilla, brewing a single Dragon's Breath also consumes an empty bottle but strangely not when you use a whole stack of them and you'll end up having a bottle drop into the ground. This tweak disables that from happening, I've also fixed some typos from the last pull request as well.