### PR TITLE
Add NC container to AOA tweak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     deobfCompile "curse.maven:fluxnetworks-248020:3178199"
     deobfCompile "curse.maven:forestry-59751:2918418"
     deobfCompile "curse.maven:modtweaker-220954:3840577"
+    deobfCompile "curse.maven:nuclearcraft-226254:3784145"
     deobfCompile "curse.maven:reborn-core-237903:3330308"
     deobfCompile "curse.maven:reskillable-286382:2815686"
     deobfCompile "curse.maven:roost-277711:2702080"

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -43,7 +43,7 @@ public class UniversalTweaks
     public static final String MODID = "universaltweaks";
     public static final String NAME = "Universal Tweaks";
     public static final String VERSION = "1.12.2-1.7.0";
-    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.0,);required-after:configanytime;after:abyssalcraft;after:aoa3;after:biomesoplenty;after:botania;after:cofhcore;after:contenttweaker;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:infernalmobs;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
+    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.0,);required-after:configanytime;after:abyssalcraft;after:aoa3;after:biomesoplenty;after:botania;after:cofhcore;after:contenttweaker;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:infernalmobs;after:nuclearcraft;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
     public static final Logger LOGGER = LogManager.getLogger(NAME);
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -54,7 +54,7 @@ public class UTMixinLoader implements ILateMixinLoader
             switch (mixinConfig)
             {
                 case "mixins.mods.aoa3.json":
-                    return Loader.isModLoaded("aoa3") && Loader.isModLoaded("fluxnetworks");
+                    return Loader.isModLoaded("aoa3") && (Loader.isModLoaded("fluxnetworks") || Loader.isModLoaded("nuclearcraft"));
                 case "mixins.mods.crafttweaker.json":
                     return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.roost.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/mixin/UTAOAHandleSetSlotMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/mixin/UTAOAHandleSetSlotMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.item.ItemStack;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
+import nc.container.processor.ContainerSorptions;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,6 +26,6 @@ public class UTAOAHandleSetSlotMixin
     {
         if (!UTConfig.MOD_INTEGRATION.AOA.utFixPlayerTickInInventorylessGui) return true;
         if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTAOAHandleSetSlot ::: Check inventory-less GUI (from AOA playerTick)");
-        return !(client.player.openContainer instanceof ContainerCore);
+        return !(client.player.openContainer instanceof ContainerCore || client.player.openContainer instanceof ContainerSorptions);
     }
 }


### PR DESCRIPTION
Adds the NuclearCraft configuration GUI (which has no player inventory, thus causes crashes) to the AOA compatibility tweak.
I would like to mention that there is an alternate fix for this GUI crash that also fixes significant network tick overhead related to AOA's `PlayerDataManager.tickEquipment()` by only calling `detectAndSendChanges()` when necessary, but it requires mixing into Advent of Ascension, so I will leave that fix locally unless on request due to licensing.