### PR TITLE
Spiderlike Eldritch Crabs + Thaumcraft Splitening

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ All changes are toggleable via the config file.
 * Thaumcraft
     * Firebat Particles: Adds particles to firebats similar to legacy versions
     * Flower Bounding Box: Fixes the bounding box always being at the center in both cinderpearls and shimmerleafs
+    * Spiderlike Eldritch Crabs: Rotates dead eldritch crabs all the way like endermites, silverfish, and spiders
     * Stable Thaumometer: Stops the thaumometer from bobbing rapidly when using it to scan objects
     * Wisp Particles: Increases particle size of wisps similar to legacy versions
 * Thermal Expansion

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1407,6 +1407,10 @@ public class UTConfig
         @Config.Name("Thaumcraft")
         public final ThaumcraftCategory THAUMCRAFT = new ThaumcraftCategory();
 
+        @Config.LangKey("cfg.universaltweaks.modintegration.tc.entities")
+        @Config.Name("Thaumcraft: Entities")
+        public final ThaumcraftEntitiesCategory THAUMCRAFT_ENTITIES = new ThaumcraftEntitiesCategory();
+
         @Config.LangKey("cfg.universaltweaks.modintegration.te")
         @Config.Name("Thermal Expansion")
         public final ThermalExpansionCategory THERMAL_EXPANSION = new ThermalExpansionCategory();
@@ -1535,10 +1539,6 @@ public class UTConfig
 
         public static class ThaumcraftCategory
         {
-            @Config.Name("Firebat Particles")
-            @Config.Comment("Adds particles to firebats similar to legacy versions")
-            public boolean utTCFirebatParticlesToggle = true;
-
             @Config.Name("Flower Bounding Box")
             @Config.Comment("Fixes the bounding box always being at the center in both cinderpearls and shimmerleafs")
             public boolean utTCFlowerBoundingBoxToggle = true;
@@ -1546,6 +1546,17 @@ public class UTConfig
             @Config.Name("Stable Thaumometer")
             @Config.Comment("Stops the thaumometer from bobbing rapidly when using it to scan objects")
             public boolean utTCStableThaumometerToggle = true;
+        }
+
+        public static class ThaumcraftEntitiesCategory
+        {
+            @Config.Name("Firebat Particles")
+            @Config.Comment("Adds particles to firebats similar to legacy versions")
+            public boolean utTCFirebatParticlesToggle = true;
+
+            @Config.Name("Spiderlike Eldritch Crabs")
+            @Config.Comment("Rotates dead eldritch crabs all the way like endermites, silverfish, and spiders")
+            public boolean utTCSpiderlikeEldritchCrabToggle = true;
 
             @Config.Name("Wisp Particles")
             @Config.Comment("Increases particle size of wisps similar to legacy versions")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -25,6 +25,8 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.storagedrawers.client.json",
             "mixins.mods.storagedrawers.server.json",
             "mixins.mods.thaumcraft.json",
+            "mixins.mods.thaumcraft.entities.client.json",
+            "mixins.mods.thaumcraft.entities.server.json",
             "mixins.mods.thermalexpansion.json",
             "mixins.mods.tconstruct.json",
             "mixins.mods.tconstruct.oredictcache.json"
@@ -64,6 +66,10 @@ public class UTMixinLoader implements ILateMixinLoader
             case "mixins.mods.storagedrawers.server.json":
                 return Loader.isModLoaded("storagedrawers");
             case "mixins.mods.thaumcraft.json":
+                return Loader.isModLoaded("thaumcraft");
+            case "mixins.mods.thaumcraft.entities.client.json":
+                return Loader.isModLoaded("thaumcraft");
+            case "mixins.mods.thaumcraft.entities.server.json":
                 return Loader.isModLoaded("thaumcraft");
             case "mixins.mods.thermalexpansion.json":
                 return Loader.isModLoaded("thermalexpansion");

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTEldritchCrabRenderMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTEldritchCrabRenderMixin.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.mods.thaumcraft.entities.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.entity.RenderLiving;
+import net.minecraft.client.renderer.entity.RenderManager;
+import thaumcraft.client.renderers.entity.mob.RenderEldritchCrab;
+import thaumcraft.common.entities.monster.EntityEldritchCrab;
+
+// Courtesy of Turkey9002
+@Mixin(RenderEldritchCrab.class)
+public abstract class UTEldritchCrabRenderMixin extends RenderLiving<EntityEldritchCrab>
+{
+    public UTEldritchCrabRenderMixin(RenderManager rendermanagerIn, ModelBase modelbaseIn, float shadowsizeIn)
+    {
+		  super(rendermanagerIn, modelbaseIn, shadowsizeIn);
+	  }
+
+    public float getDeathMaxRotation(EntityEldritchCrab entity)
+    {
+		  if (UTConfig.MOD_INTEGRATION.THAUMCRAFT_ENTITIES.utTCSpiderlikeEldritchCrabToggle) return 180.0f;
+      else return 90.0f;
+	  }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTFirebatParticlesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTFirebatParticlesMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.thaumcraft.mixin;
+package mod.acgaming.universaltweaks.mods.thaumcraft.entities.mixin;
 
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.util.EnumParticleTypes;
@@ -22,7 +22,7 @@ public class UTFirebatParticlesMixin extends EntityMob
     @Inject(method = "onLivingUpdate", at = @At(value = "HEAD"))
     public void utFirebatParticles(CallbackInfo ci)
     {
-        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.utTCFirebatParticlesToggle) return;
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT_ENTITIES.utTCFirebatParticlesToggle) return;
         if (this.world.isRemote)
         {
             this.world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, this.prevPosX + (this.world.rand.nextFloat() - this.world.rand.nextFloat()) * 0.2F, this.prevPosY + this.height / 2 + (this.world.rand.nextFloat() - this.world.rand.nextFloat()) * 0.2F, this.prevPosZ + (this.world.rand.nextFloat() - this.world.rand.nextFloat()) * 0.2F, 0, 0, 0);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTWispParticlesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/entities/mixin/UTWispParticlesMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.thaumcraft.mixin;
+package mod.acgaming.universaltweaks.mods.thaumcraft.entities.mixin;
 
 import mod.acgaming.universaltweaks.config.UTConfig;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,7 +12,7 @@ public class UTWispParticlesMixin
     @ModifyConstant(method = "onDeath", constant = @Constant(floatValue = 1.0F))
     public float utWispParticles(float constant)
     {
-        if (UTConfig.MOD_INTEGRATION.THAUMCRAFT.utTCWispParticlesToggle) return 10;
+        if (UTConfig.MOD_INTEGRATION.THAUMCRAFT_ENTITIES.utTCWispParticlesToggle) return 10;
         else return constant;
     }
 }

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -35,6 +35,7 @@ cfg.universaltweaks.modintegration.moc=Mo' Creatures
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.sd=Storage Drawers
 cfg.universaltweaks.modintegration.tc=Thaumcraft
