### PR TITLE
Fix Blood Magic memory leak, optimize BM hellfire forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     deobfCompile "curse.maven:baubles-227083:2518667"
     deobfCompile "curse.maven:binnies-mods-223525:2916129"
     deobfCompile "curse.maven:biomes-o-plenty-220318:2842510"
+    deobfCompile "curse.maven:blood-magic-224791:2822288"
     deobfCompile "curse.maven:botania-225643:3330934"
     deobfCompile "curse.maven:chameleon-230497:2450900"
     deobfCompile "curse.maven:chickens-241941:2537643"

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -43,7 +43,7 @@ public class UniversalTweaks
     public static final String MODID = "universaltweaks";
     public static final String NAME = "Universal Tweaks";
     public static final String VERSION = "1.12.2-1.7.0";
-    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.0,);required-after:configanytime;after:abyssalcraft;after:aoa3;after:biomesoplenty;after:botania;after:cofhcore;after:contenttweaker;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:infernalmobs;after:netherrocks;after:nuclearcraft;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
+    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.0,);required-after:configanytime;after:abyssalcraft;after:aoa3;after:biomesoplenty;after:bloodmagic;after:botania;after:cofhcore;after:contenttweaker;after:element;after:elenaidodge2;after:epicsiegemod;after:extratrees;after:forestry;after:infernalmobs;after:netherrocks;after:nuclearcraft;after:roost;after:storagedrawers;after:tconstruct;after:thaumcraft;after:thermalexpansion";
     public static final Logger LOGGER = LogManager.getLogger(NAME);
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfig.java
@@ -1760,6 +1760,10 @@ public class UTConfig
         @Config.Name("Biomes O' Plenty")
         public final BiomesOPlentyCategory BIOMES_O_PLENTY = new BiomesOPlentyCategory();
 
+        @Config.LangKey("cfg.universaltweaks.modintegration.bm")
+        @Config.Name("Blood Magic")
+        public final BloodMagicCategory BLOOD_MAGIC = new BloodMagicCategory();
+
         @Config.LangKey("cfg.universaltweaks.modintegration.botania")
         @Config.Name("Botania")
         public final BotaniaCategory BOTANIA = new BotaniaCategory();
@@ -1858,6 +1862,19 @@ public class UTConfig
             @Config.Name("Hot Spring Water")
             @Config.Comment("Fixes rapid inflection of regeneration effects in hot spring water")
             public boolean utBoPHotSpringWaterToggle = true;
+        }
+
+        public static class BloodMagicCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("Optimized Hellfire Forge")
+            @Config.Comment("Optimizes the Hellfire/Soul Forge to reduce tick time")
+            public boolean utBMOptimizeSoulForgeToggle = true;
+
+            @Config.RequiresMcRestart
+            @Config.Name("World Unload Memory Leak Fix")
+            @Config.Comment("Fixes memory leak related to unloading worlds/switching dimensions")
+            public boolean utBMWorldUnloadToggle = true;
         }
 
         public static class BotaniaCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -17,6 +17,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.abyssalcraft.json",
             "mixins.mods.aoa3.json",
             "mixins.mods.biomesoplenty.json",
+            "mixins.mods.bloodmagic.json",
             "mixins.mods.botania.json",
             "mixins.mods.cofhcore.json",
             "mixins.mods.crafttweaker.json",
@@ -75,6 +76,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("abyssalcraft");
             case "mixins.mods.biomesoplenty.json":
                 return Loader.isModLoaded("biomesoplenty");
+            case "mixins.mods.bloodmagic.json":
+                return Loader.isModLoaded("bloodmagic");
             case "mixins.mods.botania.json":
                 return Loader.isModLoaded("botania");
             case "mixins.mods.cofhcore.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTGenericHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTGenericHandlerMixin.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.mods.bloodmagic.mixin;
