### PR TITLE
Fix AbyssalCraft world data capability applying to all objects, not just worlds

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -14,6 +14,7 @@ import mod.acgaming.universaltweaks.bugfixes.blocks.blockoverlay.UTBlockOverlayL
 import mod.acgaming.universaltweaks.bugfixes.misc.help.UTHelp;
 import mod.acgaming.universaltweaks.config.UTConfig;
 import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.UTAbyssalCraftEvents;
 import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapability;
 import mod.acgaming.universaltweaks.mods.arcanearchives.UTArcaneArchivesEvents;
 import mod.acgaming.universaltweaks.mods.bloodmagic.UTBloodMagicEvents;
@@ -107,6 +108,7 @@ public class UniversalTweaks
     public void init(FMLInitializationEvent event)
     {
         if (UTConfig.TWEAKS_WORLD.utStrongholdToggle) MinecraftForge.TERRAIN_GEN_BUS.register(new UTStronghold());
+        if (Loader.isModLoaded("abyssalcraft") && UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) MinecraftForge.EVENT_BUS.register(new UTAbyssalCraftEvents());
         if (Loader.isModLoaded("arcanearchives") && UTConfig.MOD_INTEGRATION.ARCANE_ARCHIVES.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTArcaneArchivesEvents());
         if (Loader.isModLoaded("bloodmagic") && UTConfig.MOD_INTEGRATION.BLOOD_MAGIC.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTBloodMagicEvents());
         if (Loader.isModLoaded("mekanism") && UTConfig.MOD_INTEGRATION.MEKANISM.utDuplicationFixesToggle) UTMekanismFixes.fixBinRecipes();

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/UTAbyssalCraftEvents.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/UTAbyssalCraftEvents.java
@@ -1,0 +1,92 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft;
+
+import java.util.Map;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.world.ChunkDataEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import com.shinoow.abyssalcraft.api.transfer.caps.ItemTransferCapabilityProvider;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfig;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapability;
+import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapabilityProvider;
+
+// Courtesy of jchung01
+public class UTAbyssalCraftEvents
+{
+    private static final String CHECK_ID = UniversalTweaks.MODID + "AbyssalConfigurations";
+
+    @SubscribeEvent
+    public void attachCapabilityWorld(AttachCapabilitiesEvent<World> event)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+
+        event.addCapability(new ResourceLocation("universaltweaks", "WorldDataCapability"), new UTWorldDataCapabilityProvider());
+    }
+
+    // Save data from memory to nbt
+    @SubscribeEvent
+    public void onChunkSave(ChunkDataEvent.Save event)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+
+        Chunk chunk = event.getChunk();
+        Map<BlockPos, TileEntity> set = UTWorldDataCapability.getCap(event.getWorld()).getChunkMap(chunk);
+        // Save configured tile entity positions to nbt
+        if (set != null && !set.isEmpty())
+        {
+            NBTTagList tagList = new NBTTagList();
+            for (BlockPos pos : set.keySet())
+            {
+                TileEntity te = event.getWorld().getTileEntity(pos);
+                // Skip blocks that are no longer the expected tile entity (block was broken/replaced)
+                if (te != null && !te.hasCapability(ItemTransferCapabilityProvider.ITEM_TRANSFER_CAP, null)) continue;
+                NBTTagCompound tag = new NBTTagCompound();
+                tag.setInteger("x", pos.getX());
+                tag.setInteger("y", pos.getY());
+                tag.setInteger("z", pos.getZ());
+                tagList.appendTag(tag);
+            }
+            // Cleanup unloaded/invalid chunks from memory
+            if (!event.getChunk().isLoaded() || tagList.isEmpty())
+            {
+                UTWorldDataCapability.getCap(event.getWorld()).removeChunk(event.getChunk());
+                if (tagList.isEmpty()) return;
+            }
+
+            event.getData().setTag(CHECK_ID, tagList);
+        }
+    }
+
+    // Load data from nbt to memory
+    @SubscribeEvent
+    public void onChunkLoad(ChunkDataEvent.Load event)
+    {
+        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
+        if (event.getWorld().isRemote) return;
+
+        if (event.getData().hasKey(CHECK_ID))
+        {
+            World world = event.getWorld();
+            NBTTagList tagList = event.getData().getTagList(CHECK_ID, Constants.NBT.TAG_COMPOUND);
+            for (int i = 0; i < tagList.tagCount(); i++)
+            {
+                NBTTagCompound tag = tagList.getCompoundTagAt(i);
+                BlockPos pos = new BlockPos(tag.getInteger("x"), tag.getInteger("y"), tag.getInteger("z"));
+
+                // Add entry to memory (Tile entity is unknown if world is still loading)
+                TileEntity te = world.isBlockLoaded(pos) ? world.getTileEntity(pos) : null;
+                UTWorldDataCapability.getCap(world).addConfigured(event.getChunk(), pos, te);
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemTransferEventHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemTransferEventHandlerMixin.java
@@ -1,20 +1,10 @@
 package mod.acgaming.universaltweaks.mods.abyssalcraft.mixin;
 
-import java.util.Map;
-
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraftforge.common.util.Constants;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
-import net.minecraftforge.event.world.ChunkDataEvent;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.items.IItemHandler;
@@ -23,13 +13,10 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import com.shinoow.abyssalcraft.api.transfer.ItemTransferConfiguration;
 import com.shinoow.abyssalcraft.api.transfer.caps.IItemTransferCapability;
 import com.shinoow.abyssalcraft.api.transfer.caps.ItemTransferCapability;
-import com.shinoow.abyssalcraft.api.transfer.caps.ItemTransferCapabilityProvider;
 import com.shinoow.abyssalcraft.common.entity.EntitySpiritItem;
 import com.shinoow.abyssalcraft.common.handlers.ItemTransferEventHandler;
-import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfig;
 import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapability;
-import mod.acgaming.universaltweaks.mods.abyssalcraft.worlddata.UTWorldDataCapabilityProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -40,73 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = ItemTransferEventHandler.class, remap = false)
 public class UTItemTransferEventHandlerMixin
 {
-    private static final String CHECK_ID = UniversalTweaks.MODID + "AbyssalConfigurations";
-
-    @SubscribeEvent
-    public void attachCapabilityWorld(AttachCapabilitiesEvent<World> event)
-    {
-        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
-
-        event.addCapability(new ResourceLocation("universaltweaks", "WorldDataCapability"), new UTWorldDataCapabilityProvider());
-    }
-
-    // Save data from memory to nbt
-    @SubscribeEvent
-    public void utOnChunkSave(ChunkDataEvent.Save event)
-    {
-        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
-
-        Chunk chunk = event.getChunk();
-        Map<BlockPos, TileEntity> set = UTWorldDataCapability.getCap(event.getWorld()).getChunkMap(chunk);
-        // Save configured tile entity positions to nbt
-        if (set != null && !set.isEmpty())
-        {
-            NBTTagList tagList = new NBTTagList();
-            for (BlockPos pos : set.keySet())
-            {
-                TileEntity te = event.getWorld().getTileEntity(pos);
-                // Skip blocks that are no longer the expected tile entity (block was broken/replaced)
-                if (te != null && !te.hasCapability(ItemTransferCapabilityProvider.ITEM_TRANSFER_CAP, null)) continue;
-                NBTTagCompound tag = new NBTTagCompound();
-                tag.setInteger("x", pos.getX());
-                tag.setInteger("y", pos.getY());
-                tag.setInteger("z", pos.getZ());
-                tagList.appendTag(tag);
-            }
-            // Cleanup unloaded/invalid chunks from memory
-            if (!event.getChunk().isLoaded() || tagList.isEmpty())
-            {
-                UTWorldDataCapability.getCap(event.getWorld()).removeChunk(event.getChunk());
-                if (tagList.isEmpty()) return;
-            }
-
-            event.getData().setTag(CHECK_ID, tagList);
-        }
-    }
-
-    // Load data from nbt to memory
-    @SubscribeEvent
-    public void utOnChunkLoad(ChunkDataEvent.Load event)
-    {
-        if (!UTConfig.MOD_INTEGRATION.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
-        if (event.getWorld().isRemote) return;
-
-        if (event.getData().hasKey(CHECK_ID))
-        {
-            World world = event.getWorld();
-            NBTTagList tagList = event.getData().getTagList(CHECK_ID, Constants.NBT.TAG_COMPOUND);
-            for (int i = 0; i < tagList.tagCount(); i++)
-            {
-                NBTTagCompound tag = tagList.getCompoundTagAt(i);
-                BlockPos pos = new BlockPos(tag.getInteger("x"), tag.getInteger("y"), tag.getInteger("z"));
-
-                // Add entry to memory (Tile entity is unknown if world is still loading)
-                TileEntity te = world.isBlockLoaded(pos) ? world.getTileEntity(pos) : null;
-                UTWorldDataCapability.getCap(world).addConfigured(event.getChunk(), pos, te);
-            }
-        }
-    }
-
     // Overwrites onTick() to be more performant
     @Inject(method = "onTick", at = @At(value = "HEAD"), cancellable = true)
     private void utOnTick(TickEvent.WorldTickEvent event, CallbackInfo ci)


### PR DESCRIPTION
Turns out using `AttachCapabilitiesEvent` in a mixin caused the `<World>` generic to be stripped, causing the world data capability to be attached to ALL objects from this event (ItemStack, Entity, etc.). This caused the tweak to take up a lot more memory than necessary, especially as the game ran on (oops). 
![abyssalcaps](https://github.com/ACGaming/UniversalTweaks/assets/60687097/98e84269-96c1-4e6f-9d95-64920bb896e3)
Moved the AbyssalCraft events to its own class to be registered by UT.