### PR TITLE
Add support to Roost tweak for MaterialSystem

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1632,7 +1632,9 @@ public class UTConfig
                 ({
                     "Improves load time by registering CT chickens early for Roost to detect them",
                     "Note: All CT chickens must be specified in \"Custom Chickens\" for this tweak to work!",
-                    "Note: The .zs files creating custom chickens must be loaded with '#loader preinit', not '#loader contenttweaker'!"
+                    "Note: In your .zs files, to use ContentTweaker's MaterialSystem Parts, you must:",
+                    "1) Use '#loader finalize_contenttweaker', not '#loader contenttweaker'",
+                    "2) Use the Material Part Bracket Handler to reference the item"
                 })
             public boolean utRoostEarlyRegisterCTChickens = false;
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/UTChickenRegistration.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/UTChickenRegistration.java
@@ -1,0 +1,110 @@
+package mod.acgaming.universaltweaks.mods.roost.contenttweaker;
+
+import com.setycz.chickens.handler.SpawnType;
+import com.setycz.chickens.registry.ChickensRegistry;
+import com.setycz.chickens.registry.ChickensRegistryItem;
+import com.teamacronymcoders.contenttweaker.ContentTweaker;
+import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenFactory;
+import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenRepresentation;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public class UTChickenRegistration {
+    // register barebone chickens to registry
+    public static void utRegisterChickens()
+    {
+        for (ChickenRepresentation chickenRepresentation : ChickenFactory.CHICKEN_REPRESENTATIONS)
+        {
+            ChickensRegistryItem item = new ChickensRegistryItem(
+                    new ResourceLocation(ContentTweaker.MOD_ID, chickenRepresentation.name),
+                    chickenRepresentation.name,
+                    chickenRepresentation.textureLocation.getInternal(),
+                    ItemStack.EMPTY,
+                    chickenRepresentation.backgroundColor.getIntColor(),
+                    chickenRepresentation.foregroundColor.getIntColor(),
+                    null,
+                    null
+            );
+            ChickensRegistry.register(item);
+        }
+        if (UTConfig.DEBUG.utDebugToggle)
+        {
+            CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: Dumping chicken registry!");
+            for (ChickensRegistryItem chicken : ChickensRegistry.getItems())
+            {
+                CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: " + chicken.getRegistryName().toString());
+            }
+        }
+    }
+
+    // finish setting up chickens in init, after registries/resources are loaded
+    public static void utInitChickens()
+    {
+        if (UTConfig.DEBUG.utDebugToggle)
+        {
+            CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: Dumping chicken registry! (in init)");
+            for (ChickensRegistryItem chicken : ChickensRegistry.getItems())
+            {
+                CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: " + chicken.getRegistryName().toString());
+            }
+        }
+        for (ChickenRepresentation chickenRepresentation : ChickenFactory.CHICKEN_REPRESENTATIONS)
+        {
+            ResourceLocation registryName = new ResourceLocation(ContentTweaker.MOD_ID, chickenRepresentation.name);
+            ChickensRegistryItem item = ChickensRegistry.getByRegistryName(registryName.toString());
+            if (item == null)
+            {
+                CraftTweakerAPI.logError("Failed to find chicken item " + registryName + " in registry");
+                return;
+            }
+
+            ChickensRegistryItem parentOneItem = chickenRepresentation.parentOne != null ?
+                    ChickensRegistry.getByResourceLocation(chickenRepresentation.parentOne.getInternal()) : null;
+            ChickensRegistryItem parentTwoItem = chickenRepresentation.parentTwo != null ?
+                    ChickensRegistry.getByResourceLocation(chickenRepresentation.parentTwo.getInternal()) : null;
+            if (parentOneItem != null && parentTwoItem != null)
+            {
+                item.setParentsNew(parentOneItem, parentTwoItem);
+            }
+            else
+            {
+                item.setNoParents();
+            }
+
+            if (chickenRepresentation.layItem != null)
+            {
+                item.setLayItem(CraftTweakerMC.getItemStack(chickenRepresentation.layItem));
+            }
+
+            if (chickenRepresentation.dropItem != null)
+            {
+                item.setDropItem(CraftTweakerMC.getItemStack(chickenRepresentation.dropItem));
+            }
+
+            if (chickenRepresentation.spawnType != null)
+            {
+                SpawnType actualSpawnType = null;
+                for (SpawnType spawnTypeEnum : SpawnType.values())
+                {
+                    if (spawnTypeEnum.toString().equalsIgnoreCase(chickenRepresentation.spawnType))
+                    {
+                        actualSpawnType = spawnTypeEnum;
+                    }
+                }
+                if (actualSpawnType != null)
+                {
+                    item.setSpawnType(actualSpawnType);
+                }
+                else
+                {
+                    CraftTweakerAPI.logError("Failed to find SpawnType for String: " + chickenRepresentation.spawnType);
+                }
+            }
+
+            item.setLayCoefficient(chickenRepresentation.layCoefficient);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/UTChickenRegistration.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/UTChickenRegistration.java
@@ -1,5 +1,8 @@
 package mod.acgaming.universaltweaks.mods.roost.contenttweaker;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
 import com.setycz.chickens.handler.SpawnType;
 import com.setycz.chickens.registry.ChickensRegistry;
 import com.setycz.chickens.registry.ChickensRegistryItem;
@@ -9,9 +12,8 @@ import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenRepresentati
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import mod.acgaming.universaltweaks.config.UTConfig;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
 
+// Courtesy of jchung01
 public class UTChickenRegistration {
     // register barebone chickens to registry
     public static void utRegisterChickens()

--- a/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/mixin/UTChickenModuleMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/mixin/UTChickenModuleMixin.java
@@ -1,22 +1,10 @@
 package mod.acgaming.universaltweaks.mods.roost.contenttweaker.mixin;
 
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-
-import com.setycz.chickens.handler.SpawnType;
-import com.setycz.chickens.registry.ChickensRegistry;
-import com.setycz.chickens.registry.ChickensRegistryItem;
 import com.teamacronymcoders.base.modulesystem.ModuleBase;
-import com.teamacronymcoders.contenttweaker.ContentTweaker;
-import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenFactory;
 import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenModule;
-import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenRepresentation;
-import crafttweaker.CraftTweakerAPI;
-import crafttweaker.api.minecraft.CraftTweakerMC;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.mods.roost.contenttweaker.UTChickenRegistration;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -26,119 +14,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = ChickenModule.class, remap = false)
 public abstract class UTChickenModuleMixin extends ModuleBase
 {
-    @Override
-    public void preInit(FMLPreInitializationEvent event)
-    {
-        super.preInit(event);
-        if (!UTConfig.MOD_INTEGRATION.ROOST.utRoostEarlyRegisterCTChickens) return;
-        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTChickenModuleMixin ::: Register chickens (pre-init)");
-        utRegisterChickens();
-    }
-
     @Inject(method = "init", at = @At(value = "INVOKE", target = "Lcom/teamacronymcoders/contenttweaker/modules/chickens/ChickenFactory;registerChickens()V"), cancellable = true)
-    public void utCTChickenInit(FMLInitializationEvent e, CallbackInfo ci)
+    public void utCTChickenInit(CallbackInfo ci)
     {
-        if (UTConfig.MOD_INTEGRATION.ROOST.utRoostEarlyRegisterCTChickens)
-        {
-            if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTChickenModuleMixin ::: Finish setting up chickens (init)");
-            utInitChickens();
-            // ignore ChickenFactory.registerChickens() and use instance methods instead
-            ci.cancel();
-        }
-    }
+        if (!UTConfig.MOD_INTEGRATION.ROOST.utRoostEarlyRegisterCTChickens) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTChickenModuleMixin ::: Finish setting up chickens (init)");
 
-    // register barebone chickens to registry
-    private void utRegisterChickens()
-    {
-        for (ChickenRepresentation chickenRepresentation : ChickenFactory.CHICKEN_REPRESENTATIONS)
-        {
-            ChickensRegistryItem item = new ChickensRegistryItem(
-                new ResourceLocation(ContentTweaker.MOD_ID, chickenRepresentation.name),
-                chickenRepresentation.name,
-                chickenRepresentation.textureLocation.getInternal(),
-                ItemStack.EMPTY,
-                chickenRepresentation.backgroundColor.getIntColor(),
-                chickenRepresentation.foregroundColor.getIntColor(),
-                null,
-                null
-            );
-            ChickensRegistry.register(item);
-        }
-        if (UTConfig.DEBUG.utDebugToggle)
-        {
-            CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: Dumping chicken registry!");
-            for (ChickensRegistryItem chicken : ChickensRegistry.getItems())
-            {
-                CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: " + chicken.getRegistryName().toString());
-            }
-        }
-    }
-
-    // finish setting up chickens in init, after registries/resources are loaded
-    private void utInitChickens()
-    {
-        if (UTConfig.DEBUG.utDebugToggle)
-        {
-            CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: Dumping chicken registry! (in init)");
-            for (ChickensRegistryItem chicken : ChickensRegistry.getItems())
-            {
-                CraftTweakerAPI.logInfo("UTChickenModuleMixin ::: " + chicken.getRegistryName().toString());
-            }
-        }
-        for (ChickenRepresentation chickenRepresentation : ChickenFactory.CHICKEN_REPRESENTATIONS)
-        {
-            ResourceLocation registryName = new ResourceLocation(ContentTweaker.MOD_ID, chickenRepresentation.name);
-            ChickensRegistryItem item = ChickensRegistry.getByRegistryName(registryName.toString());
-            if (item == null)
-            {
-                CraftTweakerAPI.logError("Failed to find chicken item " + registryName + " in registry");
-                return;
-            }
-
-            ChickensRegistryItem parentOneItem = chickenRepresentation.parentOne != null ?
-                ChickensRegistry.getByResourceLocation(chickenRepresentation.parentOne.getInternal()) : null;
-            ChickensRegistryItem parentTwoItem = chickenRepresentation.parentTwo != null ?
-                ChickensRegistry.getByResourceLocation(chickenRepresentation.parentTwo.getInternal()) : null;
-            if (parentOneItem != null && parentTwoItem != null)
-            {
-                item.setParentsNew(parentOneItem, parentTwoItem);
-            }
-            else
-            {
-                item.setNoParents();
-            }
-
-            if (chickenRepresentation.layItem != null)
-            {
-                item.setLayItem(CraftTweakerMC.getItemStack(chickenRepresentation.layItem));
-            }
-
-            if (chickenRepresentation.dropItem != null)
-            {
-                item.setDropItem(CraftTweakerMC.getItemStack(chickenRepresentation.dropItem));
-            }
-
-            if (chickenRepresentation.spawnType != null)
-            {
-                SpawnType actualSpawnType = null;
-                for (SpawnType spawnTypeEnum : SpawnType.values())
-                {
-                    if (spawnTypeEnum.toString().equalsIgnoreCase(chickenRepresentation.spawnType))
-                    {
-                        actualSpawnType = spawnTypeEnum;
-                    }
-                }
-                if (actualSpawnType != null)
-                {
-                    item.setSpawnType(actualSpawnType);
-                }
-                else
-                {
-                    CraftTweakerAPI.logError("Failed to find SpawnType for String: " + chickenRepresentation.spawnType);
-                }
-            }
-
-            item.setLayCoefficient(chickenRepresentation.layCoefficient);
-        }
+        UTChickenRegistration.utInitChickens();
+        // ignore ChickenFactory.registerChickens() and use instance methods instead
+        ci.cancel();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/mixin/UTContentTweakerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/roost/contenttweaker/mixin/UTContentTweakerMixin.java
@@ -1,0 +1,32 @@
+package mod.acgaming.universaltweaks.mods.roost.contenttweaker.mixin;
+
+import net.minecraft.creativetab.CreativeTabs;
+
+import com.teamacronymcoders.base.BaseModFoundation;
+import com.teamacronymcoders.contenttweaker.ContentTweaker;
+import crafttweaker.CraftTweakerAPI;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.mods.roost.contenttweaker.UTChickenRegistration;
+import org.spongepowered.asm.mixin.Mixin;
+
+// Courtesy of jchung01
+@Mixin(value = ContentTweaker.class, remap = false)
+public abstract class UTContentTweakerMixin extends BaseModFoundation<ContentTweaker>
+{
+    public UTContentTweakerMixin(String modid, String name, String version, CreativeTabs creativeTab, boolean optionalSystems)
+    {
+        super(modid, name, version, creativeTab, optionalSystems);
+    }
+
+    @Override
+    public void finalizeOptionalSystems()
+    {
+        super.finalizeOptionalSystems();
+        if (!UTConfig.MOD_INTEGRATION.ROOST.utRoostEarlyRegisterCTChickens) return;
+        if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTContentTweakerMixin ::: Register chickens (pre-init)");
+
+        ContentTweaker.scriptsSuccessful = CraftTweakerAPI.tweaker.loadScript(false, "finalize_contenttweaker");
+        UTChickenRegistration.utRegisterChickens();
+    }
+}

--- a/src/main/resources/mixins.mods.roost.contenttweaker.json
+++ b/src/main/resources/mixins.mods.roost.contenttweaker.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTChickenModuleMixin"]
+  "mixins": ["UTChickenModuleMixin", "UTContentTweakerMixin"]
 }


### PR DESCRIPTION
Should close #142. Was unable to reproduce the crash, so can be reopened if necessary.
Adds support for ContentTweaker's MaterialSystem `MaterialPart`s in custom chicken scripts.

To use MaterialSystem in your .zs scripts adding custom chickens, you must use `#loader finalize_contenttweaker` instead of `#loader contenttweaker`. The easiest way I found to reference the `MaterialPart` is using the [Material Part Bracket Handler](https://docs.blamejared.com/1.12/en/Mods/ContentTweaker/Materials/Brackets/Bracket_MaterialPart), but any ContentTweaker syntax should work now that the tweak is done in pre-init as late as possible.