### PR TITLE
Thaumcraft Batch II

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ All changes are toggleable via the config file.
         * Caches the drawer controller tile to avoid getting the TE from the world every time a drawer slave is interacted with
     * Render Range: Approximate range in blocks at which drawers render contained items
 * Thaumcraft
-    * Bolt Focus Medium Cast Sound: Plays an additional cast sound when using any bolt focus medium to add an extra layer of pow
     * Firebat Particles: Adds particles to firebats similar to legacy versions
     * Flower Bounding Box: Fixes the bounding box always being at the center in both cinderpearls and shimmerleafs
+    * Focus Mediums: Makes several of Thaumcraft's focus mediums play new sounds to stand out more
     * Frost Focus Cast Sound Revamp: Overhauls the frost focus cast sound to make it a lot less plangent
     * Spiderlike Eldritch Crabs: Rotates dead eldritch crabs all the way like endermites, silverfish, and spiders
     * Stable Thaumometer: Stops the thaumometer from bobbing rapidly when using it to scan objects

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1584,9 +1584,9 @@ public class UTConfig
 
         public static class ThaumcraftCategory
         {
-            @Config.Name("Bolt Focus Medium Cast Sound")
-            @Config.Comment("Plays an additional cast sound when using any bolt focus medium to add an extra layer of pow")
-            public boolean utTCBoltMediumSoundToggle = true;
+            @Config.LangKey("cfg.universaltweaks.modintegration.tc.focusmediums")
+            @Config.Name("Focus Mediums")
+            public final FocusMediumsCategory FOCUS_MEDIUMS = new FocusMediumsCategory();
 
             @Config.Name("Flower Bounding Box")
             @Config.Comment("Fixes the bounding box always being at the center in both cinderpearls and shimmerleafs")
@@ -1599,6 +1599,25 @@ public class UTConfig
             @Config.Name("Stable Thaumometer")
             @Config.Comment("Stops the thaumometer from bobbing rapidly when using it to scan objects")
             public boolean utTCStableThaumometerToggle = true;
+
+            public static class FocusMediumsCategory
+            {
+                @Config.Name("[01] Bolt Focus Medium Cast Sound")
+                @Config.Comment("Plays an additional cast sound when using any bolt focus medium to add an extra layer of pow")
+                public boolean utTCBoltMediumSoundToggle = true;
+
+                @Config.Name("[02] Cloud Focus Medium Cast Sound")
+                @Config.Comment("Plays an additional cast sound when using any cloud focus medium")
+                public boolean utTCCloudMediumSoundToggle = true;
+
+                @Config.Name("[03] Mine Focus Medium Sounds")
+                @Config.Comment("Adds additional cast, despawn, and setup sounds when using any mine focus medium")
+                public boolean utTCMineMediumSoundToggle = true;
+
+                @Config.Name("[04] Spellbat Focus Medium Cast Sound")
+                @Config.Comment("Plays an additional cast sound when summoning any type of spellbat")
+                public boolean utTCSpellBatMediumSoundToggle = true;
+            }
         }
 
         public static class ThaumcraftEntitiesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -25,6 +25,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.storagedrawers.client.json",
             "mixins.mods.storagedrawers.server.json",
             "mixins.mods.thaumcraft.json",
+            "mixins.mods.thaumcraft.focusmediums.json",
             "mixins.mods.thaumcraft.entities.client.json",
             "mixins.mods.thaumcraft.entities.server.json",
             "mixins.mods.thermalexpansion.json",
@@ -67,6 +68,7 @@ public class UTMixinLoader implements ILateMixinLoader
             case "mixins.mods.storagedrawers.server.json":
                 return Loader.isModLoaded("storagedrawers");
             case "mixins.mods.thaumcraft.json":
+            case "mixins.mods.thaumcraft.focusmediums.json":
             case "mixins.mods.thaumcraft.entities.server.json":
                 return Loader.isModLoaded("thaumcraft");
             case "mixins.mods.thermalexpansion.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTFocusMineEntityMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTFocusMineEntityMixin.java
