### PR TITLE
Implement fix for AoA/FluxNetworks GUI crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     deobfCompile "curse.maven:chameleon-230497:2450900"
     deobfCompile "curse.maven:chickens-241941:2537643"
     deobfCompile "curse.maven:epic-siege-mod-229449:3356157"
+    deobfCompile "curse.maven:fluxnetworks-248020:3178199"
     deobfCompile "curse.maven:forestry-59751:2918418"
     deobfCompile "curse.maven:modtweaker-220954:3840577"
     deobfCompile "curse.maven:roost-277711:2702080"
@@ -95,6 +96,15 @@ dependencies {
     implementation "curse.maven:custom-mob-spawner-229261:2859433"
     implementation "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2"
     //implementation "net.jafama:jafama:2.3.2"
+
+    // for testing mods
+    deobfCompile "curse.maven:aoa3-311054:3054253"
+    implementation "curse.maven:mtlib-253211:3308160"
+    implementation "curse.maven:codechickenlib-242818:2779848"
+    implementation "curse.maven:thermalfoundation-222880:2926428"
+    implementation "curse.maven:cofhcore-69162:2920433"
+    implementation "curse.maven:cofhworld-271384:2920434"
+    implementation "curse.maven:redstoneflux-270789:2920436"
 }
 
 mixin {

--- a/build.gradle
+++ b/build.gradle
@@ -96,15 +96,6 @@ dependencies {
     implementation "curse.maven:custom-mob-spawner-229261:2859433"
     implementation "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2"
     //implementation "net.jafama:jafama:2.3.2"
-
-    // for testing mods
-    deobfCompile "curse.maven:aoa3-311054:3054253"
-    implementation "curse.maven:mtlib-253211:3308160"
-    implementation "curse.maven:codechickenlib-242818:2779848"
-    implementation "curse.maven:thermalfoundation-222880:2926428"
-    implementation "curse.maven:cofhcore-69162:2920433"
-    implementation "curse.maven:cofhworld-271384:2920434"
-    implementation "curse.maven:redstoneflux-270789:2920436"
 }
 
 mixin {

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -42,7 +42,7 @@ public class UniversalTweaks
     public static final String MODID = "universaltweaks";
     public static final String NAME = "Universal Tweaks";
     public static final String VERSION = "1.12.2-1.6.0";
-    public static final String DEPENDENCIES = "required-after:mixinbooter;after:biomesoplenty;after:botania;after:contenttweaker;after:customspawner;after:epicsiegemod;after:extratrees;after:forestry;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
+    public static final String DEPENDENCIES = "required-after:mixinbooter;after:aoa3;after:biomesoplenty;after:botania;after:contenttweaker;after:customspawner;after:epicsiegemod;after:extratrees;after:forestry;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
     public static final Logger LOGGER = LogManager.getLogger(NAME);
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1463,6 +1463,10 @@ public class UTConfig
 
     public static class ModIntegrationCategory
     {
+        @Config.LangKey("cfg.universaltweaks.modintegration.aoa")
+        @Config.Name("Advent of Ascension")
+        public final AOACategory AOA = new AOACategory();
+
         @Config.LangKey("cfg.universaltweaks.modintegration.bop")
         @Config.Name("Biomes O' Plenty")
         public final BiomesOPlentyCategory BIOMES_O_PLENTY = new BiomesOPlentyCategory();
@@ -1506,6 +1510,13 @@ public class UTConfig
         @Config.LangKey("cfg.universaltweaks.modintegration.tcon")
         @Config.Name("Tinkers' Construct")
         public final TinkersConstructCategory TINKERS_CONSTRUCT = new TinkersConstructCategory();
+
+        public static class AOACategory
+        {
+            @Config.Name("Inventory-less GUI Compatibility")
+            @Config.Comment("Fixes player ticking in certain GUIs without player inventories (i.e. Flux Networks GUI)")
+            public boolean utFixPlayerTickInInventorylessGui = false;
+        }
 
         public static class BiomesOPlentyCategory
         {

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1514,7 +1514,7 @@ public class UTConfig
         public static class AOACategory
         {
             @Config.Name("Inventory-less GUI Compatibility")
-            @Config.Comment("Fixes player ticking in certain GUIs without player inventories (i.e. Flux Networks GUI)")
+            @Config.Comment("Fixes AoA player ticking in certain GUIs without player inventories (i.e. Flux Networks GUI)")
             public boolean utFixPlayerTickInInventorylessGui = false;
         }
 

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -14,6 +14,7 @@ public class UTMixinLoader implements ILateMixinLoader
     public List<String> getMixinConfigs()
     {
         return Lists.newArrayList(
+                "mixins.mods.aoa3.json",
             "mixins.mods.biomesoplenty.json",
             "mixins.mods.crafttweaker.json",
             "mixins.mods.customspawner.json",
@@ -41,6 +42,8 @@ public class UTMixinLoader implements ILateMixinLoader
         {
             switch (mixinConfig)
             {
+                case "mixins.mods.aoa3.json":
+                    return Loader.isModLoaded("aoa3");
                 case "mixins.mods.crafttweaker.json":
                     return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.roost.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -43,7 +43,7 @@ public class UTMixinLoader implements ILateMixinLoader
             switch (mixinConfig)
             {
                 case "mixins.mods.aoa3.json":
-                    return Loader.isModLoaded("aoa3");
+                    return Loader.isModLoaded("aoa3") && Loader.isModLoaded("fluxnetworks");
                 case "mixins.mods.crafttweaker.json":
                     return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.roost.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/minecraft/nethandler/mixin/UTNetHandlerPlayClientMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/minecraft/nethandler/mixin/UTNetHandlerPlayClientMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.mods.aoa3.minecraft.nethandler.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+
+import sonar.fluxnetworks.common.core.ContainerCore;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import zone.rong.mixinextras.injector.WrapWithCondition;
+
+// Courtesy of jchung01
+@Mixin(value = NetHandlerPlayClient.class)
+public class UTNetHandlerPlayClientMixin
+{
+    @Shadow
+    private Minecraft client;
+
+    @WrapWithCondition(method = "handleSetSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;putStackInSlot(ILnet/minecraft/item/ItemStack;)V", ordinal = 1))
+    private boolean utAoaHandleSetSlotIfAllowed(Container instance, int slotID, ItemStack stack)
+    {
+        if (!UTConfig.MOD_INTEGRATION.AOA.utFixPlayerTickInInventorylessGui) return true;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTNetHandlerPlayClientMixin ::: Check Inventory-less GUI (from AOA playerTick)");
+        return !(client.player.openContainer instanceof ContainerCore);
+    }
+}

--- a/src/main/resources/mixins.mods.aoa3.json
+++ b/src/main/resources/mixins.mods.aoa3.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.aoa3.minecraft.nethandler.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTNetHandlerPlayClientMixin"]
+}


### PR DESCRIPTION
Fixes SonarSonic/Flux-Networks#455.
In detail, fixes log spam (and crash report spam if CensoredASM or VanillaFix is used) when navigating a FluxNetworks GUI while the player inventory is being updated; I have tested inventory updates caused by the mentioned Botania band of mana/aura, RandomThings's time in a bottle, and any charging items (jetpacks, fluxpacks, batteries, etc.) in particular.

Advent of Ascension mentions modifications of their code are not allowed fairly explicitly, so this fix mixins into a called vanilla method (neither AoA nor FluxNetworks are modified) which does add overhead, so this fix is disabled by default in the config. Admittedly a bit hacky to mixin into vanilla, but I figured it was better than a dummy player inventory in FluxNetworks GUIs.

For posterity's sake, the issue seems to be with AoA's `PlayerDataManager.tickEquipment()` calling `player.inventoryContainer.detectAndSendChanges()` on the client side without the player's `openContainer` having the properly initialized, serverside `windowId`(which in theory would be fixed by wrapping the function with an `isRemote` check?). Debugging wasn't very clear because info is passed through networking, leading to unclear crash reports at face value, but I believe that is the issue, or at least close to it.

Besides FluxNetworks, I am not aware of any other inventory-less GUIs that AoA causes crashes with, but fixes for other containers should be similar (checking `openContainer` is `instanceof [containerType here]`).

One last thing, I wasn't too sure how to structure this mixin's directories, so feel free to change the file structure/let me know how to change it.