### PR TITLE
4th Batch of Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ All changes are toggleable via config files.
 * **Particle Spawning:** Fixes various particle types not showing up on the client
 * **Piston Progress:** Properly saves the last state of pistons to tags
 * **Portal Traveling Dupe:** Fixes duplication issues that can occur when entities travel through portals
-* **Potion Amplifier Visibility:** Fixes potion effects not displaying their level when it is above 'IV'
+* **Potion Amplifier Visibility:** Fixes potion effects not displaying their level above 'IV'
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms
 * **Skeleton Aim:** Fixes skeletons not looking at their targets when strafing
 * **Sleep Resets Weather:** Fixes sleeping always resetting rain and thunder times
 * **Tile Entity Map:** Replaces the chunk position data table to prevent tile entity related issues
 * **Villager Mantle:** Returns missing hoods to villager mantles
+* **Witch Huts:** Fixes witch hut structure data not accounting for the height it is generated at
 
 ![](https://i.imgur.com/1EmHZlb.png)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All changes are toggleable via config files.
 * **Ladder Flying Slowdown:** Disables climbing movement when flying
 * **Locale:** Prevents various crashes with Turkish locale
 * **Max Health:** Corrects maximum player health on joining by setting the last saved health value
+* **Minecart AI:** Fixes non-player entities being able to control minecarts
 * **Mining Glitch:** Avoids the need for multiple mining attempts by sending additional movement packets
 * **Model Gap:** Fixes transparent gaps in all 3D models of blocks and items
 * **Mount Desync:** Fixes mounts and boats sometimes disappearing after dismounting

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All changes are toggleable via config files.
 * **Packet Size:** Increases the packet size limit to account for large packets in modded environments
 * **Particle Spawning:** Fixes various particle types not showing up on the client
 * **Piston Progress:** Properly saves the last state of pistons to tags
+* **Piston Retraction:** Improves retraction behavior on double piston extenders
 * **Portal Traveling Dupe:** Fixes duplication issues that can occur when entities travel through portals
 * **Potion Amplifier Visibility:** Fixes potion effects not displaying their level above 'IV'
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/piston/pistonretraction/mixin/UTPistonBaseBlockMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/piston/pistonretraction/mixin/UTPistonBaseBlockMixin.java
@@ -1,0 +1,32 @@
+package mod.acgaming.universaltweaks.bugfixes.blocks.piston.pistonretraction.mixin;
+
+import static net.minecraft.block.BlockPistonBase.EXTENDED;
+
+import net.minecraft.block.BlockPistonBase;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// MC-88959
+// https://bugs.mojang.com/browse/MC-88959
+// Courtesy of mrgrim
+@Mixin(BlockPistonBase.class)
+public abstract class UTPistonBaseBlockMixin
+{
+    @Inject(method = "checkForMove", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;addBlockEvent(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/Block;II)V", ordinal = 1))
+    private void onPistonDepower(World worldIn, BlockPos pos, IBlockState state, CallbackInfo ci)
+	{
+        if (UTConfigBugfixes.BLOCKS.utPistonRetractionToggle)
+		{
+            worldIn.setBlockState(pos, state.withProperty(EXTENDED, false), 2);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/minecart/mixin/UTMinecartAIMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/minecart/mixin/UTMinecartAIMixin.java
@@ -1,0 +1,34 @@
+package mod.acgaming.universaltweaks.bugfixes.entities.minecart.mixin;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.entity.player.EntityPlayer;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+// MC-64836
+// https://bugs.mojang.com/browse/MC-64836
+// Courtesy of mrgrim
+@Mixin(EntityMinecart.class)
+public abstract class UTMinecartAIMixin
+{
+    // TODO: Investigate AI code (?)
+    @Redirect(method = "moveAlongTrack", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/EntityLivingBase;moveForward:F", opcode = Opcodes.GETFIELD, ordinal = 0),
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityMinecart;getPassengers()Ljava/util/List;", ordinal = 1),
+                    to = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityMinecart;shouldDoRailFunctions()Z", remap = false)))
+    private float disableMobControl(EntityLivingBase entityIn)
+    {
+        if (UTConfigBugfixes.ENTITIES.utMinecartAIToggle && !(entityIn instanceof EntityPlayer))
+        {
+            return 0.0F;
+        }
+
+        return entityIn.moveForward;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/witchhuts/mixin/UTWitchHutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/world/witchhuts/mixin/UTWitchHutMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.bugfixes.world.witchhuts.mixin;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.gen.structure.StructureStart;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// MC-73051
+// https://bugs.mojang.com/browse/MC-73051
+// Courtesy of mrgrim, Xcom6000
+@Mixin(StructureStart.class)
+public abstract class UTWitchHutMixin
+{
+    @Shadow
+    protected abstract void updateBoundingBox();
+
+    @Inject(method = "writeStructureComponentsToNBT", at = @At(value = "CONSTANT", args = "stringValue=Children", ordinal = 0))
+    public void callUpdateBoundingBox(int chunkX, int chunkZ, CallbackInfoReturnable<NBTTagCompound> ci)
+    {
+        if (UTConfigBugfixes.WORLD.utWitchStructuresToggle) this.updateBoundingBox();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -89,6 +89,11 @@ public class UTConfigBugfixes
         @Config.Name("Piston Progress")
         @Config.Comment("Properly saves the last state of pistons to tags")
         public boolean utPistonTileToggle = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Piston Retraction")
+        @Config.Comment("Improves retraction behavior on double piston extenders")
+        public boolean utPistonRetractionToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Sleep Resets Weather")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -227,6 +227,11 @@ public class UTConfigBugfixes
         @Config.Name("Max Player Health")
         @Config.Comment("Corrects maximum player health on joining by setting the last saved health value")
         public boolean utMaxHealthToggle = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Minecart AI")
+        @Config.Comment("Fixes non-player entities being able to control minecarts")
+        public boolean utMinecartAIToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Mount Desync")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -315,7 +315,7 @@ public class UTConfigBugfixes
         
         @Config.RequiresMcRestart
         @Config.Name("Potion Amplifier Visibility")
-        @Config.Comment("Fixes potion effects not displaying their level when it is above 'IV'")
+        @Config.Comment("Fixes potion effects not displaying their level above 'IV'")
         public boolean utPotionAmplifierVisibilityToggle = true;
 
         @Config.RequiresMcRestart
@@ -375,6 +375,11 @@ public class UTConfigBugfixes
         @Config.Name("Portal Traveling Dupe")
         @Config.Comment("Fixes duplication issues that can occur when entities travel through portals")
         public boolean utPortalTravelingDupeToggle = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Witch Huts")
+        @Config.Comment("Fixes witch hut structure data not accounting for the height it is generated at")
+        public boolean utWitchStructuresToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Tile Entity Map")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -170,6 +170,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.entities.entitylists.json");
         configs.add("mixins.bugfixes.entities.horsefalling.json");
         configs.add("mixins.bugfixes.entities.maxhealth.json");
+        configs.add("mixins.bugfixes.entities.minecart.json");
         configs.add("mixins.bugfixes.entities.mount.json");
         configs.add("mixins.bugfixes.entities.saturation.json");
         configs.add("mixins.bugfixes.entities.skeletonaim.json");
@@ -368,6 +369,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.ENTITIES.utHorseFallingToggle;
             case "mixins.bugfixes.entities.maxhealth.json":
                 return UTConfigBugfixes.ENTITIES.utMaxHealthToggle;
+            case "mixins.bugfixes.entities.minecart.json":
+                return UTConfigBugfixes.ENTITIES.utMinecartAIToggle;
             case "mixins.bugfixes.entities.mount.json":
                 return UTConfigBugfixes.ENTITIES.utMountDesyncToggle;
             case "mixins.bugfixes.entities.saturation.json":
@@ -442,7 +445,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             case "mixins.tweaks.entities.taming.horse.json":
                 return UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utTamingUndeadHorsesToggle;
             case "mixins.tweaks.entities.trading.json":
-                return UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle;
+                return UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle;
             case "mixins.tweaks.items.attackcooldown.server.json":
                 return UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle;
             case "mixins.tweaks.items.eating.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -180,6 +180,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.misc.particlespawning.json");
         configs.add("mixins.bugfixes.world.chunksaving.json");
         configs.add("mixins.bugfixes.world.tileentities.json");
+        configs.add("mixins.bugfixes.world.witchhuts.json");
         configs.add("mixins.tweaks.blocks.bedobstruction.json");
         configs.add("mixins.tweaks.blocks.breakablebedrock.json");
         configs.add("mixins.tweaks.blocks.growthsize.json");
@@ -381,6 +382,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.WORLD.utChunkSavingToggle && !spongeForgeLoaded;
             case "mixins.bugfixes.world.tileentities.json":
                 return UTConfigBugfixes.WORLD.utTileEntityMap != UTConfigBugfixes.WorldCategory.EnumMaps.HASHMAP;
+            case "mixins.bugfixes.world.witchhuts.json":
+                return UTConfigBugfixes.WORLD.utWitchStructuresToggle;
             case "mixins.tweaks.blocks.bedobstruction.json":
                 return UTConfigTweaks.BLOCKS.utBedObstructionToggle;
             case "mixins.tweaks.blocks.breakablebedrock.json":
@@ -439,7 +442,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             case "mixins.tweaks.entities.taming.horse.json":
                 return UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utTamingUndeadHorsesToggle;
             case "mixins.tweaks.entities.trading.json":
-                return UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle;
+                return UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle;
             case "mixins.tweaks.items.attackcooldown.server.json":
                 return UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle;
             case "mixins.tweaks.items.eating.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -157,6 +157,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.blocks.ladderflying.json");
         configs.add("mixins.bugfixes.blocks.miningglitch.server.json");
         configs.add("mixins.bugfixes.blocks.pistontile.json");
+        configs.add("mixins.bugfixes.blocks.pistontile.pistonretraction.json");
         configs.add("mixins.bugfixes.entities.ai.json");
         configs.add("mixins.bugfixes.entities.attackradius.json");
         configs.add("mixins.bugfixes.entities.blockfire.json");
@@ -336,6 +337,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.BLOCKS.utMiningGlitchToggle;
             case "mixins.bugfixes.blocks.pistontile.json":
                 return UTConfigBugfixes.BLOCKS.utPistonTileToggle;
+            case "mixins.bugfixes.blocks.pistontile.pistonretraction.json":
+                return UTConfigBugfixes.BLOCKS.utPistonRetractionToggle;
             case "mixins.bugfixes.blocks.bed.json":
                 return UTConfigBugfixes.BLOCKS.utSleepResetsWeatherToggle;
             case "mixins.bugfixes.misc.enchantment.json":

--- a/src/main/resources/mixins.bugfixes.blocks.pistontile.pistonretraction.json
+++ b/src/main/resources/mixins.bugfixes.blocks.pistontile.pistonretraction.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.blocks.piston.pistonretraction.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTPistonBaseBlockMixin"]
+}

--- a/src/main/resources/mixins.bugfixes.entities.minecart.json
+++ b/src/main/resources/mixins.bugfixes.entities.minecart.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.entities.minecart.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTMinecartAIMixin"]
+}

--- a/src/main/resources/mixins.bugfixes.world.witchhuts.json
+++ b/src/main/resources/mixins.bugfixes.world.witchhuts.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.world.witchhuts.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTWitchHutMixin"]
+}


### PR DESCRIPTION
All from MUP.

- [MC-64836](https://bugs.mojang.com/browse/MC-64836) - Mobs "control" the minecart they are riding (also in RandomPatches).
- [MC-73051](https://bugs.mojang.com/browse/MC-73051) - Witch Hut structure data do not account for the height the witch hut is generated at.
- [MC-88959](https://bugs.mojang.com/browse/MC-88959) - Piston no longer retracts an extended piston when de-powered at the same time.