### PR TITLE
Batch of Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ All changes are toggleable via config files.
 * **Mount Desync:** Fixes mounts and boats sometimes disappearing after dismounting
 * **Packet Size:** Increases the packet size limit to account for large packets in modded environments
 * **Piston Progress:** Properly saves the last state of pistons to tags
-* **Portal Duplication Fixes:** Fixes entity duplication issues on portals
+* **Portal Duplication Fix:** Fixes duplication issues that can occur when entities travel through portals
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms
 * **Skeleton Aim:** Fixes skeletons not looking at their targets when strafing
 * **Tile Entity Map:** Replaces the chunk position data table to prevent tile entity related issues
@@ -168,6 +168,7 @@ All changes are toggleable via config files.
 * **Skip Missing Registry Entries Screen:** Automatically confirms the 'Missing Registry Entries' screen on world load
 * **Sleeping Time:** Determines at which time of day sleeping is allowed in ticks (0 - 24000)
 * **Smooth Scrolling:** Adds smooth scrolling to every in-game list
+* **Soulbound Vexes:** Summoned vexes will also die when their summoner is killed
 * **Spawn Caps:** Sets maximum spawning limits for different entity types
 * **Super Hot Torch:** Enables one-time ignition of entities by hitting them with a torch
 * **Stronghold Replacement:** Replaces stronghold generation with a safer variant

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All changes are toggleable via config files.
 * **Mount Desync:** Fixes mounts and boats sometimes disappearing after dismounting
 * **Packet Size:** Increases the packet size limit to account for large packets in modded environments
 * **Piston Progress:** Properly saves the last state of pistons to tags
+* **Portal Duplication Fixes:** Fixes entity duplication issues on portals
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms
 * **Skeleton Aim:** Fixes skeletons not looking at their targets when strafing
 * **Tile Entity Map:** Replaces the chunk position data table to prevent tile entity related issues

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All changes are toggleable via config files.
 * **Entity Bounding Boxes:** Saves entity bounding boxes to tags to prevent breakouts and suffocation
 * **Entity Desync:** Fixes entity motion desyncs most notable with arrows and thrown items
 * **Entity ID:** Fixes non-functional elytra firework boosting and guardian targeting if the entity ID is 0
