### PR TITLE
Implement a more performant version of AbyssalCraft's item transfer system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ repositories {
 }
 
 dependencies {
+    deobfCompile "curse.maven:abyssalcraft-53686:3425234"
     deobfCompile "curse.maven:baubles-227083:2518667"
     deobfCompile "curse.maven:binnies-mods-223525:2916129"
     deobfCompile "curse.maven:biomes-o-plenty-220318:2842510"
@@ -99,6 +100,13 @@ dependencies {
     implementation "curse.maven:custom-mob-spawner-229261:2859433"
     implementation "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2"
     //implementation "net.jafama:jafama:2.3.2"
+    // for testing mods
+    implementation "curse.maven:mtlib-253211:3308160"
+    implementation "curse.maven:codechickenlib-242818:2779848"
+    implementation "curse.maven:thermalfoundation-222880:2926428"
+    implementation "curse.maven:cofhcore-69162:2920433"
+    implementation "curse.maven:cofhworld-271384:2920434"
+    implementation "curse.maven:redstoneflux-270789:2920436"
 }
 
 mixin {

--- a/build.gradle
+++ b/build.gradle
@@ -100,13 +100,6 @@ dependencies {
     implementation "curse.maven:custom-mob-spawner-229261:2859433"
     implementation "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2"
     //implementation "net.jafama:jafama:2.3.2"
-    // for testing mods
-    implementation "curse.maven:mtlib-253211:3308160"
-    implementation "curse.maven:codechickenlib-242818:2779848"
-    implementation "curse.maven:thermalfoundation-222880:2926428"
-    implementation "curse.maven:cofhcore-69162:2920433"
-    implementation "curse.maven:cofhworld-271384:2920434"
-    implementation "curse.maven:redstoneflux-270789:2920436"
 }
 
 mixin {

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -43,7 +43,7 @@ public class UniversalTweaks
     public static final String MODID = "universaltweaks";
     public static final String NAME = "Universal Tweaks";
     public static final String VERSION = "1.12.2-1.6.0";
-    public static final String DEPENDENCIES = "required-after:mixinbooter;after:aoa3;after:biomesoplenty;after:botania;after:contenttweaker;after:customspawner;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
+    public static final String DEPENDENCIES = "required-after:mixinbooter;after:abyssalcraft;after:aoa3;after:biomesoplenty;after:botania;after:contenttweaker;after:customspawner;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
     public static final Logger LOGGER = LogManager.getLogger(NAME);
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,5 +1,6 @@
 package mod.acgaming.universaltweaks;
 
+import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapability;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.common.MinecraftForge;
@@ -55,6 +56,7 @@ public class UniversalTweaks
         UTAutoSaveOFCompat.updateOFConfig();
         if (UTConfig.TWEAKS_WORLD.utStrongholdToggle) GameRegistry.registerWorldGenerator(new SafeStrongholdWorldGenerator(), Integer.MAX_VALUE);
         if (Loader.isModLoaded("tconstruct") && UTConfig.MOD_INTEGRATION.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) UTOreDictCache.preInit();
+        if (Loader.isModLoaded("abyssalcraft") && UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) UTWorldDataCapability.register();
         LOGGER.info(NAME + " pre-initialized");
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1485,6 +1485,10 @@ public class UTConfig
 
     public static class ModIntegrationCategory
     {
+        @Config.LangKey("cfg.universaltweaks.modintegration.abyssalcraft")
+        @Config.Name("AbyssalCraft")
+        public final AbyssalCraftCategory ABYSSALCRAFT = new AbyssalCraftCategory();
+
         @Config.LangKey("cfg.universaltweaks.modintegration.aoa")
         @Config.Name("Advent of Ascension")
         public final AOACategory AOA = new AOACategory();
@@ -1548,6 +1552,13 @@ public class UTConfig
         @Config.LangKey("cfg.universaltweaks.modintegration.tcon")
         @Config.Name("Tinkers' Construct")
         public final TinkersConstructCategory TINKERS_CONSTRUCT = new TinkersConstructCategory();
+
+        public static class AbyssalCraftCategory
+        {
+            @Config.Name("Optimized Item Transport")
+            @Config.Comment("Makes an optimization to reduce tick overhead of AbyssalCraft's item transport system")
+            public boolean utOptimizedItemTransferToggle = true;
+        }
 
         public static class AOACategory
         {

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -61,7 +61,7 @@ public class UTMixinLoader implements ILateMixinLoader
         }
         switch (mixinConfig)
         {
-            case "mixins.mods.abyssalcraft.json" :
+            case "mixins.mods.abyssalcraft.json":
                 return Loader.isModLoaded("abyssalcraft");
             case "mixins.mods.biomesoplenty.json":
                 return Loader.isModLoaded("biomesoplenty");

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -14,6 +14,7 @@ public class UTMixinLoader implements ILateMixinLoader
     public List<String> getMixinConfigs()
     {
         return Lists.newArrayList(
+            "mixins.mods.abyssalcraft.json",
             "mixins.mods.aoa3.json",
             "mixins.mods.biomesoplenty.json",
             "mixins.mods.crafttweaker.json",
@@ -60,6 +61,8 @@ public class UTMixinLoader implements ILateMixinLoader
         }
         switch (mixinConfig)
         {
+            case "mixins.mods.abyssalcraft.json" :
+                return Loader.isModLoaded("abyssalcraft");
             case "mixins.mods.biomesoplenty.json":
                 return Loader.isModLoaded("biomesoplenty");
             case "mixins.mods.cqrepoured.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/UTItemTransferManager.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/UTItemTransferManager.java
@@ -1,0 +1,85 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft;
+
+import java.util.Map;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.Chunk;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+// Intermediary class, based off of Pneumaticraft's SemiblockManager
+public class UTItemTransferManager
+{
+    public static final UTItemTransferManager INSTANCE = new UTItemTransferManager();
+    /*
+     * Holds map of configured tile entities' positions per (loaded) chunk
+     * Existing configurations before tweak was enabled need to be reconfigured
+     */
+    private final Map<Chunk, Map<BlockPos, TileEntity>> configuredTileEntities = new Object2ObjectOpenHashMap<>();
+
+    public boolean isEmpty()
+    {
+        return configuredTileEntities.isEmpty();
+    }
+
+    public boolean contains(Chunk chunk)
+    {
+        return configuredTileEntities.containsKey(chunk);
+    }
+
+    // Get a map of tile entities for this chunk or create a new one if it doesn't exist
+    private Map<BlockPos, TileEntity> getOrCreateMap(Chunk chunk)
+    {
+        Map<BlockPos, TileEntity> positions = configuredTileEntities.get(chunk);
+        if (positions == null)
+        {
+            positions = new Object2ObjectOpenHashMap<>();
+            configuredTileEntities.put(chunk, positions);
+        }
+        return positions;
+    }
+
+    public Map<BlockPos, TileEntity> getChunkMap(Chunk chunk)
+    {
+        return configuredTileEntities.get(chunk);
+    }
+
+    // Gets a flattened view of all (BlockPos, TileEntity)s loaded
+    public Map<BlockPos, TileEntity> getFlattenedView()
+    {
+        Map<BlockPos, TileEntity> flattenedMap = new Object2ObjectOpenHashMap<>();
+        for (Map<BlockPos, TileEntity> map : configuredTileEntities.values())
+        {
+            flattenedMap.putAll(map);
+        }
+        return flattenedMap;
+    }
+
+    // Add the configured tile entity to chunk's map (if it doesn't exist)
+    public void addConfigured(Chunk chunk, BlockPos pos, TileEntity te)
+    {
+        getOrCreateMap(chunk).putIfAbsent(pos, te);
+    }
+
+    // Update the configured tile entity to chunk's map
+    public void updateConfigured(Chunk chunk, BlockPos pos, TileEntity te)
+    {
+        getOrCreateMap(chunk).put(pos, te);
+    }
+
+    // Remove the configured tile entity's position from chunk's map
+    public void removeConfigured(Chunk chunk, BlockPos pos)
+    {
+        Map<BlockPos, TileEntity> map = getOrCreateMap(chunk);
+        map.remove(pos);
+        // Remove chunk entry so configuredTileEntities can check isEmpty() easily
+        if (map.isEmpty()) removeChunk(chunk);
+    }
+
+    // Remove chunk entry from parent map
+    public void removeChunk(Chunk chunk)
+    {
+        configuredTileEntities.remove(chunk);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
@@ -1,11 +1,6 @@
 package mod.acgaming.universaltweaks.mods.abyssalcraft.mixin;
 
-import java.util.Set;
-
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
@@ -15,14 +10,15 @@ import net.minecraft.world.chunk.Chunk;
 
 import com.shinoow.abyssalcraft.common.items.ItemConfigurator;
 import mod.acgaming.universaltweaks.config.UTConfig;
-import mod.acgaming.universaltweaks.mods.abyssalcraft.UTItemTransferManager;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapability;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@Mixin(value = ItemConfigurator.class, remap = false)
+// Courtesy of jchung01
+// remap = false causes issues?
+@Mixin(value = ItemConfigurator.class)
 public class UTItemConfiguratorMixin
 {
     // Item is called "Spirit Tablet"
@@ -38,24 +34,24 @@ public class UTItemConfiguratorMixin
 
     // mode == 1
     @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;addTransferConfiguration(Lcom/shinoow/abyssalcraft/api/transfer/ItemTransferConfiguration;)V"))
-    private void utAddConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> ci)
+    private void utAddConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir)
     {
         if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
 
         Chunk chunk = w.getChunk(pos);
-        UTItemTransferManager.INSTANCE.addConfigured(chunk, pos, w.getTileEntity(pos));
+        UTWorldDataCapability.getCap(w).addConfigured(chunk, pos, w.getTileEntity(pos));
         // Not sure if this is necessary?
         chunk.markDirty();
     }
 
     // mode == 2
     @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;clearConfigurations()V"))
-    private void utRemoveConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> ci)
+    private void utRemoveConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir)
     {
         if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
 
         Chunk chunk = w.getChunk(pos);
-        UTItemTransferManager.INSTANCE.removeConfigured(w.getChunk(pos), pos);
+        UTWorldDataCapability.getCap(w).removeConfigured(w.getChunk(pos), pos);
         // Not sure if this is necessary?
         chunk.markDirty();
     }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
@@ -1,0 +1,62 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.mixin;
+
+import java.util.Set;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+import com.shinoow.abyssalcraft.common.items.ItemConfigurator;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.UTItemTransferManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(value = ItemConfigurator.class, remap = false)
+public class UTItemConfiguratorMixin
+{
+    // Item is called "Spirit Tablet"
+    /*
+     * Mode reference:
+     * mode == 0: Set Path
+     *      - No changes needed, only edits the configurator's nbt
+     * mode == 1: Apply Configuration
+     *       - Need to add TE to UTItemTransferListHolder.configuredTileEntities
+     * mode == 2: Clear Configurations
+     *       - Need to remove TE from UTItemTransferListHolder.configuredTileEntities
+     */
+
+    // mode == 1
+    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;addTransferConfiguration(Lcom/shinoow/abyssalcraft/api/transfer/ItemTransferConfiguration;)V"))
+    private void utAddConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> ci)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+
+        Chunk chunk = w.getChunk(pos);
+        UTItemTransferManager.INSTANCE.addConfigured(chunk, pos, w.getTileEntity(pos));
+        // Not sure if this is necessary?
+        chunk.markDirty();
+    }
+
+    // mode == 2
+    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;clearConfigurations()V"))
+    private void utRemoveConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> ci)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+
+        Chunk chunk = w.getChunk(pos);
+        UTItemTransferManager.INSTANCE.removeConfigured(w.getChunk(pos), pos);
+        // Not sure if this is necessary?
+        chunk.markDirty();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemTransferEventHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemTransferEventHandlerMixin.java
@@ -1,0 +1,178 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.mixin;
+
+import java.util.Map;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.event.world.ChunkDataEvent;
+import net.minecraftforge.event.world.ChunkEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+import com.shinoow.abyssalcraft.api.transfer.ItemTransferConfiguration;
+import com.shinoow.abyssalcraft.api.transfer.caps.IItemTransferCapability;
+import com.shinoow.abyssalcraft.api.transfer.caps.ItemTransferCapability;
+import com.shinoow.abyssalcraft.common.entity.EntitySpiritItem;
+import com.shinoow.abyssalcraft.common.handlers.ItemTransferEventHandler;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.UTItemTransferManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ItemTransferEventHandler.class, remap = false)
+public class UTItemTransferEventHandlerMixin
+{
+    private static final String CHECK_ID = UniversalTweaks.MODID + "AbyssalConfigurations";
+
+    // Save data from memory to nbt
+    @SubscribeEvent
+    public void utOnChunkSave(ChunkDataEvent.Save event)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+
+        Chunk chunk = event.getChunk();
+        Map<BlockPos, TileEntity> set = UTItemTransferManager.INSTANCE.getChunkMap(chunk);
+        // Save configured tile entity positions to nbt
+        if (set != null && !set.isEmpty())
+        {
+            NBTTagList tagList = new NBTTagList();
+            for (BlockPos pos : set.keySet())
+            {
+                TileEntity te = event.getWorld().getTileEntity(pos);
+                // Skip blocks that are no longer the expected tile entity (block was broken/replaced)
+                if (te != null && !hasCap(te)) continue;
+                NBTTagCompound tag = new NBTTagCompound();
+                tag.setInteger("x", pos.getX());
+                tag.setInteger("y", pos.getY());
+                tag.setInteger("z", pos.getZ());
+                tagList.appendTag(tag);
+            }
+            // Cleanup unloaded/invalid chunks from memory
+            if (!event.getChunk().isLoaded() || tagList.isEmpty())
+            {
+                UTItemTransferManager.INSTANCE.removeChunk(event.getChunk());
+                if (tagList.isEmpty()) return;
+            }
+
+            event.getData().setTag(CHECK_ID, tagList);
+        }
+    }
+
+    // Load data from nbt to memory
+    @SubscribeEvent
+    public void utOnChunkLoad(ChunkDataEvent.Load event)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+        if (event.getWorld().isRemote) return;
+
+        if (event.getData().hasKey(CHECK_ID))
+        {
+            World world = event.getWorld();
+            NBTTagList tagList = event.getData().getTagList(CHECK_ID, Constants.NBT.TAG_COMPOUND);
+            for (int i = 0; i < tagList.tagCount(); i++)
+            {
+                NBTTagCompound tag = tagList.getCompoundTagAt(i);
+                BlockPos pos = new BlockPos(tag.getInteger("x"), tag.getInteger("y"), tag.getInteger("z"));
+
+                // Add entry to memory (Tile entity is unknown if world is still loading)
+                TileEntity te = world.isBlockLoaded(pos) ? world.getTileEntity(pos) : null;
+                UTItemTransferManager.INSTANCE.addConfigured(event.getChunk(), pos, te);
+            }
+        }
+    }
+
+    // Overwrites onTick() to be more performant
+    @Inject(method = "onTick", at = @At(value = "HEAD"), cancellable = true)
+    private void utOnTick(TickEvent.WorldTickEvent event, CallbackInfo ci)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+        ci.cancel();
+
+        // Mostly copied from original onTick()
+        if (event.side == Side.SERVER && event.type == TickEvent.Type.WORLD && event.phase == TickEvent.Phase.END)
+        {
+            if (UTItemTransferManager.INSTANCE.isEmpty()) return;
+            World world = event.world;
+            if (world.getTotalWorldTime() % 20 != 0) return;
+            // Get a map of all configured tile entities instead of using stream
+            UTItemTransferManager.INSTANCE.getFlattenedView()
+                    .forEach((pos, tile) ->
+                    {
+                        // Get tile entity if it was unknown at add time
+                        if (tile == null)
+                        {
+                            tile = world.getTileEntity(pos);
+                            UTItemTransferManager.INSTANCE.updateConfigured(world.getChunk(pos), pos, tile);
+                        }
+
+                        IItemTransferCapability cap = ItemTransferCapability.getCap(tile);
+                        for (ItemTransferConfiguration cfg : cap.getTransferConfigurations())
+                        {
+                            IItemHandler inventory = ItemTransferEventHandler.getInventory(tile, cfg.getExitFacing());
+                            // Sided inventories, you never know
+                            if (inventory != null)
+                            {
+                                boolean hasFilter = !cfg.getFilter().isEmpty() && cfg.getFilter().stream().anyMatch(i -> !i.isEmpty());
+                                ItemStack stack = ItemStack.EMPTY;
+                                int slot = -1;
+                                for (int i = 0; i < inventory.getSlots(); i++)
+                                {
+                                    stack = inventory.getStackInSlot(i);
+                                    if (!stack.isEmpty())
+                                        if (!hasFilter || isInFilter(cfg.getFilter(), stack, cfg.filterByNBT()))
+                                        {
+                                            stack = inventory.extractItem(i, 1, true);
+                                            slot = i;
+                                            break;
+                                        }
+                                }
+                                if (!stack.isEmpty() && slot > -1)
+                                {
+                                    BlockPos exitPos = cfg.getRoute()[cfg.getRoute().length - 1];
+                                    TileEntity te = world.getTileEntity(exitPos);
+                                    if (te != null)
+                                    {
+                                        IItemHandler exitInv = ItemTransferEventHandler.getInventory(te, cfg.getEntryFacing());
+                                        // Insertion worked
+                                        if (exitInv != null && ItemHandlerHelper.insertItem(exitInv, stack, true).isEmpty())
+                                        {
+                                            stack = inventory.extractItem(slot, 1, false);
+                                            EntitySpiritItem spirit = new EntitySpiritItem(world, pos.getX() + 0.5D, pos.getY(), pos.getZ() + 0.5D, stack.copy());
+                                            spirit.setRoute(cfg.getRoute());
+                                            spirit.setFacing(cfg.getEntryFacing());
+                                            world.spawnEntity(spirit);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+        }
+    }
+
+    @Shadow
+    private boolean hasCap(TileEntity te)
+    {
+        return false;
+    }
+
+    @Shadow
+    private boolean isInFilter(NonNullList<ItemStack> filter, ItemStack stack, boolean nbt)
+    {
+        return false;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/IUTWorldDataCapability.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/IUTWorldDataCapability.java
@@ -1,0 +1,84 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata;
+
+import java.util.Map;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.Chunk;
+
+/**
+ * Interface for World Data Capability
+ * @author jchung01
+ */
+public interface IUTWorldDataCapability
+{
+    /**
+     * @return       true if the map of chunks with configured tile entities is empty;
+     *               false otherwise.
+     */
+    boolean isEmpty();
+
+    /**
+     * @param chunk  the chunk to check
+     * @return       true if the chunk is in the map;
+     *               false otherwise.
+     */
+    boolean contains(Chunk chunk);
+
+    /**
+     * Gets the map of tile entities for this chunk,
+     * creating a new one if it doesn't exist.
+     *
+     * @param chunk  the chunk the map corresponds to
+     * @return       the map of configured tile entities in this chunk
+     */
+    Map<BlockPos, TileEntity> getOrCreateMap(Chunk chunk);
+
+    /**
+     * Gets the map of tile entities for this chunk.
+     *
+     * @param chunk  the chunk the map corresponds to
+     * @return       the map of configured tile entities in this chunk
+     */
+    Map<BlockPos, TileEntity> getChunkMap(Chunk chunk);
+
+    /**
+     * Gets a flattened Map view of all tile entities loaded in the world.
+     *
+     * @return       the map of loaded, configured tile entities in the world
+     */
+    Map<BlockPos, TileEntity> getFlattenedView();
+
+    /**
+     * Adds the configured tile entity to the chunk's map if it doesn't exist.
+     *
+     * @param chunk  the chunk the tile entity is in
+     * @param pos    the position of the tile entity
+     * @param te     the configured tile entity to add
+     */
+    void addConfigured(Chunk chunk, BlockPos pos, TileEntity te);
+
+    /**
+     * Updates the configured tile entity in the chunk's map.
+     *
+     * @param chunk  the chunk the tile entity is in
+     * @param pos    the position of the tile entity
+     * @param te     the configured tile entity to update
+     */
+    void updateConfigured(Chunk chunk, BlockPos pos, TileEntity te);
+
+    /**
+     * Removes the configured tile entity from the chunk's map.
+     *
+     * @param chunk  the chunk the tile entity is in
+     * @param pos    the position of the tile entity
+     */
+    void removeConfigured(Chunk chunk, BlockPos pos);
+
+    /**
+     * Removes the chunk entry from the map of chunks with configured tile entities
+     *
+     * @param chunk  the chunk entry
+     */
+    void removeChunk(Chunk chunk);
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/UTWorldDataCapabilityProvider.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/UTWorldDataCapabilityProvider.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+// Courtesy of jchung01
+public class UTWorldDataCapabilityProvider implements ICapabilityProvider
+{
+    @CapabilityInject(IUTWorldDataCapability.class)
+    public static Capability<IUTWorldDataCapability> WORLD_DATA_CAP = null;
+
+    private final IUTWorldDataCapability capability;
+
+    public UTWorldDataCapabilityProvider()
+    {
+        capability = new UTWorldDataCapability();
+    }
+
+    @Override
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing enumFacing)
+    {
+        return capability == WORLD_DATA_CAP;
+    }
+
+    @Nullable
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing enumFacing)
+    {
+        if(capability == WORLD_DATA_CAP)
+            return (T) this.capability;
+
+        return null;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/UTWorldDataCapabilityStorage.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/worlddata/UTWorldDataCapabilityStorage.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.Capability.IStorage;
+
+// Courtesy of jchung01
+public class UTWorldDataCapabilityStorage implements IStorage<IUTWorldDataCapability>
+{
+    public static final IStorage<IUTWorldDataCapability> INSTANCE = new UTWorldDataCapabilityStorage();
+
+    // Not using persistent storage for World data.
+    @Nullable
+    @Override
+    public NBTBase writeNBT(Capability<IUTWorldDataCapability> capability, IUTWorldDataCapability IUTWorldDataCapability, EnumFacing enumFacing)
+    {
+        return new NBTTagCompound();
+    }
+
+    // Not using persistent storage for World data.
+    @Override
+    public void readNBT(Capability<IUTWorldDataCapability> capability, IUTWorldDataCapability IUTWorldDataCapability, EnumFacing enumFacing, NBTBase nbtBase) {}
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -27,6 +27,7 @@ cfg.universaltweaks.bugfixes.misc.modelgap=Model Gap
 cfg.universaltweaks.bugfixes.world=Bugfixes: World
 cfg.universaltweaks.debug=Debug
 cfg.universaltweaks.modintegration=Mod Integration
+cfg.universaltweaks.modintegration.abyssalcraft=Abyssalcraft
 cfg.universaltweaks.modintegration.aoa=Advent of Ascension
 cfg.universaltweaks.modintegration.bop=Biomes O' Plenty
 cfg.universaltweaks.modintegration.botania=Botania

--- a/src/main/resources/mixins.mods.abyssalcraft.json
+++ b/src/main/resources/mixins.mods.abyssalcraft.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.abyssalcraft.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTItemConfiguratorMixin", "UTItemTransferEventHandlerMixin"]
+}

--- a/src/main/resources/mixins.mods.abyssalcraft.json
+++ b/src/main/resources/mixins.mods.abyssalcraft.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["UTItemConfiguratorMixin", "UTItemTransferEventHandlerMixin"]
+  "mixins": ["UTItemConfiguratorMixin", "UTItemTransferEventHandlerMixin"]
 }


### PR DESCRIPTION
This tweak replaces AbyssalCraft's item transfer system with a more performant one, improving tick overhead even when the user is not utiltizing the system at all. The performance gains should be most noticeable in worlds with many loaded tile entities (regardless of if any of them are using the item transfer system).

For context, the existing system does a lot of work in `onTick()`, even when there are no tile entities configured to use the system. This tweak changes the implementation to only work on "remembered" configured tile entities using a `World` capability and saving to `ChunkData` for persistence. The only tile entities `onTick()` will check then are ones added specifically by the "Spirit Tablet"/Configurator and saved tile entities that were configured before by aforementioned item.

However, this does seem to be a (partially) breaking change. I am pretty sure this tweak cannot account for tile entities that were configured before the tweak was enabled, so any of those tile entities must be reconfigured after the tweak has been enabled. To be fair, I am not aware of anyone who has ever used this item transfer system, so this is probably not too much of a concern.

Testing in a developed world with a lot of tile entities, none using the item transfer system:
With tweak disabled:
![abyssal2](https://user-images.githubusercontent.com/60687097/233233554-49af2f3e-427e-4e19-a8d4-162bc7485f57.PNG)
With tweak **enabled**:
![abyssal1](https://user-images.githubusercontent.com/60687097/233233617-aafed24e-8fef-40d7-ad23-7b79b030056b.PNG)
Removes 1% of total tick time, which is decent in my opinion.
