### PR TITLE
Use better data structures for NuclearCraft RadiationEnvironmentHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     deobfCompile "curse.maven:fluxnetworks-248020:3178199"
     deobfCompile "curse.maven:forestry-59751:2918418"
     deobfCompile "curse.maven:modtweaker-220954:3840577"
+    deobfCompile "curse.maven:nuclearcraft-226254:3784145"
     deobfCompile "curse.maven:reborn-core-237903:3330308"
     deobfCompile "curse.maven:reskillable-286382:2815686"
     deobfCompile "curse.maven:roost-277711:2702080"

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1952,13 +1952,15 @@ public class UTConfig
                     ({
                             "Changes the data table of the radiation environment handler to improve performance",
                             "CONCURRENT_HASHMAP:        NuclearCraft default",
-                            "CONCURRENT_LINKED_HASHMAP: Keeps an order of radiation environment info to speed up iteration",
+                            "CONCURRENT_LINKED_HASHMAP: Keeps order of radiation environment info to improve iteration - Better performance",
+                            "CONCURRENT_LINKED_QUEUE:   Uses a queue to avoid iteration - Best performance"
                     })
-            public EnumMaps utNCRadiationEnvironmentMap = EnumMaps.CONCURRENT_LINKED_HASHMAP;
+            public EnumMaps utNCRadiationEnvironmentMap = EnumMaps.CONCURRENT_LINKED_QUEUE;
             public enum EnumMaps
             {
                 CONCURRENT_HASHMAP,
-                CONCURRENT_LINKED_HASHMAP
+                CONCURRENT_LINKED_HASHMAP,
+                CONCURRENT_LINKED_QUEUE
             }
         }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1782,6 +1782,10 @@ public class UTConfig
         @Config.Name("Infernal Mobs")
         public final InfernalMobsCategory INFERNAL_MOBS = new InfernalMobsCategory();
 
+        @Config.LangKey("cfg.universaltweaks.modintegration.nuclearcraft")
+        @Config.Name("NuclearCraft")
+        public final NuclearCraftCategory NUCLEARCRAFT = new NuclearCraftCategory();
+
         @Config.LangKey("cfg.universaltweaks.modintegration.roost")
         @Config.Name("Roost")
         public final RoostCategory ROOST = new RoostCategory();
@@ -1938,6 +1942,24 @@ public class UTConfig
             @Config.Name("Sticky Recall Compatibility")
             @Config.Comment("Enables compatibility between Infernal Mobs' Sticky effect and Capsule's Recall enchantment")
             public boolean utIMStickyRecallToggle = true;
+        }
+
+        public static class NuclearCraftCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("Radiation Environment Map")
+            @Config.Comment
+                    ({
+                            "Changes the data table of the radiation environment handler to improve performance",
+                            "CONCURRENT_HASHMAP:        NuclearCraft default",
+                            "CONCURRENT_LINKED_HASHMAP: Keeps an order of radiation environment info to speed up iteration",
+                    })
+            public EnumMaps utNCRadiationEnvironmentMap = EnumMaps.CONCURRENT_LINKED_HASHMAP;
+            public enum EnumMaps
+            {
+                CONCURRENT_HASHMAP,
+                CONCURRENT_LINKED_HASHMAP
+            }
         }
 
         public static class RoostCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -28,6 +28,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.forestry.cocoa.json",
             "mixins.mods.forestry.extratrees.json",
             "mixins.mods.infernalmobs.json",
+            "mixins.mods.nuclearcraft.json",
             "mixins.mods.reskillable.json",
             "mixins.mods.roost.json",
             "mixins.mods.roost.contenttweaker.json",
@@ -93,6 +94,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("extratrees");
             case "mixins.mods.infernalmobs.json":
                 return Loader.isModLoaded("infernalmobs");
+            case "mixins.mods.nuclearcraft.json":
+                return Loader.isModLoaded("nuclearcraft");
             case "mixins.mods.reskillable.json":
                 return Loader.isModLoaded("reskillable");
             case "mixins.mods.roost.contenttweaker.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/nuclearcraft/mixin/UTRadiationEnvironmentHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/nuclearcraft/mixin/UTRadiationEnvironmentHandlerMixin.java
@@ -1,40 +1,117 @@
 package mod.acgaming.universaltweaks.mods.nuclearcraft.mixin;
 
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
+
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.common.gameevent.TickEvent.WorldTickEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
 import mod.acgaming.universaltweaks.config.UTConfig.ModIntegrationCategory.NuclearCraftCategory.EnumMaps;
+import nc.config.NCConfig;
 import nc.radiation.environment.RadiationEnvironmentHandler;
 import nc.radiation.environment.RadiationEnvironmentInfo;
