### PR TITLE
3rd Batch of Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ All changes are toggleable via config files.
 * **Soulbound Vexes:** Summoned vexes will also die when their summoner is killed
 * **Spawn Caps:** Sets maximum spawning limits for different entity types
 * **Super Hot Torch:** Enables one-time ignition of entities by hitting them with a torch
+* **Suppress Ore Dictionary Errors:** Suppresses Forge's broken ore dictionary errors
 * **Stronghold Replacement:** Replaces stronghold generation with a safer variant
 * **Swing Through Grass:** Allows hitting entities through grass instead of breaking it
 * **Tidy Chunk:** Tidies newly generated chunks by removing scattered item entities

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ All changes are toggleable via config files.
 * **No Leftover Breath Bottles:** Disables dragon's breath from leaving off empty bottles when a stack is brewed with
 * **No Night Vision Flash:** Disables the flashing effect when the night vision potion effect is about to run out
 * **No Potion Shift:** Disables the inventory shift when potion effects are active
+* **No Portal Spawning:** Prevents zombie pigmen spawning from nether portals
 * **No Redstone Lighting:** Disables lighting of active redstone, repeaters, and comparators to improve performance
 * **No Saddled Wandering:** Stops horses wandering around when saddled
 * **No Smelting XP:** Disables the experience reward when smelting items in furnaces

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All changes are toggleable via config files.
 * **Packet Size:** Increases the packet size limit to account for large packets in modded environments
 * **Particle Spawning:** Fixes various particle types not showing up on the client
 * **Piston Progress:** Properly saves the last state of pistons to tags
-* **Portal Duplication Fix:** Fixes duplication issues that can occur when entities travel through portals
+* **Portal Traveling Dupe:** Fixes duplication issues that can occur when entities travel through portals
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms
 * **Skeleton Aim:** Fixes skeletons not looking at their targets when strafing
 * **Sleep Resets Weather:** Fixes sleeping always resetting rain and thunder times
@@ -130,6 +130,7 @@ All changes are toggleable via config files.
 * **Hardcore Buckets:** Prevents placing of liquid source blocks in the world
 * **Horizontal Collision Damage:** Applies horizontal collision damage to the player akin to elytra collision
 * **Husk & Stray Spawning:** Lets husks and strays spawn underground like regular zombies and skeletons
+* **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings
 * **Incurable Potions:** Excludes potion effects from being curable with curative items like buckets of milk
 * **Infinite Music:** Lets background music play continuously without delays
 * **Item Entities:** Enables the modification of item entity properties

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portal/UTPortalTravelingDupe.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/portal/UTPortalTravelingDupe.java
@@ -13,12 +13,12 @@ import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 
 // Courtesy of fonnymunkey
 @Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
