### PR TITLE
only builds recipe cache when game has started

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/craftingcache/UTCraftingCache.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/craftingcache/UTCraftingCache.java
@@ -9,6 +9,8 @@ import net.minecraft.world.World;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.LoaderState;
 
 // Courtesy of EverNife
 public class UTCraftingCache
@@ -34,7 +36,7 @@ public class UTCraftingCache
     public static IRecipe findMatchingRecipe(InventoryCrafting craftMatrix, World worldIn)
     {
         boolean hasNBT = hasAnyNBT(craftMatrix);
-        if (!hasNBT)
+        if (!hasNBT && Loader.instance().hasReachedState(LoaderState.SERVER_STARTING))
         {
             UTOptionalContent<IRecipe> optionalContent = getOrCreateCachedRecipe(craftMatrix);
             if (!optionalContent.hasContent()) optionalContent.setContent(findMatchingRecipeDefault(craftMatrix, worldIn));


### PR DESCRIPTION
Some mods may access crafting recipes when game loading. For example, Mekansim accesses log to plank recipes in order to build sawmill recipes. Then the recipe cache is built when game loading. But it is before CraftTweaker modifies recipes. So the old cache would not reflect the new modification.
The PR makes the recipe cache is only be built after the game has started. Mods shouldn't access the same recipe twice in game loading, the cache is meaningless in this case.
Refer to: Krutoy242/Enigmatica2Expert-Extended#202