### PR TITLE
Fix invisible Compact Machine walls when using Nothirium 0.2.x+ or Vintagium

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,8 +158,8 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:thaumcraft-223628:2629023')
     compileOnly rfg.deobf('curse.maven:the-erebus-220698:3211974')
     compileOnly rfg.deobf('curse.maven:thermal-expansion-69163:2926431')
-    implementation rfg.deobf('slimeknights.mantle:Mantle:1.12-1.3.3.56')
-    implementation rfg.deobf('slimeknights:TConstruct:1.12.2-2.13.0.190')
+    compileOnly rfg.deobf('slimeknights.mantle:Mantle:1.12-1.3.3.56')
+    compileOnly rfg.deobf('slimeknights:TConstruct:1.12.2-2.13.0.190')
     compileOnly rfg.deobf('net.darkhax.bookshelf:Bookshelf-1.12.2:2.3.590')
     compileOnly rfg.deobf('net.darkhax.gamestages:GameStages-1.12.2:2.0.120')
     compileOnly rfg.deobf('net.darkhax.itemstages:ItemStages-1.12.2:2.0.51')
@@ -171,6 +171,7 @@ dependencies {
     compileOnly 'curse.maven:chisel-235279:2915375'
     compileOnly 'curse.maven:codechickenlib-242818:2779848'
     compileOnly 'curse.maven:cofhworld-271384:2920434'
+    compileOnly 'curse.maven:compactmachines-224218:2707509'
     compileOnly 'curse.maven:endercore-231868:2972849'
     compileOnly 'curse.maven:enderio-64578:2989201'
     compileOnly 'curse.maven:extrautilities-225561:2678374'
@@ -196,7 +197,7 @@ dependencies {
     compileOnly 'curse.maven:tinkerscomplement-272671:2843439'
     compileOnly 'curse.maven:tinyprogressions-250850:2721018'
     compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
-    compileOnly 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
+    // implementation 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
 
     if (project.use_mixins.toBoolean()) {
         String mixin = modUtils.enableMixins("zone.rong:mixinbooter:8.9", "universaltweaks.refmap.json")

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -77,6 +77,7 @@ public class UniversalTweaks
         + "after:chisel;"
         + "after:cofhcore;"
         + "after:collective;"
+        + "after:compactmachines3;"
         + "after:contenttweaker;"
         + "after:element;"
         + "after:elenaidodge2;"

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -55,6 +55,10 @@ public class UTConfigMods
     @Config.Name("CoFH Core")
     public static final CoFHCoreCategory COFH_CORE = new CoFHCoreCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.compactmachines")
+    @Config.Name("Compact Machines")
+    public static final CompactMachinesCoreCategory COMPACT_MACHINES = new CompactMachinesCoreCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.elementarystaffs")
     @Config.Name("Elementary Staffs")
     public static final ElementaryStaffsCategory ELEMENTARY_STAFFS = new ElementaryStaffsCategory();
@@ -284,6 +288,14 @@ public class UTConfigMods
         @Config.Name("Vorpal Enchantment Damage")
         @Config.Comment("Sets the damage multiplier of the Vorpal enchantment")
         public double utCoFHVorpalDamage = 10.0D;
+    }
+
+    public static class CompactMachinesCoreCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Invisible Wall Render Fix")
+        @Config.Comment("Fixes some compact machine walls being invisible if Nothirium 0.2.x+ or Vintagium is installed")
+        public boolean utCMRenderFixToggle = true;
     }
 
     public static class ElementaryStaffsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -246,7 +246,15 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
     @Override
     public boolean shouldMixinConfigQueue(String mixinConfig)
     {
-        if (isDev) return true;
+        if (isDev)
+        {
+            // Causes crashes in dev env only
+            if (mixinConfig.equals("mixins.tweaks.misc.armorcurve.json"))
+            {
+                return false;
+            }
+            return true;
+        }
         if (isClient)
         {
             switch (mixinConfig)

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -1,8 +1,8 @@
 package mod.acgaming.universaltweaks.core;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import net.minecraftforge.fml.common.Loader;
 
 import mod.acgaming.universaltweaks.config.UTConfigMods;
@@ -13,67 +13,72 @@ public class UTMixinLoader implements ILateMixinLoader
     @Override
     public List<String> getMixinConfigs()
     {
-        return Lists.newArrayList(
-            "mixins.mods.abyssalcraft.json",
-            "mixins.mods.actuallyadditions.dupes.json",
-            "mixins.mods.aoa3.json",
-            "mixins.mods.arcanearchives.dupes.json",
-            "mixins.mods.biomesoplenty.json",
-            "mixins.mods.bloodmagic.dupes.json",
-            "mixins.mods.bloodmagic.json",
-            "mixins.mods.botania.dupes.json",
-            "mixins.mods.botania.json",
-            "mixins.mods.ceramics.json",
-            "mixins.mods.chisel.tcomplement.dupes.json",
-            "mixins.mods.cofhcore.json",
-            "mixins.mods.collective.json",
-            "mixins.mods.compactmachines.json",
-            "mixins.mods.cqrepoured.json",
-            "mixins.mods.crafttweaker.json",
-            "mixins.mods.elementarystaffs.json",
-            "mixins.mods.elenaidodge2.json",
-            "mixins.mods.epicsiegemod.json",
-            "mixins.mods.erebus.json",
-            "mixins.mods.extrautilities.dupes.json",
-            "mixins.mods.forestry.cocoa.json",
-            "mixins.mods.forestry.dupes.json",
-            "mixins.mods.forestry.extratrees.json",
-            "mixins.mods.forestry.json",
-            "mixins.mods.industrialcraft.dupes.json",
-            "mixins.mods.industrialforegoing.dupes.json",
-            "mixins.mods.infernalmobs.json",
-            "mixins.mods.ironbackpacks.dupes.json",
-            "mixins.mods.itemstages.json",
-            "mixins.mods.mekanism.dupes.json",
-            "mixins.mods.mobstages.json",
-            "mixins.mods.netherchest.dupes.json",
-            "mixins.mods.netherrocks.json",
-            "mixins.mods.nuclearcraft.json",
-            "mixins.mods.quark.dupes.json",
-            "mixins.mods.reskillable.json",
-            "mixins.mods.roost.contenttweaker.json",
-            "mixins.mods.roost.json",
-            "mixins.mods.simpledifficulty.json",
-            "mixins.mods.spiceoflife.dupes.json",
-            "mixins.mods.storagedrawers.client.json",
-            "mixins.mods.tconstruct.json",
-            "mixins.mods.tconstruct.toolcustomization.json",
-            "mixins.mods.tconstruct.toolcustomization.plustic.json",
-            "mixins.mods.tconstruct.oredictcache.json",
-            "mixins.mods.techreborn.json",
-            "mixins.mods.thaumcraft.dupes.json",
-            "mixins.mods.thaumcraft.enderio.dupes.json",
-            "mixins.mods.thaumcraft.entities.client.json",
-            "mixins.mods.thaumcraft.entities.server.json",
-            "mixins.mods.thaumcraft.foci.focuseffects.json",
-            "mixins.mods.thaumcraft.foci.focusmediums.json",
-            "mixins.mods.thaumcraft.json",
-            "mixins.mods.thaumicwonders.dupes.json",
-            "mixins.mods.thefarlanders.dupes.json",
-            "mixins.mods.thermalexpansion.dupes.json",
-            "mixins.mods.thermalexpansion.json",
-            "mixins.mods.tinyprogressions.dupes.json"
-        );
+        List<String> configs = new ArrayList<>();
+        // CLIENT ONLY
+        if (UTLoadingPlugin.isClient)
+        {
+            configs.add("mixins.mods.aoa3.json");
+            configs.add("mixins.mods.compactmachines.json");
+            configs.add("mixins.mods.crafttweaker.json");
+            configs.add("mixins.mods.roost.json");
+            configs.add("mixins.mods.storagedrawers.client.json");
+            configs.add("mixins.mods.thaumcraft.entities.client.json");
+        }
+        // COMMON
+        configs.add("mixins.mods.abyssalcraft.json");
+        configs.add("mixins.mods.actuallyadditions.dupes.json");
+        configs.add("mixins.mods.arcanearchives.dupes.json");
+        configs.add("mixins.mods.biomesoplenty.json");
+        configs.add("mixins.mods.bloodmagic.dupes.json");
+        configs.add("mixins.mods.bloodmagic.json");
+        configs.add("mixins.mods.botania.dupes.json");
+        configs.add("mixins.mods.botania.json");
+        configs.add("mixins.mods.ceramics.json");
+        configs.add("mixins.mods.chisel.tcomplement.dupes.json");
+        configs.add("mixins.mods.cofhcore.json");
+        configs.add("mixins.mods.collective.json");
+        configs.add("mixins.mods.cqrepoured.json");
+        configs.add("mixins.mods.elementarystaffs.json");
+        configs.add("mixins.mods.elenaidodge2.json");
+        configs.add("mixins.mods.epicsiegemod.json");
+        configs.add("mixins.mods.erebus.json");
+        configs.add("mixins.mods.extrautilities.dupes.json");
+        configs.add("mixins.mods.forestry.cocoa.json");
+        configs.add("mixins.mods.forestry.dupes.json");
+        configs.add("mixins.mods.forestry.extratrees.json");
+        configs.add("mixins.mods.forestry.json");
+        configs.add("mixins.mods.industrialcraft.dupes.json");
+        configs.add("mixins.mods.industrialforegoing.dupes.json");
+        configs.add("mixins.mods.infernalmobs.json");
+        configs.add("mixins.mods.ironbackpacks.dupes.json");
+        configs.add("mixins.mods.itemstages.json");
+        configs.add("mixins.mods.mekanism.dupes.json");
+        configs.add("mixins.mods.mobstages.json");
+        configs.add("mixins.mods.netherchest.dupes.json");
+        configs.add("mixins.mods.netherrocks.json");
+        configs.add("mixins.mods.nuclearcraft.json");
+        configs.add("mixins.mods.quark.dupes.json");
+        configs.add("mixins.mods.reskillable.json");
+        configs.add("mixins.mods.roost.contenttweaker.json");
+        configs.add("mixins.mods.simpledifficulty.json");
+        configs.add("mixins.mods.spiceoflife.dupes.json");
+        configs.add("mixins.mods.tconstruct.json");
+        configs.add("mixins.mods.tconstruct.toolcustomization.json");
+        configs.add("mixins.mods.tconstruct.toolcustomization.plustic.json");
+        configs.add("mixins.mods.tconstruct.oredictcache.json");
+        configs.add("mixins.mods.techreborn.json");
+        configs.add("mixins.mods.thaumcraft.dupes.json");
+        configs.add("mixins.mods.thaumcraft.enderio.dupes.json");
+        configs.add("mixins.mods.thaumcraft.entities.server.json");
+        configs.add("mixins.mods.thaumcraft.foci.focuseffects.json");
+        configs.add("mixins.mods.thaumcraft.foci.focusmediums.json");
+        configs.add("mixins.mods.thaumcraft.json");
+        configs.add("mixins.mods.thaumicwonders.dupes.json");
+        configs.add("mixins.mods.thefarlanders.dupes.json");
+        configs.add("mixins.mods.thermalexpansion.dupes.json");
+        configs.add("mixins.mods.thermalexpansion.json");
+        configs.add("mixins.mods.tinyprogressions.dupes.json");
+        return configs;
     }
 
     @Override
@@ -85,10 +90,10 @@ public class UTMixinLoader implements ILateMixinLoader
             {
                 case "mixins.mods.aoa3.json":
                     return Loader.isModLoaded("aoa3") && (Loader.isModLoaded("fluxnetworks") || Loader.isModLoaded("nuclearcraft"));
-                case "mixins.mods.crafttweaker.json":
-                    return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.compactmachines.json":
                     return Loader.isModLoaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle;
+                case "mixins.mods.crafttweaker.json":
+                    return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.roost.json":
                     return Loader.isModLoaded("roost");
                 case "mixins.mods.storagedrawers.client.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -27,6 +27,7 @@ public class UTMixinLoader implements ILateMixinLoader
             "mixins.mods.chisel.tcomplement.dupes.json",
             "mixins.mods.cofhcore.json",
             "mixins.mods.collective.json",
+            "mixins.mods.compactmachines.json",
             "mixins.mods.cqrepoured.json",
             "mixins.mods.crafttweaker.json",
             "mixins.mods.elementarystaffs.json",
@@ -86,6 +87,8 @@ public class UTMixinLoader implements ILateMixinLoader
                     return Loader.isModLoaded("aoa3") && (Loader.isModLoaded("fluxnetworks") || Loader.isModLoaded("nuclearcraft"));
                 case "mixins.mods.crafttweaker.json":
                     return Loader.isModLoaded("crafttweaker");
+                case "mixins.mods.compactmachines.json":
+                    return Loader.isModLoaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle;
                 case "mixins.mods.roost.json":
                     return Loader.isModLoaded("roost");
                 case "mixins.mods.storagedrawers.client.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/mixin/UTCubeToolsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/mixin/UTCubeToolsMixin.java
@@ -1,0 +1,71 @@
+package mod.acgaming.universaltweaks.mods.compactmachines.mixin;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
+import net.minecraft.world.IBlockAccess;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.dave.compactmachines3.init.Blockss;
+import org.dave.compactmachines3.misc.CubeTools;
+import org.dave.compactmachines3.reference.EnumMachineSize;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// Courtesy of jchung01
+@Mixin(value = CubeTools.class, remap = false)
+public class UTCubeToolsMixin {
+
+    /**
+     * Using a block's complete (x,y,z) position, determine the size of compact machine it belongs to.
+     *
+     * @param section the section of world, possibly a sub-chunk or chunk
+     * @param pos the block pos, including its y dimension
+     * @return the corresponding compact machine's interior size + 1
+     */
+    @Unique
+    private static int universalTweaks$getCubeSizeWithYContext(IBlockAccess section, MutableBlockPos pos) {
+        pos.setPos(pos.getX() * 1024, pos.getY(), pos.getZ());
+        for (int i = EnumMachineSize.values().length - 1; i >= 0; i--) {
+            EnumMachineSize size = EnumMachineSize.values()[i];
+            // (x + dimension, y, z)
+            pos.move(EnumFacing.EAST, size.getDimension());
+            if (section.getBlockState(pos).getBlock() == Blockss.wall) {
+                return size.getDimension();
+            }
+            // Reset to (x, y, z)
+            pos.move(EnumFacing.WEST, size.getDimension());
+        }
+        return EnumMachineSize.TINY.getDimension();
+    }
+
+    /**
+     * Reassigns the size of the compact machine that is found from this block position using the y dimension.
+     * This is necessary because of two things that interact badly:
+     * <p>- {@link org.dave.compactmachines3.misc.CubeTools#getCubeSize(IBlockAccess, int)} only ever uses y=40 (the machine's base) for every block position to check the machine size.</p>
+     * <p>- Some optimization mods (i.e. Nothirium, Vintagium) replace the vanilla {@link net.minecraft.world.ChunkCache} with separate, sub-chunk based caches.</p>
+     * <br>
+     * These two things mean that when such optimization mods are present, {@link IBlockAccess#getBlockState(BlockPos)} will only be able
+     * to get block state info for the bottom sub-chunk of the machine, not the upper sub-chunk. This causes invisible walls for that upper sub-chunk.
+     *
+     * @param instance the EnumMachineSize instance
+     * @param world the section of world, possibly a sub-chunk or chunk
+     * @param pos the block pos
+     * @return the corresponding compact machine's interior size + 1
+     */
+    @Redirect(method = "shouldSideBeRendered", at = @At(value = "INVOKE", target = "Lorg/dave/compactmachines3/reference/EnumMachineSize;getDimension()I"))
+    private static int utReassignSize(EnumMachineSize instance, IBlockAccess world, BlockPos pos) {
+        if (!UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle) return instance.getDimension();
+        PooledMutableBlockPos mPos = PooledMutableBlockPos.retain(pos);
+        try {
+            return universalTweaks$getCubeSizeWithYContext(world, mPos.setPos(pos.getX() / 1024, pos.getY(), 0));
+        } finally {
+            // Have to manually release in 1.12
+            mPos.release();
+        }
+    }
+
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -51,6 +51,7 @@ cfg.universaltweaks.modintegration.bop=Biomes O' Plenty
 cfg.universaltweaks.modintegration.botania=Botania
 cfg.universaltweaks.modintegration.chisel=Chisel
 cfg.universaltweaks.modintegration.cofhcore=CoFH Core
+cfg.universaltweaks.modintegration.compactmachines=Compact Machines
 cfg.universaltweaks.modintegration.cqrepoured=Chocolate Quest Repoured
 cfg.universaltweaks.modintegration.elementarystaffs=Elementary Staffs
 cfg.universaltweaks.modintegration.elenaidodge2=Elenai Dodge 2

--- a/src/main/resources/mixins.mods.compactmachines.json
+++ b/src/main/resources/mixins.mods.compactmachines.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.compactmachines.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTCubeToolsMixin"]
+}


### PR DESCRIPTION
Fixes Asek3/sodium-1.12#7 and Meldexun/Nothirium#63, making Meldexun/Nothirium#88 unnecessary. See https://github.com/Meldexun/Nothirium/issues/63#issuecomment-1806576044 for an explanation of why this happens. Included here as Asek mentioned the mixin should probably be part of UniversalTweaks. Because of the issue in #365 (this PR doesn't fix this issue), I added a check for the config toggle in `UTCubeToolsMixin`.