-public class UTPortalDuplicationFix
+public class UTPortalTravelingDupe
 {
     @SubscribeEvent
     public static void dimensionChangeEvent(EntityTravelToDimensionEvent event)
     {
-        if (event.getEntity().world.isRemote || !UTConfigBugfixes.WORLD.utPortalDuplicationFixToggle) return;
+        if (event.getEntity().world.isRemote || !UTConfigBugfixes.WORLD.utPortalTravelingDupeToggle) return;
         if (event.getEntity() instanceof EntityLiving && !(event.getEntity() instanceof EntityPlayer))
         {
             EntityLiving entity = (EntityLiving) event.getEntity();

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -367,9 +367,9 @@ public class UTConfigBugfixes
         public boolean utFrustumCullingToggle = true;
 
         @Config.RequiresMcRestart
-        @Config.Name("Portal Duplication Fix")
+        @Config.Name("Portal Traveling Dupe")
         @Config.Comment("Fixes duplication issues that can occur when entities travel through portals")
-        public boolean utPortalDuplicationFixToggle = true;
+        public boolean utPortalTravelingDupeToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Tile Entity Map")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1206,6 +1206,11 @@ public class UTConfigTweaks
         @Config.Comment("Disables the experience reward when smelting items in furnaces")
         public boolean utSmeltingXPToggle = false;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Improved Entity Tracker Warning")
+        @Config.Comment("Provides more information to addPacket removed entity warnings")
+        public boolean utImprovedEntityTrackerToggle = true;
+
         @Config.Name("Offhand Improvement")
         @Config.Comment("Prevents placing offhand blocks when blocks or food are held in the mainhand")
         public boolean utOffhandToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -452,6 +452,11 @@ public class UTConfigTweaks
         public boolean utMobDespawnToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("No Portal Spawning")
+        @Config.Comment("Prevents zombie pigmen spawning from nether portals")
+        public boolean utPortalSpawningToggle = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("No Saddled Wandering")
         @Config.Comment("Stops horses wandering around when saddled")
         public boolean utSaddledWanderingToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1019,6 +1019,10 @@ public class UTConfigTweaks
             @Config.Name("[16] Clear Despawn: Urgent Flashing")
             @Config.Comment("Makes item entities flash faster as they get closer to despawning")
             public boolean utIEClearDespawnUrgentToggle = true;
+
+            @Config.Name("[17] Slowed Movement")
+            @Config.Comment("Slows how often item entities update their position to improve performance")
+            public boolean utIEUpdateToggle  = true;
         }
 
         public static class MendingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1609,6 +1609,11 @@ public class UTConfigTweaks
         public boolean utRedstoneLightingToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Suppress Ore Dictionary Errors")
+        @Config.Comment("Suppresses Forge's broken ore dictionary errors")
+        public boolean utOreDictionaryCheckToggle = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Uncap FPS")
         @Config.Comment("Removes the hardcoded 30 FPS limit in screens like the main menu")
         public boolean utUncapFPSToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -227,6 +227,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.performance.autosave.json");
         configs.add("mixins.tweaks.performance.craftingcache.json");
         configs.add("mixins.tweaks.performance.dyeblending.json");
+        configs.add("mixins.tweaks.performance.oredictionarycheck.json");
         configs.add("mixins.tweaks.performance.prefixcheck.json");
         configs.add("mixins.tweaks.performance.redstone.json");
         configs.add("mixins.tweaks.world.chunks.gen.json");
@@ -470,6 +471,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.PERFORMANCE.utCraftingCacheToggle;
             case "mixins.tweaks.performance.dyeblending.json":
                 return UTConfigTweaks.PERFORMANCE.utDyeBlendingToggle;
+            case "mixins.tweaks.performance.oredictionarycheck.json":
+                return UTConfigTweaks.PERFORMANCE.utOreDictionaryCheckToggle;
             case "mixins.tweaks.performance.prefixcheck.json":
                 return UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle;
             case "mixins.tweaks.performance.redstone.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -203,6 +203,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.entities.spawning.creeper.confetti.json");
         configs.add("mixins.tweaks.entities.spawning.golem.json");
         configs.add("mixins.tweaks.entities.spawning.husk.json");
+        configs.add("mixins.tweaks.entities.spawning.portal.json");
         configs.add("mixins.tweaks.entities.spawning.stray.json");
         configs.add("mixins.tweaks.entities.speed.boat.json");
         configs.add("mixins.tweaks.entities.speed.player.json");
@@ -425,6 +426,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             case "mixins.tweaks.entities.spawning.husk.json":
             case "mixins.tweaks.entities.spawning.stray.json":
                 return UTConfigTweaks.ENTITIES.utHuskStraySpawningToggle;
+            case "mixins.tweaks.entities.spawning.portal.json":
+                return UTConfigTweaks.ENTITIES.utPortalSpawningToggle;
             case "mixins.tweaks.entities.speed.boat.json":
                 return UTConfigTweaks.ENTITIES.utBoatSpeed != 0.04D;
             case "mixins.tweaks.entities.speed.player.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -218,6 +218,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.items.xpbottle.json");
         configs.add("mixins.tweaks.misc.armorcurve.json");
         configs.add("mixins.tweaks.misc.bannerlayers.json");
+        configs.add("mixins.tweaks.misc.console.addpacket.json");
         configs.add("mixins.tweaks.misc.incurablepotions.json");
         configs.add("mixins.tweaks.misc.lightning.damage.json");
         configs.add("mixins.tweaks.misc.lightning.fire.json");
@@ -454,6 +455,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.MISC.utBannerLayers != 6;
             case "mixins.tweaks.misc.buttons.snooper.server.json":
                 return UTConfigTweaks.MISC.utSnooperToggle;
+            case "mixins.tweaks.misc.console.addpacket.json":
+                return UTConfigTweaks.MISC.utImprovedEntityTrackerToggle;
             case "mixins.tweaks.misc.lightning.damage.json":
                 return UTConfigTweaks.MISC.LIGHTNING.utLightningDamage != 5.0D || UTConfigTweaks.MISC.LIGHTNING.utLightningFireTicks != 8;
             case "mixins.tweaks.misc.lightning.fire.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/portal/mixin/UTPortalMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/portal/mixin/UTPortalMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.entities.spawning.portal.mixin;
+
+import java.util.Random;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.block.BlockPortal;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of fonnymunkey
+@Mixin(BlockPortal.class)
+public abstract class UTPortalMixin
+{
+    @Inject(
+            method = "updateTick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockBreakable;updateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;Ljava/util/Random;)V", shift = At.Shift.AFTER),
+            cancellable = true
+    )
+    public void utPortalUpdateTick(World worldIn, BlockPos pos, IBlockState state, Random rand, CallbackInfo ci)
+    {
+    	if (UTConfigTweaks.ENTITIES.utPortalSpawningToggle) ci.cancel();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -155,5 +156,13 @@ public abstract class UTEntityItemMixin extends Entity
             final ItemStack stack = this.getItem();
             if (stack.getCount() >= stack.getMaxStackSize()) cir.setReturnValue(false);
         }
