### PR TITLE
Crafting Cache: check if recipe matches before returning

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/craftingcache/UTCraftingCache.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/craftingcache/UTCraftingCache.java
@@ -41,8 +41,16 @@ public class UTCraftingCache
         if (isValid(craftMatrix) && Loader.instance().hasReachedState(LoaderState.SERVER_STARTING))
         {
             UTOptionalContent<IRecipe> optionalContent = getOrCreateCachedRecipe(craftMatrix);
-            if (!optionalContent.hasContent()) optionalContent.setContent(findMatchingRecipeDefault(craftMatrix, worldIn));
-            return optionalContent.getContent();
+
+            if (optionalContent.hasContent())
+            {
+                IRecipe recipe = optionalContent.getContent();
+                if (recipe == null || recipe.matches(craftMatrix, worldIn)) return recipe;
+            }
+
+            IRecipe recipe = findMatchingRecipeDefault(craftMatrix, worldIn);
+            optionalContent.setContent(recipe);
+            return recipe;
         }
         return findMatchingRecipeDefault(craftMatrix, worldIn);
     }


### PR DESCRIPTION
Fairy Lights was broken with the crafting cache. It has a recipe which mutates its state when `matches` is called. It has a dynamic recipe where you can add whatever types of lights you want on the strand of fairy lights, and then the Recipe object converts those ingredients into a result with NBT describing the light pattern.

You can see the source here, it updates `this.result` based on the ingredients before returning true or false: https://github.com/pau101/Fairy-Lights/blob/10d00ca8d997cff16139050065f61feed0fbbe9b/src/main/java/me/paulf/fairylights/util/crafting/GenericRecipe.java#L166C24-L166C24

The fix is to simply call `recipe.matches` on the cached recipe before returning it. It kinda seems like it would be good to verify `matches` before returning the recipe anyway, like if another recipe had a dynamic `matches` value that could switch to false.

Fixes #289 

As a sidenote -- it also makes me wonder about the reverse: are there any recipes which might return `false` but later return `true`? With the crafting cache, those recipes would never be checked again because the `null` result would be cached. I guess we probably don't hit this in practice. It could be worth adding a separate `craftingCacheShouldCacheNulls` config that could be disabled if ever there was a mod that needed the functionality; I bet most of the gains from the crafting cache come from automation systems that are doing a lot of crafting and so the recipes will always have a known valid match.