+import nc.tile.radiation.ITileRadiationEnvironment;
 import nc.util.FourPos;
+import org.apache.commons.lang3.tuple.Pair;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // courtesy of jchung01
 @Mixin(value = RadiationEnvironmentHandler.class, remap = false)
 public class UTRadiationEnvironmentHandlerMixin
 {
+    // ENVIRONMENT will be used as the "backup" backing map if using ENVIRONMENT_QUEUE
+    // ENVIRONMENT_BACKUP will be unused
     @Mutable
     @Shadow
     @Final
     private static ConcurrentMap<FourPos, RadiationEnvironmentInfo> ENVIRONMENT;
 
-    @Redirect(method = "<clinit>", at = @At(value = "FIELD", ordinal = 0))
-    private static void utRadiationEnvironmentMap(ConcurrentMap<FourPos, RadiationEnvironmentInfo> map)
+    // Used instead of iterating through HashMap in updateRadiationEnvironment()
+    private static final Queue<Pair<FourPos, RadiationEnvironmentInfo>> ENVIRONMENT_QUEUE = UTConfig.MOD_INTEGRATION.NUCLEARCRAFT.utNCRadiationEnvironmentMap == EnumMaps.CONCURRENT_LINKED_QUEUE ? new ConcurrentLinkedQueue<>() : null;
+
+    @Inject(method = "updateRadiationEnvironment", at = @At(value = "HEAD"), cancellable = true)
+    private void utUseEnvironmentQueue(WorldTickEvent event, CallbackInfo ci)
+    {
+        if (UTConfig.MOD_INTEGRATION.NUCLEARCRAFT.utNCRadiationEnvironmentMap != EnumMaps.CONCURRENT_LINKED_QUEUE) return;
+        ci.cancel();
+
+        if (!NCConfig.radiation_enabled_public) return;
+
+        if (event.phase != Phase.END || event.side == Side.CLIENT || !(event.world instanceof WorldServer)) return;
+        int dim = event.world.provider.getDimension();
+
+        // Don't check size here, it's expensive for queue
+        int count = (1 + NCConfig.radiation_world_chunks_per_tick) / 2;
+        boolean queueEmpty = false;
+
+        while (count > 0 && !(queueEmpty = ENVIRONMENT_QUEUE.isEmpty()))
+        {
+            --count;
+
+            Map.Entry<FourPos, RadiationEnvironmentInfo> environmentEntry = ENVIRONMENT_QUEUE.poll();
+            if (environmentEntry == null) break;
+
+            FourPos pos = environmentEntry.getKey();
+            RadiationEnvironmentInfo info = environmentEntry.getValue();
+
+            if (pos.getDimension() == dim)
+            {
+                for (Map.Entry<FourPos, ITileRadiationEnvironment> infoEntry : info.tileMap.entrySet())
+                {
+                    infoEntry.getValue().handleRadiationEnvironmentInfo(info);
+                }
+            }
+
+            // Already removed entry with poll()
+
+            ENVIRONMENT.put(pos, info);
+        }
+
+        if (queueEmpty)
+        {
+            // addAll has casting issues, use forEach
+            for (Map.Entry<FourPos, RadiationEnvironmentInfo> environmentEntry : ENVIRONMENT.entrySet())
+            {
+                ENVIRONMENT_QUEUE.add(Pair.of(environmentEntry.getKey(), environmentEntry.getValue()));
+            }
+            ENVIRONMENT.clear();
+        }
+    }
+
+    // If using ENVIRONMENT as "backup", don't need to track ENVIRONMENT_BACKUP
+    @Inject(method = "removeTile", at = @At(value = "FIELD", target = "Lnc/radiation/environment/RadiationEnvironmentHandler;ENVIRONMENT_BACKUP:Ljava/util/concurrent/ConcurrentMap;", opcode = Opcodes.GETSTATIC), cancellable = true)
+    private static void utSkipRemoveFromBackup(CallbackInfo ci)
+    {
+        if (UTConfig.MOD_INTEGRATION.NUCLEARCRAFT.utNCRadiationEnvironmentMap != EnumMaps.CONCURRENT_LINKED_QUEUE) return;
+        ci.cancel();
+    }
+
+
+    @Redirect(method = "<clinit>", at = @At(value = "FIELD", target = "Lnc/radiation/environment/RadiationEnvironmentHandler;ENVIRONMENT:Ljava/util/concurrent/ConcurrentMap;"))
+    private static void utUseEnvironmentLinkedMap(ConcurrentMap<FourPos, RadiationEnvironmentInfo> map)
     {
         if (UTConfig.MOD_INTEGRATION.NUCLEARCRAFT.utNCRadiationEnvironmentMap == EnumMaps.CONCURRENT_LINKED_HASHMAP)
         {
-            if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTRadiationEnvironmentHandler ::: Concurrent linked hash map");
-            // only replace ENVIRONMENT, ENVIRONMENT_BACKUP is not iterated on often
+            if (UTConfig.DEBUG.utDebugToggle)
+                UniversalTweaks.LOGGER.debug("UTRadiationEnvironmentHandler ::: Concurrent linked hash map");
+            // only replace ENVIRONMENT, ENVIRONMENT_BACKUP is not iterated on often (if at all)
             ENVIRONMENT = new ConcurrentLinkedHashMap.Builder<FourPos, RadiationEnvironmentInfo>().maximumWeightedCapacity(Long.MAX_VALUE - Integer.MAX_VALUE).build();
-        }
-        else ENVIRONMENT = new ConcurrentHashMap();
+        } else ENVIRONMENT = new ConcurrentHashMap<>();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/nuclearcraft/mixin/UTRadiationEnvironmentHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/nuclearcraft/mixin/UTRadiationEnvironmentHandlerMixin.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.mods.nuclearcraft.mixin;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.config.UTConfig.ModIntegrationCategory.NuclearCraftCategory.EnumMaps;
+import nc.radiation.environment.RadiationEnvironmentHandler;
+import nc.radiation.environment.RadiationEnvironmentInfo;
+import nc.util.FourPos;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// courtesy of jchung01
+@Mixin(value = RadiationEnvironmentHandler.class, remap = false)
+public class UTRadiationEnvironmentHandlerMixin
+{
+    @Mutable
+    @Shadow
+    @Final
+    private static ConcurrentMap<FourPos, RadiationEnvironmentInfo> ENVIRONMENT;
+
+    @Redirect(method = "<clinit>", at = @At(value = "FIELD", ordinal = 0))
+    private static void utRadiationEnvironmentMap(ConcurrentMap<FourPos, RadiationEnvironmentInfo> map)
+    {
+        if (UTConfig.MOD_INTEGRATION.NUCLEARCRAFT.utNCRadiationEnvironmentMap == EnumMaps.CONCURRENT_LINKED_HASHMAP)
+        {
+            if (UTConfig.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTRadiationEnvironmentHandler ::: Concurrent linked hash map");
+            // only replace ENVIRONMENT, ENVIRONMENT_BACKUP is not iterated on often
+            ENVIRONMENT = new ConcurrentLinkedHashMap.Builder<FourPos, RadiationEnvironmentInfo>().maximumWeightedCapacity(Long.MAX_VALUE - Integer.MAX_VALUE).build();
+        }
+        else ENVIRONMENT = new ConcurrentHashMap();
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -39,6 +39,7 @@ cfg.universaltweaks.modintegration.esm=Epic Siege Mod
 cfg.universaltweaks.modintegration.forestry=Forestry
 cfg.universaltweaks.modintegration.infernalmobs=Infernal Mobs
 cfg.universaltweaks.modintegration.moc=Mo' Creatures
+cfg.universaltweaks.modintegration.nuclearcraft=NuclearCraft
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.simpledifficulty=Simple Difficulty
 cfg.universaltweaks.modintegration.sd=Storage Drawers

--- a/src/main/resources/mixins.mods.nuclearcraft.json
+++ b/src/main/resources/mixins.mods.nuclearcraft.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.nuclearcraft.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTRadiationEnvironmentHandlerMixin"]
+}


### PR DESCRIPTION
Improves tick performance of NuclearCraft's `RadiationEnvironmentHandler` by replacing the `ConcurrentHashMap` with either:
 a) `ConcurrentLinkedHashMap` or
 b) a `ConcurrentLinkedQueue`, as it is better to poll from a queue than iterate through the hash map in this case.
Configurable to use either one or leave as default.
I was unable to setup a dev environment (even when trying to utilize RetroFuturaGradle) to properly debug if the queue implementation retains original behavior, but from testing in worlds, I haven't encountered any issues.
Here's a single profile for each setting to provide insight into relative performance differences:
Default, `ConcurrentHashMap`:
![rad1](https://github.com/ACGaming/UniversalTweaks/assets/60687097/fa7ec646-53d8-43d3-a630-aebfcca3d94a)
`ConcurrentLinkedHashMap`:
![rad2](https://github.com/ACGaming/UniversalTweaks/assets/60687097/477c1caa-18fb-40a6-ab18-b8ce4a6eac28)
`ConcurrentLinkedQueue`:
![rad3](https://github.com/ACGaming/UniversalTweaks/assets/60687097/0dec23b8-8475-411c-b249-4655eac569de)