+cfg.universaltweaks.modintegration.tc.entities=Thaumcraft: Entities
 cfg.universaltweaks.modintegration.tcon=Tinkers' Construct
 cfg.universaltweaks.modintegration.te=Thermal Expansion
 cfg.universaltweaks.tweaks.blocks=Tweaks: Blocks

--- a/src/main/resources/mixins.mods.thaumcraft.entities.client.json
+++ b/src/main/resources/mixins.mods.thaumcraft.entities.client.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.thaumcraft.entities.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTEldritchCrabRenderMixin"]
+}

--- a/src/main/resources/mixins.mods.thaumcraft.entities.server.json
+++ b/src/main/resources/mixins.mods.thaumcraft.entities.server.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.thaumcraft.entities.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTFirebatParticlesMixin", "UTWispParticlesMixin"]
+}

--- a/src/main/resources/mixins.mods.thaumcraft.json
+++ b/src/main/resources/mixins.mods.thaumcraft.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTCinderpearlMixin", "UTFirebatParticlesMixin", "UTShimmerleafMixin", "UTStableThaumometerMixin", "UTWispParticlesMixin"]
+  "mixins": ["UTCinderpearlMixin", "UTShimmerleafMixin", "UTStableThaumometerMixin"]
 }


### PR DESCRIPTION
Another tweak for Thaumcraft, this one is another simple tweak that makes eldritch crabs rotate all the way like spiders on death. The Thaumcraft entity tweaks have also been split into their own category, I plan to make more tweaks for it once I figure out mixins.