### PR TITLE
Implement copy seed tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1132,6 +1132,10 @@ public class UTConfig
         @Config.Comment("Adds a button to the pause menu to toggle cheats")
         public boolean utToggleCheatsToggle = true;
 
+        @Config.Name("Copy World Seed")
+        @Config.Comment("Enables clicking of `/seed` world seed in chat to copy to clipboard")
+        public boolean utCopyWorldSeedToggle = true;
+
         public static class IncurablePotionsCategory
         {
             @Config.Name("[1] Incurable Potions Toggle")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1134,7 +1134,7 @@ public class UTConfig
 
         @Config.Name("Copy World Seed")
         @Config.Comment("Enables clicking of `/seed` world seed in chat to copy to clipboard")
-        public boolean utCopyWorldSeedToggle = true;
+        public boolean utCopyWorldSeedToggle = false;
 
         public static class IncurablePotionsCategory
         {

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -130,6 +130,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             "mixins.tweaks.items.xpbottle.json",
             "mixins.tweaks.misc.buttons.realms.json",
             "mixins.tweaks.misc.buttons.snooper.client.json",
+            "mixins.tweaks.misc.commands.seed.json",
             "mixins.tweaks.misc.credits.json",
             "mixins.tweaks.misc.incurablepotions.json",
             "mixins.tweaks.misc.lightningflash.json",
@@ -261,6 +262,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                     return firstLaunch || UTConfigParser.isPresent("B:\"Remove Realms Button\"=true");
                 case "mixins.tweaks.misc.buttons.snooper.client.json":
                     return firstLaunch || UTConfigParser.isPresent("B:\"Remove Snooper\"=true");
+                case "mixins.tweaks.misc.commands.seed.json":
+                    return firstLaunch || UTConfigParser.isPresent("B:\"Copy Seed\"=true");
                 case "mixins.tweaks.misc.credits.json":
                     return !firstLaunch && UTConfigParser.isPresent("B:\"Skip Credits\"=true");
                 case "mixins.tweaks.misc.lightningflash.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -263,7 +263,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 case "mixins.tweaks.misc.buttons.snooper.client.json":
                     return firstLaunch || UTConfigParser.isPresent("B:\"Remove Snooper\"=true");
                 case "mixins.tweaks.misc.commands.seed.json":
-                    return !firstLaunch && UTConfigParser.isPresent("B:\"Copy Seed\"=true");
+                    return !firstLaunch && UTConfigParser.isPresent("B:\"Copy World Seed\"=true");
                 case "mixins.tweaks.misc.credits.json":
                     return !firstLaunch && UTConfigParser.isPresent("B:\"Skip Credits\"=true");
                 case "mixins.tweaks.misc.lightningflash.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -263,7 +263,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 case "mixins.tweaks.misc.buttons.snooper.client.json":
                     return firstLaunch || UTConfigParser.isPresent("B:\"Remove Snooper\"=true");
                 case "mixins.tweaks.misc.commands.seed.json":
-                    return firstLaunch || UTConfigParser.isPresent("B:\"Copy Seed\"=true");
+                    return !firstLaunch && UTConfigParser.isPresent("B:\"Copy Seed\"=true");
                 case "mixins.tweaks.misc.credits.json":
                     return !firstLaunch && UTConfigParser.isPresent("B:\"Skip Credits\"=true");
                 case "mixins.tweaks.misc.lightningflash.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.util.text.event.ClickEvent;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
@@ -1,0 +1,38 @@
+package mod.acgaming.universaltweaks.tweaks.misc.commands.seed.mixin;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.event.ClickEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+// Courtesy of jchung01
+@Mixin(GuiScreen.class)
+public abstract class UTCopySeedMixin
+{
+    @Shadow
+    public Minecraft mc;
+
+    @Inject(method = "handleComponentClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiScreen;sendChatMessage(Ljava/lang/String;Z)V"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    private void utCopySeed(ITextComponent component, CallbackInfoReturnable<Boolean> cir, ClickEvent clickevent)
+    {
+        if (!UTConfig.TWEAKS_MISC.utCopyWorldSeedToggle) return;
+
+        String[] splitCommand = clickevent.getValue().split(" ");
+        if (!splitCommand[0].equals("/utCopySeed")) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTCopySeedMixin :: Copy seed");
+
+        GuiScreen.setClipboardString(splitCommand[1]);
+        mc.player.sendMessage(new TextComponentString("Copied seed to clipboard!"));
+        cir.setReturnValue(Boolean.TRUE);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTCopySeedMixin.java
@@ -1,13 +1,14 @@
 package mod.acgaming.universaltweaks.tweaks.misc.commands.seed.mixin;
 
-import mod.acgaming.universaltweaks.UniversalTweaks;
-import mod.acgaming.universaltweaks.config.UTConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
-
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.event.ClickEvent;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTFormatSeedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/seed/mixin/UTFormatSeedMixin.java
@@ -1,0 +1,49 @@
+package mod.acgaming.universaltweaks.tweaks.misc.commands.seed.mixin;
+
+import net.minecraft.command.CommandShowSeed;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.event.ClickEvent;
+import net.minecraft.util.text.event.HoverEvent;
+import net.minecraft.world.World;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+// Courtesy of jchung01
+@Mixin(CommandShowSeed.class)
+public class UTFormatSeedMixin
+{
+    // Can probably also use @ModifyArg + MixinExtras' @Local, but in beta/subject to change
+    @Inject(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/ICommandSender;sendMessage(Lnet/minecraft/util/text/ITextComponent;)V"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    private void utFormatSeedCommand(MinecraftServer server, ICommandSender sender, String[] args, CallbackInfo ci, World world)
+    {
+        if (!UTConfig.TWEAKS_MISC.utCopyWorldSeedToggle) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTFormatSeedMixin :: Format seed");
+
+        long seed = world.getSeed();
+        TextComponentTranslation seedText = new TextComponentTranslation("commands.seed.success", seed);
+
+        // format seed
+        Style style = new Style();
+        style.setColor(TextFormatting.GREEN).setUnderlined(true);
+
+        // make & set events
+        style.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Click to copy seed to clipboard")));
+        // use a dummy command that UTCopySeedMixin will handle
+        style.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/utCopySeed " + seed));
+        seedText.setStyle(style);
+
+        sender.sendMessage(seedText);
+        ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.tweaks.misc.commands.seed.json
+++ b/src/main/resources/mixins.tweaks.misc.commands.seed.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.commands.seed.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTCopySeedMixin", "UTFormatSeedMixin"]
+}


### PR DESCRIPTION
Closes #76.
![2023-04-11_00 55 24](https://user-images.githubusercontent.com/60687097/231094137-130889e3-6b99-4d8a-a1a2-a7420e0135e9.png)
I think this is only a client-side tweak, but if there are issues maybe it isn't.
Disabled by default due to overhead.