+    }
+
+    // Courtesy of fonnymunkey
+    @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityItem;move(Lnet/minecraft/entity/MoverType;DDD)V"))
+    public boolean utIEOnUpdate(EntityItem instance, MoverType moverType, double dx, double dy, double dz)
+    {
+        // Run on odd ticks to not skip the '% 25' check
+        return UTConfigTweaks.ITEMS.ITEM_ENTITIES.utIEUpdateToggle && instance.ticksExisted % 2 != 0;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
@@ -1,6 +1,7 @@
 package mod.acgaming.universaltweaks.tweaks.items.itementities.mixin;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.MoverType;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/console/addpacket/UTEntityTrackerEntryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/console/addpacket/UTEntityTrackerEntryMixin.java
@@ -1,0 +1,26 @@
+package mod.acgaming.universaltweaks.tweaks.misc.console.addpacket.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityTrackerEntry;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityTrackerEntry.class)
+public abstract class UTEntityTrackerEntryMixin
+{
+    @Shadow @Final private Entity trackedEntity;
+
+    @Redirect(method = "createSpawnPacket", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;)V", remap = false))
+    public boolean utCreateSpawnPacket(Logger instance, String s)
+    {
+        return UTConfigTweaks.MISC.utImprovedEntityTrackerToggle && instance.warn(s + ", name: " + this.trackedEntity.getName() + " pos: {x:" + this.trackedEntity.posX + ",y:" + this.trackedEntity.posY + ",z:" + this.trackedEntity.posZ + "}");
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/console/addpacket/UTEntityTrackerEntryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/console/addpacket/UTEntityTrackerEntryMixin.java
@@ -13,14 +13,15 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+// Courtesy of fonnymunkey
 @Mixin(EntityTrackerEntry.class)
 public abstract class UTEntityTrackerEntryMixin
 {
     @Shadow @Final private Entity trackedEntity;
 
     @Redirect(method = "createSpawnPacket", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;)V", remap = false))
-    public boolean utCreateSpawnPacket(Logger instance, String s)
+    public void utCreateSpawnPacket(Logger instance, String s)
     {
-        return UTConfigTweaks.MISC.utImprovedEntityTrackerToggle && instance.warn(s + ", name: " + this.trackedEntity.getName() + " pos: {x:" + this.trackedEntity.posX + ",y:" + this.trackedEntity.posY + ",z:" + this.trackedEntity.posZ + "}");
+    	instance.warn(s + ", name: " + this.trackedEntity.getName() + " pos: {x:" + this.trackedEntity.posX + ",y:" + this.trackedEntity.posY + ",z:" + this.trackedEntity.posZ + "}");
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/oredictionarycheck/mixin/UTOreDictionaryCheckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/oredictionarycheck/mixin/UTOreDictionaryCheckMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.oredictionarycheck.mixin;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraftforge.oredict.OreDictionary;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+
+@Mixin(OreDictionary.class)
+public class UTOreDictionaryCheckMixin
+{
+    @WrapWithCondition(
+            method = "registerOreImpl",
+            at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/FMLLog;bigWarning(Ljava/lang/String;[Ljava/lang/Object;)V"),
+            remap = false
+    )
+    private static boolean utCheckOreDictionary(String i, Object[] format)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utOreDictionaryCheckToggle;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/oredictionarycheck/mixin/UTOreDictionaryCheckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/oredictionarycheck/mixin/UTOreDictionaryCheckMixin.java
@@ -9,8 +9,9 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 
+// Courtesy of fonnymunkey
 @Mixin(OreDictionary.class)
-public class UTOreDictionaryCheckMixin
+public abstract class UTOreDictionaryCheckMixin
 {
     @WrapWithCondition(
             method = "registerOreImpl",

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -35,6 +35,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("blockoverlayfix") && UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle) messages.add("Block Overlay Fix");
         if (Loader.isModLoaded("bottomsugarcanharvest") && UTConfigTweaks.BLOCKS.utSugarCaneSize != 3) messages.add("Bottom Sugar Cane Harvest");
         if (Loader.isModLoaded("bowinfinityfix") && UTConfigTweaks.ITEMS.utBowInfinityToggle) messages.add("Bow Infinity Fix");
+        if (Loader.isModLoaded("breedablekillerrabbit") && UTConfigTweaks.ENTITIES.utRabbitKillerChance > 0.0D) messages.add("Breedable Killer Rabbit");
         if (Loader.isModLoaded("burnbabyburn") && UTConfigTweaks.ENTITIES.utBurningBabyZombiesToggle) messages.add("BurnBabyBurn");
         if (Loader.isModLoaded("chickensshed") && UTConfigTweaks.ENTITIES.CHICKEN_SHEDDING.utChickenSheddingToggle) messages.add("ChickensShed");
         if (Loader.isModLoaded("cie") && UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle) messages.add("Configurable Item Entities (CIE)");
@@ -42,6 +43,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("cleardespawn") && UTConfigTweaks.ITEMS.ITEM_ENTITIES.utIEClearDespawnToggle) messages.add("Clear Despawn");
         if (Loader.isModLoaded("collisiondamage") && UTConfigTweaks.ENTITIES.COLLISION_DAMAGE.utCollisionDamageToggle) messages.add("Collision Damage");
         if (Loader.isModLoaded("configurablecane") && UTConfigTweaks.BLOCKS.utSugarCaneSize != 3) messages.add("Configurable Cane");
+        if (Loader.isModLoaded("configurabledespawntimer") && UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle) messages.add("Configurable Despawn Timer");
         if (Loader.isModLoaded("continousmusic") && UTConfigTweaks.MISC.utInfiniteMusicToggle) messages.add("Infinite Music");
         if (Loader.isModLoaded("creeperconfetti") && UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiChance > 0) messages.add("Creeper Confetti");
         if (Loader.isModLoaded("damagetilt") && UTConfigTweaks.MISC.utDamageTiltToggle) messages.add("Damage Tilt");
@@ -67,6 +69,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("givemebackmyhp") && UTConfigBugfixes.ENTITIES.utMaxHealthToggle) messages.add("Give Me Back My HP");
         if (Loader.isModLoaded("gottagofast") && UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle) messages.add("Gotta Go Fast");
         if (Loader.isModLoaded("helpfixer") && UTConfigBugfixes.MISC.utHelpToggle) messages.add("HelpFixer");
+        if (Loader.isModLoaded("hiddenrecipebook") && UTConfigTweaks.MISC.utRecipeBookToggle) messages.add("Hidden Recipe Book");
         if (Loader.isModLoaded("horsefallfix") && UTConfigBugfixes.ENTITIES.utHorseFallingToggle) messages.add("HorseFallFix");
         if (Loader.isModLoaded("horsestandstill") && UTConfigTweaks.ENTITIES.utSaddledWanderingToggle) messages.add("Stupid Horse Stand Still");
         if (Loader.isModLoaded("ikwid") && UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle) messages.add("I Know What I'm Doing");
@@ -93,7 +96,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("parry") && UTConfigTweaks.ITEMS.PARRY.utParryToggle) messages.add("Shield Parry");
         if (Loader.isModLoaded("pathundergates") && UTConfigTweaks.BLOCKS.utLenientPathsToggle) messages.add("Path Under Gates");
         if (Loader.isModLoaded("pickupnotifier") && UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) messages.add("Pick Up Notifier");
-        if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalDuplicationFixToggle) messages.add("PortalDupeBegone");
+        if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalTravelingDupeToggle) messages.add("PortalDupeBegone");
         if (Loader.isModLoaded("preventghost") && UTConfigBugfixes.BLOCKS.utMiningGlitchToggle) messages.add("Prevent Ghost Blocks");
         if (Loader.isModLoaded("quickleafdecay") && UTConfigTweaks.BLOCKS.utLeafDecayToggle) messages.add("Quick Leaf Decay");
         if (Loader.isModLoaded("rallyhealth") && UTConfigTweaks.ENTITIES.RALLY_HEALTH.utRallyHealthToggle) messages.add("Rally Health");

--- a/src/main/resources/mixins.tweaks.entities.spawning.portal.json
+++ b/src/main/resources/mixins.tweaks.entities.spawning.portal.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.spawning.portal.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTPortalMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.console.addpacket.json
+++ b/src/main/resources/mixins.tweaks.misc.console.addpacket.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.console.addpacket.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTEntityTrackerEntryMixin"]
+}

--- a/src/main/resources/mixins.tweaks.performance.oredictionarycheck.json
+++ b/src/main/resources/mixins.tweaks.performance.oredictionarycheck.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.oredictionarycheck.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTOreDictionaryCheckMixin"]
+}


### PR DESCRIPTION
Should cover most of the vanilla RLMixins tweaks now.

- **No Portal Spawning:** Prevents zombie pigmen spawning from nether portals (false by default).
- **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings
- **Slowed Item Entity Movement:** Slows how often item entities update movement (possibly improving performance).
- **Suppress Ore Dictionary Errors:** Disables Forge's broken ore dictionary errors (false by default).