+
+import java.util.Map;
+
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.WorldEvent;
+
+import WayofTime.bloodmagic.ritual.AreaDescriptor;
+import WayofTime.bloodmagic.ritual.IMasterRitualStone;
+import WayofTime.bloodmagic.util.handler.event.GenericHandler;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+// Courtesy of michaelPoul
+@Mixin(value = GenericHandler.class, remap = false)
+public class UTGenericHandlerMixin
+{
+    @Shadow
+    public static Map<World, Map<IMasterRitualStone, AreaDescriptor>> forceSpawnMap;
+    @Shadow
+    public static Map<World, Map<IMasterRitualStone, AreaDescriptor>> preventSpawnMap;
+
+    @Inject(method = "onWorldUnload", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private static void utRemoveRemainingWorld(WorldEvent.Unload event, CallbackInfo ci, World world)
+    {
+        if (!UTConfig.MOD_INTEGRATION.BLOOD_MAGIC.utBMWorldUnloadToggle) return;
+        forceSpawnMap.remove(world);
+        preventSpawnMap.remove(world);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTTileSoulForgeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTTileSoulForgeMixin.java
@@ -1,0 +1,71 @@
+package mod.acgaming.universaltweaks.mods.bloodmagic.mixin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ITickable;
+
+import WayofTime.bloodmagic.api.impl.BloodMagicAPI;
+import WayofTime.bloodmagic.api.impl.BloodMagicRecipeRegistrar;
+import WayofTime.bloodmagic.api.impl.recipe.RecipeTartaricForge;
+import WayofTime.bloodmagic.soul.IDemonWillConduit;
+import WayofTime.bloodmagic.tile.TileInventory;
+import WayofTime.bloodmagic.tile.TileSoulForge;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// Courtesy of jchung01
+@Mixin(value = TileSoulForge.class, remap = false)
+public abstract class UTTileSoulForgeMixin extends TileInventory implements ITickable, IDemonWillConduit
+{
+    private boolean isAdded = false;
+    private RecipeTartaricForge utLastRecipe = null;
+
+    // Dummy constructor
+    public UTTileSoulForgeMixin(int size, String name)
+    {
+        super(size, name);
+    }
+
+    @Override
+    public void markDirty()
+    {
+        super.markDirty();
+        if (!UTConfig.MOD_INTEGRATION.BLOOD_MAGIC.utBMOptimizeSoulForgeToggle) return;
+        utRefreshRecipe();
+    }
+
+    /**
+     * Use cached recipe in update().
+     * Uses Redirect because getTartaricForge() must not be called unless necessary.
+     * <p>
+     * Remapping needed!
+     */
+    @Redirect(method = "update", at = @At(value = "INVOKE", target = "LWayofTime/bloodmagic/api/impl/BloodMagicRecipeRegistrar;getTartaricForge(Ljava/util/List;)LWayofTime/bloodmagic/api/impl/recipe/RecipeTartaricForge;"), remap = true)
+    private RecipeTartaricForge utUseCachedRecipe(BloodMagicRecipeRegistrar registrar, List<ItemStack> input)
+    {
+        if (!UTConfig.MOD_INTEGRATION.BLOOD_MAGIC.utBMOptimizeSoulForgeToggle) return registrar.getTartaricForge(input);
+        if (!isAdded)
+        {
+            utLastRecipe = registrar.getTartaricForge(input);
+            isAdded = true;
+        }
+        return utLastRecipe;
+    }
+
+    public void utRefreshRecipe()
+    {
+        List<ItemStack> inputList = new ArrayList<>();
+        for (int i = 0; i < 4; i++)
+        {
+            if (!getStackInSlot(i).isEmpty())
+            {
+                inputList.add(getStackInSlot(i));
+            }
+        }
+        utLastRecipe = BloodMagicAPI.INSTANCE.getRecipeRegistrar().getTartaricForge(inputList);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -29,6 +29,7 @@ cfg.universaltweaks.debug=Debug
 cfg.universaltweaks.modintegration=Mod Integration
 cfg.universaltweaks.modintegration.abyssalcraft=AbyssalCraft
 cfg.universaltweaks.modintegration.aoa=Advent of Ascension
+cfg.universaltweaks.modintegration.bm=Blood Magic
 cfg.universaltweaks.modintegration.bop=Biomes O' Plenty
 cfg.universaltweaks.modintegration.botania=Botania
 cfg.universaltweaks.modintegration.cofhcore=CoFH Core

--- a/src/main/resources/mixins.mods.bloodmagic.json
+++ b/src/main/resources/mixins.mods.bloodmagic.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.bloodmagic.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTGenericHandlerMixin", "UTTileSoulForgeMixin"]
+}


### PR DESCRIPTION
Adds the simple memory leak fix from WayofTime/BloodMagic#1686 that was never published to CurseForge for 1.12. This memory leak occurred whenever switching dimensions/unloading worlds, which would cause eventual memory problems for the client.
Also optimizes hellfire forges by caching their last recipe used:
Before -
![bm1](https://github.com/ACGaming/UniversalTweaks/assets/60687097/b33d652e-00db-4936-b6e7-c691d90816f2)
After -
![bm2](https://github.com/ACGaming/UniversalTweaks/assets/60687097/00a872e7-8789-4e48-8c7f-efcf93d13a8b)