@@ -1,0 +1,64 @@
+package mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin;
+
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.World;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.api.casters.FocusEffect;
+import thaumcraft.api.casters.FocusPackage;
+import thaumcraft.common.entities.projectile.EntityFocusMine;
+import thaumcraft.common.lib.SoundsTC;
+
+// Courtesy of Turkey9002
+@Mixin(EntityFocusMine.class)
+public abstract class UTFocusMineEntityMixin extends EntityThrowable
+{
+    @Shadow(remap = false)
+    FocusPackage focusPackage;
+    @Shadow(remap = false)
+    public int counter;
+    @Shadow(remap = false)
+    FocusEffect[] effects;
+
+    public UTFocusMineEntityMixin(World worldIn)
+    {
+		super(worldIn);
+    }
+
+    @Inject(method = "onImpact", at = @At(value = "HEAD"))
+    protected void impactSound(final RayTraceResult mop, CallbackInfo ci) 
+    {
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCMineMediumSoundToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumMineFocus ::: On impact");
+        if (this.counter > 0) 
+        {
+            this.playSound(SoundsTC.ticks, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+        }
+    }
+
+    @Inject(method = "onUpdate", at = @At(value = "HEAD"))
+    public void updateSounds(CallbackInfo ci)
+    {
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCMineMediumSoundToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumMineFocus ::: On update");
+    	if (this.ticksExisted > 1200 || (!this.world.isRemote && this.getThrower() == null))
+    	{
+    		this.playSound(SoundsTC.craftfail, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+    	}
+    	
+    	if (this.isEntityAlive())
+    	{
+            if (this.counter == 1 && this.effects == null)
+            {
+                this.playSound(SoundsTC.hhoff, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumBoltFocusMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumBoltFocusMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.thaumcraft.mixin;
+package mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin;
 
 import net.minecraft.util.SoundCategory;
 
@@ -20,7 +20,7 @@ public class UTMediumBoltFocusMixin extends FocusMediumTouch
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
     public void utMediumBoltFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir)
     {
-        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.utTCBoltMediumSoundToggle) return;
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCBoltMediumSoundToggle) return;
         if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumBoltFocus ::: Execute");
         this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.shock, SoundCategory.PLAYERS, 0.175F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
     }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumCloudFocusMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumCloudFocusMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin;
+
+import net.minecraft.util.SoundCategory;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import thaumcraft.api.casters.FocusMedium;
+import thaumcraft.api.casters.Trajectory;
+import thaumcraft.common.items.casters.foci.FocusMediumCloud;
+import thaumcraft.common.lib.SoundsTC;
+
+// Courtesy of Turkey9002
+@Mixin(FocusMediumCloud.class)
+public abstract class UTMediumCloudFocusMixin extends FocusMedium
+{
+    @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
+    public void utMediumCloudFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCCloudMediumSoundToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumCloudFocus ::: Execute");
+        this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.egscreech, SoundCategory.PLAYERS, 0.25F, 1.25F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumMineFocusMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumMineFocusMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin;
+
+import net.minecraft.util.SoundCategory;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import thaumcraft.api.casters.FocusMedium;
+import thaumcraft.api.casters.Trajectory;
+import thaumcraft.common.items.casters.foci.FocusMediumMine;
+import thaumcraft.common.lib.SoundsTC;
+
+// Courtesy of Turkey9002
+@Mixin(FocusMediumMine.class)
+public abstract class UTMediumMineFocusMixin extends FocusMedium
+{
+    @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
+    public void utMediumMineFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCMineMediumSoundToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumMineFocus ::: Execute");
+        this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.upgrade, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumSpellBatFocusMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/focusmediums/mixin/UTMediumSpellBatFocusMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin;
+
+import net.minecraft.util.SoundCategory;
+import net.minecraft.init.SoundEvents;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import thaumcraft.api.casters.FocusMedium;
+import thaumcraft.api.casters.Trajectory;
+import thaumcraft.common.items.casters.foci.FocusMediumSpellBat;
+
+// Courtesy of Turkey9002
+@Mixin(FocusMediumSpellBat.class)
+public abstract class UTMediumSpellBatFocusMixin extends FocusMedium
+{
+    @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
+    public void utMediumSpellBatFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfig.MOD_INTEGRATION.THAUMCRAFT.FOCUS_MEDIUMS.utTCSpellBatMediumSoundToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMediumSpellBatFocus ::: Execute");
+        this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundEvents.ENTITY_WITHER_SHOOT, SoundCategory.PLAYERS, 0.45F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -35,6 +35,7 @@ cfg.universaltweaks.modintegration.moc=Mo' Creatures
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.sd=Storage Drawers
 cfg.universaltweaks.modintegration.tc=Thaumcraft
+cfg.universaltweaks.modintegration.tc.focusmediums=Focus Mediums
 cfg.universaltweaks.modintegration.tc.entities=Thaumcraft: Entities
 cfg.universaltweaks.modintegration.tcon=Tinkers' Construct
 cfg.universaltweaks.modintegration.te=Thermal Expansion

--- a/src/main/resources/mixins.mods.thaumcraft.focusmediums.json
+++ b/src/main/resources/mixins.mods.thaumcraft.focusmediums.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.thaumcraft.focusmediums.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTFocusMineEntityMixin", "UTMediumBoltFocusMixin", "UTMediumCloudFocusMixin", "UTMediumMineFocusMixin", "UTMediumSpellBatFocusMixin"]
+}

--- a/src/main/resources/mixins.mods.thaumcraft.json
+++ b/src/main/resources/mixins.mods.thaumcraft.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTCinderpearlMixin", "UTFrostFocusMixin", "UTMediumBoltFocusMixin", "UTShimmerleafMixin", "UTStableThaumometerMixin"]
+  "mixins": ["UTCinderpearlMixin", "UTFrostFocusMixin", "UTShimmerleafMixin", "UTStableThaumometerMixin"]
 }


### PR DESCRIPTION
- Added cast sound tweaks for Thaumcraft's cloud, mine, and spellbat focus mediums.
- The arcane mine now has sounds for when it despawns, when it's getting setup, and when it's armed if the tweak for it is enabled. This should make the mechanic of it a lot less confusing.
- Merged the above three tweaks and the bolt cast sound tweak into their own subcategory.