### PR TITLE
Automatically register CT chickens to Roost tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -520,22 +520,11 @@ public class UTConfigMods
         @Config.Comment
             ({
                 "Improves load time by registering CT chickens early for Roost to detect them",
-                "Note: All CT chickens must be specified in \"Custom Chickens\" for this tweak to work!",
-                "Note: In your .zs files, to use ContentTweaker's MaterialSystem Parts, you must:",
+                "Note: If you would like to use ContentTweaker's MaterialSystem Parts for the layed item, in your script you must:",
                 "1) Use '#loader finalize_contenttweaker', not '#loader contenttweaker'",
                 "2) Use the Material Part Bracket Handler to reference the item"
             })
-        public boolean utRoostEarlyRegisterCTChickens = false;
-
-        @Config.RequiresMcRestart
-        @Config.Name("Custom Chickens")
-        @Config.Comment
-            ({
-                "Adds custom chickens from mods (e.g. ContentTweaker) to Roost's stock texture check",
-                "Syntax: name",
-                "name     Chicken name",
-            })
-        public String[] utRoostChickenMods = new String[] {};
+        public boolean utRoostEarlyRegisterCTChickens = true;
     }
 
     public static class SimpleDifficultyCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -95,7 +95,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 case "mixins.mods.crafttweaker.json":
                     return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.roost.json":
-                    return Loader.isModLoaded("roost");
+                    return Loader.isModLoaded("roost") && Loader.isModLoaded("contenttweaker");
                 case "mixins.mods.storagedrawers.client.json":
                     return Loader.isModLoaded("storagedrawers");
                 case "mixins.mods.thaumcraft.entities.client.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/roost/mixin/UTProxyClientMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/roost/mixin/UTProxyClientMixin.java
@@ -1,12 +1,13 @@
 package mod.acgaming.universaltweaks.mods.roost.mixin;
 
-import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 
+import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenFactory;
+import com.teamacronymcoders.contenttweaker.modules.chickens.ChickenRepresentation;
 import com.timwoodcreates.roost.RoostTextures;
 import com.timwoodcreates.roost.proxy.ProxyClient;
 import mod.acgaming.universaltweaks.UniversalTweaks;
@@ -24,11 +25,11 @@ public class UTProxyClientMixin
     @Inject(method = "loadComplete", at = @At("HEAD"))
     public void utRoostLoadComplete(FMLLoadCompleteEvent e, CallbackInfo ci)
     {
-        if (UTConfigMods.ROOST.utRoostChickenMods.length == 0) return;
+        if (!UTConfigMods.ROOST.utRoostEarlyRegisterCTChickens) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTProxyClientMixin ::: Rebuild roost stock textures");
         // stockTextures is immutable set, use stream to rebuild
         RoostTextures.stockTextures = Stream.concat(RoostTextures.stockTextures.stream(),
-                Arrays.stream(UTConfigMods.ROOST.utRoostChickenMods))
+                ChickenFactory.CHICKEN_REPRESENTATIONS.stream().map(ChickenRepresentation::getName))
             .collect(Collectors.collectingAndThen(Collectors.toSet(), ImmutableSet::copyOf));
     }
 }


### PR DESCRIPTION
Small change to automatically add all defined chickens from ContentTweaker's `ChickenFactory` to Roost's stock textures. Removes the need to manually define the chickens in the config. Because no manual input is required, changed the tweak to be enabled by default.