### PR TITLE
Implement Tinker's tool damage customization tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ dependencies {
     compileOnly 'curse.maven:mrtjpcore-229002:2735197'
     compileOnly 'curse.maven:netherchest-268888:2655413'
     compileOnly 'curse.maven:netherrocks-226140:2628297'
+    compileOnly 'curse.maven:plustic-376903:4703532'
     compileOnly 'curse.maven:projectredbase-228702:2745545'
     compileOnly 'curse.maven:projectredworld-229049:2745551'
     compileOnly 'curse.maven:quark-243121:2924091'

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,17 @@ repositories {
         name = 'Mod Maven'
         url = 'https://modmaven.dev'
     }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
     mavenLocal() // Must be last for caching to work
 }
 
@@ -115,76 +126,76 @@ dependencies {
     embed 'com.udojava:EvalEx:2.7'
 
     // Mods
-    implementation rfg.deobf('cofh:CoFHCore:1.12.2-+:universal')
-    implementation rfg.deobf('com.teamacronymcoders.base:base:1.12.2-3.14.0')
-    implementation rfg.deobf('com.teamacronymcoders:ContentTweaker:1.12.2-4.10.0')
-    implementation rfg.deobf('CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684')
-    implementation rfg.deobf('curse.maven:abyssalcraft-53686:3425234')
-    implementation rfg.deobf('curse.maven:atomicstrykers-infernal-mobs-227875:3431758')
-    implementation rfg.deobf('curse.maven:baubles-227083:2518667')
-    implementation rfg.deobf('curse.maven:binnies-mods-223525:2916129')
-    implementation rfg.deobf('curse.maven:biomes-o-plenty-220318:2842510')
-    implementation rfg.deobf('curse.maven:blood-magic-224791:2822288')
-    implementation rfg.deobf('curse.maven:botania-225643:3330934')
-    implementation rfg.deobf('curse.maven:ceramics-250617:3158763')
-    implementation rfg.deobf('curse.maven:chameleon-230497:2450900')
-    implementation rfg.deobf('curse.maven:chickens-241941:2537643')
-    implementation rfg.deobf('curse.maven:collective-342584:3533131')
-    implementation rfg.deobf('curse.maven:cqrepoured-303422:3953103')
-    implementation rfg.deobf('curse.maven:elementary-staffs-346007:2995593')
-    implementation rfg.deobf('curse.maven:elenaidodge2-442962:3343308')
-    implementation rfg.deobf('curse.maven:epic-siege-mod-229449:3356157')
-    implementation rfg.deobf('curse.maven:fluxnetworks-248020:3178199')
-    implementation rfg.deobf('curse.maven:forestry-59751:2918418')
-    implementation rfg.deobf('curse.maven:modtweaker-220954:3840577')
-    implementation rfg.deobf('curse.maven:nuclearcraft-226254:3784145')
-    implementation rfg.deobf('curse.maven:reborn-core-237903:3330308')
-    implementation rfg.deobf('curse.maven:reskillable-286382:2815686')
-    implementation rfg.deobf('curse.maven:roost-277711:2702080')
-    implementation rfg.deobf('curse.maven:simpledifficulty-360779:3613814')
-    implementation rfg.deobf('curse.maven:storage-drawers-223852:2952606')
-    implementation rfg.deobf('curse.maven:tech-reborn-233564:2966851')
-    implementation rfg.deobf('curse.maven:thaumcraft-223628:2629023')
-    implementation rfg.deobf('curse.maven:the-erebus-220698:3211974')
-    implementation rfg.deobf('curse.maven:thermal-expansion-69163:2926431')
+    compileOnly rfg.deobf('cofh:CoFHCore:1.12.2-+:universal')
+    compileOnly rfg.deobf('com.teamacronymcoders.base:base:1.12.2-3.14.0')
+    compileOnly rfg.deobf('com.teamacronymcoders:ContentTweaker:1.12.2-4.10.0')
+    compileOnly rfg.deobf('CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684')
+    compileOnly rfg.deobf('curse.maven:abyssalcraft-53686:3425234')
+    compileOnly rfg.deobf('curse.maven:atomicstrykers-infernal-mobs-227875:3431758')
+    compileOnly rfg.deobf('curse.maven:baubles-227083:2518667')
+    compileOnly rfg.deobf('curse.maven:binnies-mods-223525:2916129')
+    compileOnly rfg.deobf('curse.maven:biomes-o-plenty-220318:2842510')
+    compileOnly rfg.deobf('curse.maven:blood-magic-224791:2822288')
+    compileOnly rfg.deobf('curse.maven:botania-225643:3330934')
+    compileOnly rfg.deobf('curse.maven:ceramics-250617:3158763')
+    compileOnly rfg.deobf('curse.maven:chameleon-230497:2450900')
+    compileOnly rfg.deobf('curse.maven:chickens-241941:2537643')
+    compileOnly rfg.deobf('curse.maven:collective-342584:3533131')
+    compileOnly rfg.deobf('curse.maven:cqrepoured-303422:3953103')
+    compileOnly rfg.deobf('curse.maven:elementary-staffs-346007:2995593')
+    compileOnly rfg.deobf('curse.maven:elenaidodge2-442962:3343308')
+    compileOnly rfg.deobf('curse.maven:epic-siege-mod-229449:3356157')
+    compileOnly rfg.deobf('curse.maven:fluxnetworks-248020:3178199')
+    compileOnly rfg.deobf('curse.maven:forestry-59751:2918418')
+    compileOnly rfg.deobf('curse.maven:modtweaker-220954:3840577')
+    compileOnly rfg.deobf('curse.maven:nuclearcraft-226254:3784145')
+    compileOnly rfg.deobf('curse.maven:reborn-core-237903:3330308')
+    compileOnly rfg.deobf('curse.maven:reskillable-286382:2815686')
+    compileOnly rfg.deobf('curse.maven:roost-277711:2702080')
+    compileOnly rfg.deobf('curse.maven:simpledifficulty-360779:3613814')
+    compileOnly rfg.deobf('curse.maven:storage-drawers-223852:2952606')
+    compileOnly rfg.deobf('curse.maven:tech-reborn-233564:2966851')
+    compileOnly rfg.deobf('curse.maven:thaumcraft-223628:2629023')
+    compileOnly rfg.deobf('curse.maven:the-erebus-220698:3211974')
+    compileOnly rfg.deobf('curse.maven:thermal-expansion-69163:2926431')
     implementation rfg.deobf('slimeknights.mantle:Mantle:1.12-1.3.3.56')
     implementation rfg.deobf('slimeknights:TConstruct:1.12.2-2.13.0.190')
-    implementation rfg.deobf('net.darkhax.bookshelf:Bookshelf-1.12.2:2.3.590')
-    implementation rfg.deobf('net.darkhax.gamestages:GameStages-1.12.2:2.0.120')
-    implementation rfg.deobf('net.darkhax.itemstages:ItemStages-1.12.2:2.0.51')
-    implementation rfg.deobf('net.darkhax.mobstages:MobStages-1.12.2:2.0.13')
-    implementation 'curse.maven:actuallyaditions-228404:2844115'
-    implementation 'curse.maven:applecore-224472:2969118'
-    implementation 'curse.maven:arcanearchives-311357:3057332'
-    implementation 'curse.maven:bewitchment-285439:3044569'
-    implementation 'curse.maven:chisel-235279:2915375'
-    implementation 'curse.maven:codechickenlib-242818:2779848'
-    implementation 'curse.maven:cofhworld-271384:2920434'
-    implementation 'curse.maven:endercore-231868:2972849'
-    implementation 'curse.maven:enderio-64578:2989201'
-    implementation 'curse.maven:extrautilities-225561:2678374'
-    implementation 'curse.maven:forgemultipartcbe-258426:2755790'
-    implementation 'curse.maven:guideapi-228832:2645992'
-    implementation 'curse.maven:industrialcraft-242638:3078604'
-    implementation 'curse.maven:industrialforegoing-266515:2745324'
-    implementation 'curse.maven:ironbackpacks-227049:2564573'
-    implementation 'curse.maven:mekanism-268560:2835175'
-    implementation 'curse.maven:mrtjpcore-229002:2735197'
-    implementation 'curse.maven:netherchest-268888:2655413'
-    implementation 'curse.maven:netherrocks-226140:2628297'
-    implementation 'curse.maven:projectredbase-228702:2745545'
-    implementation 'curse.maven:projectredworld-229049:2745551'
-    implementation 'curse.maven:quark-243121:2924091'
-    implementation 'curse.maven:simplyjetpacks2-251792:3294422'
-    implementation 'curse.maven:tardis-290247:2903453'
-    implementation 'curse.maven:teslacorelib-254602:2891841'
-    implementation 'curse.maven:thaumicwonders-316704:2787954'
-    implementation 'curse.maven:thefarlanders-336432:2805139'
-    implementation 'curse.maven:thermalfoundation-222880:2926428'
-    implementation 'curse.maven:thespiceoflife-220811:2571951'
-    implementation 'curse.maven:tinkerscomplement-272671:2843439'
-    implementation 'curse.maven:tinyprogressions-250850:2721018'
-    implementation 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
+    compileOnly rfg.deobf('net.darkhax.bookshelf:Bookshelf-1.12.2:2.3.590')
+    compileOnly rfg.deobf('net.darkhax.gamestages:GameStages-1.12.2:2.0.120')
+    compileOnly rfg.deobf('net.darkhax.itemstages:ItemStages-1.12.2:2.0.51')
+    compileOnly rfg.deobf('net.darkhax.mobstages:MobStages-1.12.2:2.0.13')
+    compileOnly 'curse.maven:actuallyaditions-228404:2844115'
+    compileOnly 'curse.maven:applecore-224472:2969118'
+    compileOnly 'curse.maven:arcanearchives-311357:3057332'
+    compileOnly 'curse.maven:bewitchment-285439:3044569'
+    compileOnly 'curse.maven:chisel-235279:2915375'
+    compileOnly 'curse.maven:codechickenlib-242818:2779848'
+    compileOnly 'curse.maven:cofhworld-271384:2920434'
+    compileOnly 'curse.maven:endercore-231868:2972849'
+    compileOnly 'curse.maven:enderio-64578:2989201'
+    compileOnly 'curse.maven:extrautilities-225561:2678374'
+    compileOnly 'curse.maven:forgemultipartcbe-258426:2755790'
+    compileOnly 'curse.maven:guideapi-228832:2645992'
+    compileOnly 'curse.maven:industrialcraft-242638:3078604'
+    compileOnly 'curse.maven:ironbackpacks-227049:2564573'
+    compileOnly 'curse.maven:mekanism-268560:2835175'
+    compileOnly 'curse.maven:mrtjpcore-229002:2735197'
+    compileOnly 'curse.maven:netherchest-268888:2655413'
+    compileOnly 'curse.maven:netherrocks-226140:2628297'
+    compileOnly 'curse.maven:projectredbase-228702:2745545'
+    compileOnly 'curse.maven:projectredworld-229049:2745551'
+    compileOnly 'curse.maven:quark-243121:2924091'
+    compileOnly 'curse.maven:simplyjetpacks2-251792:3294422'
+    compileOnly 'curse.maven:tardis-290247:2903453'
+    compileOnly 'curse.maven:teslacorelib-254602:2891841'
+    compileOnly 'curse.maven:thaumicwonders-316704:2787954'
+    compileOnly 'curse.maven:thefarlanders-336432:2805139'
+    compileOnly 'curse.maven:thermalfoundation-222880:2926428'
+    compileOnly 'curse.maven:thespiceoflife-220811:2571951'
+    compileOnly 'curse.maven:tinkerscomplement-272671:2843439'
+    compileOnly 'curse.maven:tinyprogressions-250850:2721018'
+    compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
+    compileOnly 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
 
     if (project.use_mixins.toBoolean()) {
         String mixin = modUtils.enableMixins("zone.rong:mixinbooter:8.9", "universaltweaks.refmap.json")

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -92,6 +92,7 @@ public class UniversalTweaks
         + "after:netherchest;"
         + "after:netherrocks;"
         + "after:nuclearcraft;"
+        + "after:plustic;"
         + "after:projectred-exploration;"
         + "after:quark;"
         + "after:roost;"

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/fallingblockdamage/mixin/UTFallingBlockDamageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/fallingblockdamage/mixin/UTFallingBlockDamageMixin.java
@@ -24,7 +24,7 @@ public abstract class UTFallingBlockDamageMixin extends Entity
         super(worldIn);
     }
 
-    @Redirect(method = "fall", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList(Ljava/lang/Iterable;)Ljava/util/ArrayList;"))
+    @Redirect(method = "fall", at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList(Ljava/lang/Iterable;)Ljava/util/ArrayList;", remap = false))
     public ArrayList<Entity> utFallingBlockDamage(Iterable<? extends Entity> elements)
     {
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTFallingBlockDamage ::: Block falling");

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -821,6 +821,14 @@ public class UTConfigMods
                 })
             public float utTConToolRapierDamageCutoff = 13.0f;
 
+            @Config.Name("PlusTiC: Katana Attack Damage Cutoff")
+            @Config.Comment
+                ({
+                    "Sets the attack damage cutoff at which diminishing returns start for the PlusTiC katana",
+                    "Default value: 22.0"
+                })
+            public float utTConToolKatanaDamageCutoff = 22.0f;
+
             @Config.Name("Attack Damage Decay Rate")
             @Config.Comment
                 ({

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -777,6 +777,61 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Tool Customization")
+        @Config.Comment("Enables usage of tweaks in below category to customize Tinkers' tools stats")
+        public boolean utTConToolCustomizationToggle = true;
+
+        @Config.LangKey("cfg.universaltweaks.modintegration.tcon.toolcustomization")
+        @Config.Name("Tool Customization")
+        public final TinkersConstructCategory.ToolCustomizationCategory TOOL_CUSTOMIZATION = new TinkersConstructCategory.ToolCustomizationCategory();
+
+        public static class ToolCustomizationCategory
+        {
+            @Config.Name("General Attack Damage Cutoff")
+            @Config.Comment
+                ({
+                    "Sets the attack damage cutoff at which diminishing returns start for any Tinkers' tool not listed here",
+                    "Default value: 15.0"
+                })
+            public float utTConToolGeneralDamageCutoff = 15.0f;
+
+            @Config.Name("Cleaver Attack Damage Cutoff")
+            @Config.Comment
+                ({
+                    "Sets the attack damage cutoff at which diminishing returns start for the cleaver",
+                    "Default value: 25.0"
+                })
+            public float utTConToolCleaverDamageCutoff = 25.0f;
+
+            @Config.Name("Longsword Attack Damage Cutoff")
+            @Config.Comment
+                ({
+                    "Sets the attack damage cutoff at which diminishing returns start for the longsword",
+                    "Default value: 18.0"
+                })
+            public float utTConToolLongswordDamageCutoff = 18.0f;
+
+            @Config.Name("Rapier Attack Damage Cutoff")
+            @Config.Comment
+                ({
+                    "Sets the attack damage cutoff at which diminishing returns start for the rapier",
+                    "Default value: 13.0"
+                })
+            public float utTConToolRapierDamageCutoff = 13.0f;
+
+            @Config.Name("Attack Damage Decay Rate")
+            @Config.Comment
+                ({
+                    "Sets the rate at which a tool's attack damage incrementally decays depending on its damage cutoff",
+                    "Default value: 0.9",
+                    "Range: 0.0 - 1.0",
+                    "Note: A rate of 1.0 means there is no damage decay",
+                    "Note: The damage curve will cap the maximum value to (tool's damage cutoff)/(1 - decay rate)"
+                })
+            public String utTConToolDamageDecayRate = "0.9";
+        }
     }
 
     public static class TinyProgressionsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -56,6 +56,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.spiceoflife.dupes.json",
             "mixins.mods.storagedrawers.client.json",
             "mixins.mods.tconstruct.json",
+            "mixins.mods.tconstruct.toolcustomization.json",
             "mixins.mods.tconstruct.oredictcache.json",
             "mixins.mods.techreborn.json",
             "mixins.mods.thaumcraft.dupes.json",
@@ -189,6 +190,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("thermalexpansion") && UTConfigMods.THERMAL_EXPANSION.utDuplicationFixesToggle;
             case "mixins.mods.tconstruct.json":
                 return Loader.isModLoaded("tconstruct");
+            case "mixins.mods.tconstruct.toolcustomization.json":
+                return Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle;
             case "mixins.mods.tconstruct.oredictcache.json":
                 return Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle;
             case "mixins.mods.tinyprogressions.dupes.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -57,6 +57,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.storagedrawers.client.json",
             "mixins.mods.tconstruct.json",
             "mixins.mods.tconstruct.toolcustomization.json",
+            "mixins.mods.tconstruct.toolcustomization.plustic.json",
             "mixins.mods.tconstruct.oredictcache.json",
             "mixins.mods.techreborn.json",
             "mixins.mods.thaumcraft.dupes.json",
@@ -192,6 +193,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("tconstruct");
             case "mixins.mods.tconstruct.toolcustomization.json":
                 return Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle;
+            case "mixins.mods.tconstruct.toolcustomization.plustic.json":
+                return Loader.isModLoaded("tconstruct") && Loader.isModLoaded("plustic") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle;
             case "mixins.mods.tconstruct.oredictcache.json":
                 return Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle;
             case "mixins.mods.tinyprogressions.dupes.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTItemConfiguratorMixin.java
@@ -17,22 +17,22 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // Courtesy of jchung01
-@Mixin(ItemConfigurator.class) // Remapping needed!
+@Mixin(value = ItemConfigurator.class) // Remapping needed!
 public class UTItemConfiguratorMixin
 {
     // Item is called "Spirit Tablet"
     /*
      * Mode reference:
      * mode == 0: Set Path
-     *      - No changes needed, only edits the configurator's nbt
+     *       - No changes needed, only edits the configurator's nbt
      * mode == 1: Apply Configuration
-     *       - Need to add TE to UTItemTransferListHolder.configuredTileEntities
+     *       - Need to add TE to UTWorldDataCapability.configuredTileEntities
      * mode == 2: Clear Configurations
-     *       - Need to remove TE from UTItemTransferListHolder.configuredTileEntities
+     *       - Need to remove TE from UTWorldDataCapability.configuredTileEntities
      */
 
     // mode == 1
-    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;addTransferConfiguration(Lcom/shinoow/abyssalcraft/api/transfer/ItemTransferConfiguration;)V"))
+    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;addTransferConfiguration(Lcom/shinoow/abyssalcraft/api/transfer/ItemTransferConfiguration;)V", remap = false))
     private void utAddConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir)
     {
         if (!UTConfigMods.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;
@@ -43,7 +43,7 @@ public class UTItemConfiguratorMixin
     }
 
     // mode == 2
-    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;clearConfigurations()V"))
+    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lcom/shinoow/abyssalcraft/api/transfer/caps/IItemTransferCapability;clearConfigurations()V", remap = false))
     private void utRemoveConfiguredTileEntity(EntityPlayer player, World w, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir)
     {
         if (!UTConfigMods.ABYSSALCRAFT.utOptimizedItemTransferToggle) return;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTTileSoulForgeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTTileSoulForgeMixin.java
@@ -57,7 +57,7 @@ public abstract class UTTileSoulForgeMixin extends TileInventory implements ITic
      * <p>
      * Remapping needed!
      */
-    @Redirect(method = "update", at = @At(value = "INVOKE", target = "LWayofTime/bloodmagic/api/impl/BloodMagicRecipeRegistrar;getTartaricForge(Ljava/util/List;)LWayofTime/bloodmagic/api/impl/recipe/RecipeTartaricForge;"), remap = true)
+    @Redirect(method = "update", at = @At(value = "INVOKE", target = "LWayofTime/bloodmagic/api/impl/BloodMagicRecipeRegistrar;getTartaricForge(Ljava/util/List;)LWayofTime/bloodmagic/api/impl/recipe/RecipeTartaricForge;", remap = false), remap = true)
     private RecipeTartaricForge utUseCachedRecipe(BloodMagicRecipeRegistrar registrar, List<ItemStack> input)
     {
         if (!UTConfigMods.BLOOD_MAGIC.utBMOptimizeSoulForgeToggle) return registrar.getTartaricForge(input);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/forestry/mixin/UTMultiFarmCocoaMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/forestry/mixin/UTMultiFarmCocoaMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(FarmLogicCocoa.class)
+@Mixin(value = FarmLogicCocoa.class, remap = false)
 public class UTMultiFarmCocoaMixin
 {
     @Mutable

--- a/src/main/java/mod/acgaming/universaltweaks/mods/simpledifficulty/mixin/UTRainCollectorCanteenMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/simpledifficulty/mixin/UTRainCollectorCanteenMixin.java
@@ -26,7 +26,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(BlockRainCollector.class)
+@Mixin(value = BlockRainCollector.class, remap = false)
 public abstract class UTRainCollectorCanteenMixin
 {
     @Shadow
@@ -36,7 +36,7 @@ public abstract class UTRainCollectorCanteenMixin
     @Shadow
     public abstract void setWaterLevel(World world, BlockPos pos, IBlockState state, int level);
 
-    @Inject(method = "onBlockActivated", at = @At(value = "RETURN", ordinal = 4), cancellable = true)
+    @Inject(method = "onBlockActivated", at = @At(value = "RETURN", ordinal = 4), cancellable = true, remap = true)
     public void utRainCollectorCanteen(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> cir)
     {
         if (!UTConfigMods.SIMPLE_DIFFICULTY.utRainCollectorCanteenToggle) return;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/MaterialAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/MaterialAccessor.java
@@ -4,7 +4,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import slimeknights.tconstruct.library.materials.Material;
 
-@Mixin(Material.class)
+@Mixin(value = Material.class, remap = false)
 public interface MaterialAccessor
 {
     @Accessor("hidden")

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTCleaverMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTCleaverMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import slimeknights.tconstruct.tools.melee.item.Cleaver;
 
+// Courtesy of jchung01
 @Mixin(value = Cleaver.class, remap = false)
 public class UTCleaverMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTCleaverMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTCleaverMixin.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import slimeknights.tconstruct.tools.melee.item.Cleaver;
+
+@Mixin(value = Cleaver.class, remap = false)
+public class UTCleaverMixin
+{
+    @Inject(method = "damageCutoff", at = @At(value = "RETURN"), cancellable = true)
+    private void utModifyDamageCutoff(CallbackInfoReturnable<Float> cir)
+    {
+        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolCleaverDamageCutoff);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTLongswordMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTLongswordMixin.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import slimeknights.tconstruct.tools.melee.item.LongSword;
+
+@Mixin(value = LongSword.class, remap = false)
+public class UTLongswordMixin
+{
+    @Inject(method = "damageCutoff", at = @At(value = "RETURN"), cancellable = true)
+    private void utModifyDamageCutoff(CallbackInfoReturnable<Float> cir)
+    {
+        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolLongswordDamageCutoff);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTLongswordMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTLongswordMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import slimeknights.tconstruct.tools.melee.item.LongSword;
 
+// Courtesy of jchung01
 @Mixin(value = LongSword.class, remap = false)
 public class UTLongswordMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTRapierMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTRapierMixin.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import slimeknights.tconstruct.tools.melee.item.Rapier;
+
+@Mixin(value = Rapier.class, remap = false)
+public class UTRapierMixin
+{
+    @Inject(method = "damageCutoff", at = @At(value = "RETURN"), cancellable = true)
+    private void utModifyDamageCutoff(CallbackInfoReturnable<Float> cir)
+    {
+        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolRapierDamageCutoff);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolCoreMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolCoreMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import slimeknights.tconstruct.library.tools.ToolCore;
 
+// Courtesy of jchung01
 @Mixin(value = ToolCore.class, remap = false)
 public class UTToolCoreMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolCoreMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolCoreMixin.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import slimeknights.tconstruct.library.tools.ToolCore;
+
+@Mixin(value = ToolCore.class, remap = false)
+public class UTToolCoreMixin
+{
+    @Inject(method = "damageCutoff", at = @At(value = "RETURN"), cancellable = true)
+    private void utModifyDamageCutoff(CallbackInfoReturnable<Float> cir)
+    {
+        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolGeneralDamageCutoff);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolHelperMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolHelperMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import slimeknights.tconstruct.library.utils.ToolHelper;
 
+// Courtesy of jchung01
 @Mixin(value = ToolHelper.class, remap = false)
 public class UTToolHelperMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolHelperMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/mixin/UTToolHelperMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import slimeknights.tconstruct.library.utils.ToolHelper;
+
+@Mixin(value = ToolHelper.class, remap = false)
+public class UTToolHelperMixin
+{
+    @ModifyConstant(method = "calcCutoffDamage", constant = @Constant(floatValue = 0.9f))
+    private static float utModifyDecayRate(float original)
+    {
+        try
+        {
+            float newDecayRate = Float.parseFloat(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolDamageDecayRate);
+            if (newDecayRate < 0.0f || newDecayRate > 1.0f)
+            {
+                if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.info("UTToolHelperMixin ::: Config's 'Attack Damage Decay Rate' is not in the valid range, must be a value from 0.0 to 1.0. Falling back to default value.");
+                return original;
+            }
+            return newDecayRate;
+        }
+        catch (NumberFormatException e)
+        {
+            UniversalTweaks.LOGGER.error("UTToolHelperMixin ::: Could not parse a float from config's 'Attack Damage Decay Rate', must be a value from 0.0 to 1.0. Falling back to default value.");
+            return original;
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/plustic/mixin/UTToolKatanaMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/toolcustomization/plustic/mixin/UTToolKatanaMixin.java
@@ -1,19 +1,19 @@
-package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin;
+package mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.plustic.mixin;
 
+import landmaster.plustic.tools.ToolKatana;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import slimeknights.tconstruct.tools.melee.item.Rapier;
 
 // Courtesy of jchung01
-@Mixin(value = Rapier.class, remap = false)
-public class UTRapierMixin
+@Mixin(value = ToolKatana.class, remap = false)
+public class UTToolKatanaMixin
 {
     @Inject(method = "damageCutoff", at = @At(value = "RETURN"), cancellable = true)
     private void utModifyDamageCutoff(CallbackInfoReturnable<Float> cir)
     {
-        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolRapierDamageCutoff);
+        cir.setReturnValue(UTConfigMods.TINKERS_CONSTRUCT.TOOL_CUSTOMIZATION.utTConToolKatanaDamageCutoff);
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/startup/mixin/UTFasterBackgroundStartupMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/startup/mixin/UTFasterBackgroundStartupMixin.java
@@ -24,7 +24,7 @@ public class UTFasterBackgroundStartupMixin
      * if the user is pressing a Keyboard button to show some info, but, as you are on alt-tab
      * this process can take a looong time (a modpack startup from 3 min can go up to 9 min)
      */
-    @WrapWithCondition(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onItemTooltip(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Ljava/util/List;Lnet/minecraft/client/util/ITooltipFlag;)Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;"))
+    @WrapWithCondition(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onItemTooltip(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Ljava/util/List;Lnet/minecraft/client/util/ITooltipFlag;)Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;", remap = false))
     public boolean utFasterBackgroundStartup(ItemStack itemStack, EntityPlayer entityPlayer, List<String> toolTip, ITooltipFlag flags)
     {
         return !UTConfigTweaks.PERFORMANCE.utFasterBackgroundStartupToggle || !FMLClientHandler.instance().isLoading();

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/world/sealevel/mixin/UTSeaLevelChunkGeneratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/world/sealevel/mixin/UTSeaLevelChunkGeneratorMixin.java
@@ -1,5 +1,7 @@
 package mod.acgaming.universaltweaks.tweaks.world.sealevel.mixin;
 
+import net.minecraft.world.gen.ChunkGeneratorSettings;
+
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -7,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.world.gen.ChunkGeneratorSettings$Factory")
+@Mixin(ChunkGeneratorSettings.Factory.class)
 public class UTSeaLevelChunkGeneratorMixin
 {
     @Shadow

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -72,6 +72,7 @@ cfg.universaltweaks.modintegration.tc.foci.focusmediums=Focus Mediums
 cfg.universaltweaks.modintegration.tc.foci=Thaumcraft: Foci
 cfg.universaltweaks.modintegration.tc=Thaumcraft
 cfg.universaltweaks.modintegration.tcon=Tinkers' Construct
+cfg.universaltweaks.modintegration.tcon.toolcustomization=Tool Customization
 cfg.universaltweaks.modintegration.te=Thermal Expansion
 cfg.universaltweaks.modintegration.thaumicwonders=Thaumic Wonders
 cfg.universaltweaks.modintegration.thefarlanders=The Farlanders

--- a/src/main/resources/mixins.mods.tconstruct.toolcustomization.json
+++ b/src/main/resources/mixins.mods.tconstruct.toolcustomization.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTCleaverMixin", "UTLongswordMixin", "UTRapierMixin", "UTToolCoreMixin", "UTToolHelperMixin"]
+}

--- a/src/main/resources/mixins.mods.tconstruct.toolcustomization.plustic.json
+++ b/src/main/resources/mixins.mods.tconstruct.toolcustomization.plustic.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.tconstruct.toolcustomization.plustic.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTToolKatanaMixin"]
+}


### PR DESCRIPTION
On request of @sainagh, this adds the ability to tweak the hardcoded damage cutoffs for various Tinker's (and addon's) weapons. This "damage cutoff" is the value at which you start getting diminishing returns on damage over this value. You can also tweak the decay rate of the damage falloff. See the `Tool Customization` category under the mod integration for Tinker's for details. Others can feel free to add onto this category if desired (GameStages compat, other stat tweaks, etc). 

If you would like a visualization of the damage curve, see [this graph](https://www.desmos.com/calculator/i0rxljs5ra). 

Also cleans up build.gradle a bit and remapping warnings when building. Fetching Industrial Foregoing wasn't behaving, so using Modrinth maven for that. Feel free to revert any changes in commit f689f2b if there's a loss in any functionality by changing remappings, but I believe it shouldn't break any tweaks.