+* **Entity Lists:** Fixes entity lists often not getting updated correctly 
 * **Entity NaN:** Prevents corruption of entities caused by invalid health or damage values
 * **Entity Suffocation:** Pushes entities out of blocks when growing up to prevent suffocation
 * **Entity Tracker:** Fixes entity tracker to prevent client-sided desyncs when teleporting or changing dimensions

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/entitylists/mixins/UTEntityTilePistonMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/entitylists/mixins/UTEntityTilePistonMixin.java
@@ -1,0 +1,38 @@
+package mod.acgaming.universaltweaks.bugfixes.entities.entitylists.mixin;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityPiston;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.AxisAlignedBB;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Surrogate;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+// MC-108469
+// https://bugs.mojang.com/browse/MC-108469
+// Courtesy of mrgrim
+@Mixin(TileEntityPiston.class)
+public abstract class UTEntityTilePistonMixin extends TileEntity
+{
+    @Inject(method = "moveCollidedEntities", at = @At(value = "INVOKE", target = "Ljava/lang/ThreadLocal;set(Ljava/lang/Object;)V", ordinal = 1, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void utUpdateEntity(float p_184322_1_, CallbackInfo ci, EnumFacing enumfacing, double d0, List list, AxisAlignedBB axisalignedbb, List list1, boolean flag, int i, Entity entity, double d1)
+    {
+        if (UTConfigBugfixes.ENTITIES.utEntityListsToggle) world.updateEntityWithOptionalForce(entity, false);
+    }
+
+    @Surrogate
+    public void utUpdateEntity(float p_184322_1_, CallbackInfo ci, EnumFacing enumfacing, double d0, List list, AxisAlignedBB axisalignedbb, List list1, boolean flag, int i, Entity entity, double d1, int quark0)
+    {
+        if (UTConfigBugfixes.ENTITIES.utEntityListsToggle) world.updateEntityWithOptionalForce(entity, false);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/entitylists/mixins/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/entitylists/mixins/UTWorldMixin.java
@@ -1,0 +1,37 @@
+package mod.acgaming.universaltweaks.bugfixes.entities.entitylists.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.AxisAlignedBB;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+// MC-108469
+// https://bugs.mojang.com/browse/MC-108469
+// Courtesy of mrgrim
+@Mixin(World.class)
+public abstract class UTWorldMixin
+{
+    @Redirect(method = "updateEntityWithOptionalForce",
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getChunk(II)Lnet/minecraft/world/chunk/Chunk;", ordinal = 0),
+                    to = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getChunk(II)Lnet/minecraft/world/chunk/Chunk;", ordinal = 1)),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;setPositionNonDirty()Z", ordinal = 0))
+    public boolean utAlwaysLoadChunk(Entity entityIn)
+    {
+        if (UTConfigBugfixes.ENTITIES.utEntityListsToggle)
+        {
+            return true;
+        } else
+        {
+            // Returns false
+            return entityIn.setPositionNonDirty();
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portalduplicationfixes/UTPortalDuplicationFix.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portalduplicationfixes/UTPortalDuplicationFix.java
@@ -15,12 +15,12 @@ import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 
 // Courtesy of fonnymunkey
 @Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
-public class UTPortalDuplicationFixes
+public class UTPortalDuplicationFix
 {
     @SubscribeEvent
     public static void dimensionChangeEvent(EntityTravelToDimensionEvent event)
     {
-        if (event.getEntity().world.isRemote || !(UTConfigBugfixes.WORLD.utPortalDuplicationFixesToggle)) return;
+        if (event.getEntity().world.isRemote || !(UTConfigBugfixes.WORLD.utPortalDuplicationFixToggle)) return;
         if (event.getEntity() instanceof EntityLiving && !(event.getEntity() instanceof EntityPlayer))
         {
             EntityLiving entity = (EntityLiving) event.getEntity();

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portalduplicationfixes/UTPortalDuplicationFixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portalduplicationfixes/UTPortalDuplicationFixes.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.bugfixes.world.portalduplicationfixes;
+
+import org.apache.logging.log4j.Level;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of fonnymunkey
+@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
+public class UTPortalDuplicationFixes
+{
+    @SubscribeEvent
+    public static void dimensionChangeEvent(EntityTravelToDimensionEvent event)
+    {
+        if (event.getEntity().world.isRemote || !(UTConfigBugfixes.WORLD.utPortalDuplicationFixesToggle)) return;
+        if (event.getEntity() instanceof EntityLiving && !(event.getEntity() instanceof EntityPlayer))
+        {
+            EntityLiving entity = (EntityLiving) event.getEntity();
+
+            if (entity.isDead || !entity.isEntityAlive() || entity.getHealth() <= 0)
+            {
+                event.setCanceled(true);
+                if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.log(Level.WARN, "Possible attempted dupe at X: " + entity.posX + " Y: " + entity.posY + " Z: " + entity.posZ + " Entity Name: " + entity.getName());
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -346,6 +346,11 @@ public class UTConfigBugfixes
         public boolean utFrustumCullingToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Portal Duplication Fixes")
+        @Config.Comment("Fixes entity duplication issues on portals")
+        public boolean utPortalDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Tile Entity Map")
         @Config.Comment
             ({

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -346,8 +346,8 @@ public class UTConfigBugfixes
         public boolean utFrustumCullingToggle = true;
 
         @Config.RequiresMcRestart
-        @Config.Name("Portal Duplication Fixes")
-        @Config.Comment("Fixes entity duplication issues on portals")
+        @Config.Name("Portal Duplication Fix")
+        @Config.Comment("Fixes duplication issues that can occur when entities travel through portals")
         public boolean utPortalDuplicationFixesToggle = true;
 
         @Config.RequiresMcRestart

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -187,6 +187,11 @@ public class UTConfigBugfixes
         @Config.Comment("Fixes non-functional elytra firework boosting and guardian targeting if the entity ID is 0")
         public boolean utEntityIDToggle = true;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Entity Lists")
+        @Config.Comment("Fixes entity lists often not getting updated correctly")
+        public boolean utEntityListsToggle = true;
+
         @Config.Name("Entity NaN Values")
         @Config.Comment("Prevents corruption of entities caused by invalid health or damage values")
         public boolean utEntityNaNToggle = true;
@@ -348,7 +353,7 @@ public class UTConfigBugfixes
         @Config.RequiresMcRestart
         @Config.Name("Portal Duplication Fix")
         @Config.Comment("Fixes duplication issues that can occur when entities travel through portals")
-        public boolean utPortalDuplicationFixesToggle = true;
+        public boolean utPortalDuplicationFixToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Tile Entity Map")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -393,6 +393,11 @@ public class UTConfigTweaks
         @Config.RangeDouble(min = 0.0D, max = 1.0D)
         public double utRabbitToastChance = 0.0D;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Soulbound Vexes")
+        @Config.Comment("Summoned vexes will also die when their summoner is killed")
+        public boolean utSoulboundVexesToggle = true;
+
         public static class AttributesCategory
         {
             @Config.RequiresMcRestart

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -165,6 +165,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.entities.dimensionchange.json");
         configs.add("mixins.bugfixes.entities.disconnectdupe.json");
         configs.add("mixins.bugfixes.entities.entityid.json");
+        configs.add("mixins.bugfixes.entities.entitylists.json");
         configs.add("mixins.bugfixes.entities.horsefalling.json");
         configs.add("mixins.bugfixes.entities.maxhealth.json");
         configs.add("mixins.bugfixes.entities.mount.json");
@@ -345,6 +346,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.ENTITIES.utDisconnectDupeToggle;
             case "mixins.bugfixes.entities.entityid.json":
                 return UTConfigBugfixes.ENTITIES.utEntityIDToggle;
+            case "mixins.bugfixes.entities.entitylists.json":
+                return UTConfigBugfixes.ENTITIES.utEntityListsToggle;
             case "mixins.bugfixes.entities.horsefalling.json":
                 return UTConfigBugfixes.ENTITIES.utHorseFallingToggle;
             case "mixins.bugfixes.entities.maxhealth.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/soulboundvexes/UTSoulboundVexes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/soulboundvexes/UTSoulboundVexes.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.tweaks.entities.soulboundvexes;
+
+import org.apache.logging.log4j.Level;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.monster.EntityVex;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
+public class UTSoulboundVexes
+{
+    @SubscribeEvent
+    public static void soulboundVexesEvent(LivingUpdateEvent event)
+	{
+    	if (!(UTConfigTweaks.ENTITIES.utSoulboundVexesToggle)) return;
+    	
+        if (event.getEntity() instanceof EntityVex)
+		{
+            Entity summoner = ((EntityVex) event.getEntity()).getOwner();
+
+            if (summoner != null && summoner.isDead && !(event.getEntity().isDead))
+			{
+                event.getEntity().attackEntityFrom(DamageSource.GENERIC.setDamageIsAbsolute().setDamageBypassesArmor(), event.getEntityLiving().getMaxHealth());
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -93,7 +93,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("parry") && UTConfigTweaks.ITEMS.PARRY.utParryToggle) messages.add("Shield Parry");
         if (Loader.isModLoaded("pathundergates") && UTConfigTweaks.BLOCKS.utLenientPathsToggle) messages.add("Path Under Gates");
         if (Loader.isModLoaded("pickupnotifier") && UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) messages.add("Pick Up Notifier");
-        if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalDuplicationFixesToggle) messages.add("PortalDupeBegone");
+        if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalDuplicationFixToggle) messages.add("PortalDupeBegone");
         if (Loader.isModLoaded("preventghost") && UTConfigBugfixes.BLOCKS.utMiningGlitchToggle) messages.add("Prevent Ghost Blocks");
         if (Loader.isModLoaded("quickleafdecay") && UTConfigTweaks.BLOCKS.utLeafDecayToggle) messages.add("Quick Leaf Decay");
         if (Loader.isModLoaded("rallyhealth") && UTConfigTweaks.ENTITIES.RALLY_HEALTH.utRallyHealthToggle) messages.add("Rally Health");

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -93,6 +93,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("parry") && UTConfigTweaks.ITEMS.PARRY.utParryToggle) messages.add("Shield Parry");
         if (Loader.isModLoaded("pathundergates") && UTConfigTweaks.BLOCKS.utLenientPathsToggle) messages.add("Path Under Gates");
         if (Loader.isModLoaded("pickupnotifier") && UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) messages.add("Pick Up Notifier");
+        if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalDuplicationFixesToggle) messages.add("PortalDupeBegone");
         if (Loader.isModLoaded("preventghost") && UTConfigBugfixes.BLOCKS.utMiningGlitchToggle) messages.add("Prevent Ghost Blocks");
         if (Loader.isModLoaded("quickleafdecay") && UTConfigTweaks.BLOCKS.utLeafDecayToggle) messages.add("Quick Leaf Decay");
         if (Loader.isModLoaded("rallyhealth") && UTConfigTweaks.ENTITIES.RALLY_HEALTH.utRallyHealthToggle) messages.add("Rally Health");

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -88,6 +88,7 @@ cfg.universaltweaks.tweaks.blocks.overhaulbeacon=Overhaul Beacon
 cfg.universaltweaks.tweaks.blocks.sapling=Sapling Behavior
 cfg.universaltweaks.tweaks.entities.attributes=Attributes
 cfg.universaltweaks.tweaks.entities.betterburning=Better Burning
+cfg.universaltweaks.tweaks.entities.chickenshedding=Chicken Shedding
 cfg.universaltweaks.tweaks.entities.collisiondamage=Collision Damage
 cfg.universaltweaks.tweaks.entities.creeperconfetti=Creeper Confetti
 cfg.universaltweaks.tweaks.entities.damagevelocity=Damage Velocity

--- a/src/main/resources/mixins.bugfixes.entities.entitylists.json
+++ b/src/main/resources/mixins.bugfixes.entities.entitylists.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.entities.entitylists.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEntityTilePistonMixin", "UTWorldMixin"]
+}


### PR DESCRIPTION
- Fix dupe issues when entities enter a portal while taking damage at the same time (Supersedes PortalDupeBegone).
- Fix for [MC-108469](https://bugs.mojang.com/browse/MC-108469) (from [MUP](https://github.com/mrgrim/MUP)).
- Tweak that makes summoned vexes die off when their summoning entity is killed.