### PR TITLE
5th Batch of Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,15 @@ All changes are toggleable via config files.
     * **Lightning Fire Ticks:** Sets the duration in ticks lightning bolts set entities on fire
     * **No Lightning Fire:** Disables the creation of fire around lightning strikes
     * **No Lightning Flash:** Disables the flashing of skybox and ground brightness on lightning strikes
-    * **No Lighting Item Destruction:** Disables lightning bolts destroying items
+    * **No Lightning Item Destruction:** Prevents lightning bolts from destroying items
 * **Linear XP Amount:** Sets the amount of XP needed for each level, effectively removing the increasing level scaling
 * **Load Sounds:** Plays sounds when the game or the world are loaded
 * **Mending Overpowered:** If mending fix is enabled, repairs entire damaged inventory with XP
 * **Mending:** Only repairs damaged equipment with XP
 * **Mob Despawn Improvement:** Mobs carrying picked up items will drop their equipment and despawn properly
 * **More Banner Layers:** Sets the amount of applicable pattern layers for banners
+* **Mute Ore Dictionary Errors:** Silences ore dictionary errors
+* **Mute Texture Map Errors:** Silences texture map errors
 * **No Attack Cooldown:** Disables the 1.9 combat update attack cooldown
 * **No Crafting Repair:** Disables crafting recipes for repairing tools
 * **No Golems:** Disables the manual creation of golems and withers
@@ -185,7 +187,6 @@ All changes are toggleable via config files.
 * **Soulbound Vexes:** Summoned vexes will also die when their summoner is killed
 * **Spawn Caps:** Sets maximum spawning limits for different entity types
 * **Super Hot Torch:** Enables one-time ignition of entities by hitting them with a torch
-* **Suppress Ore Dictionary Errors:** Suppresses Forge's broken ore dictionary errors
 * **Stronghold Replacement:** Replaces stronghold generation with a safer variant
 * **Swing Through Grass:** Allows hitting entities through grass instead of breaking it
 * **Tidy Chunk:** Tidies newly generated chunks by removing scattered item entities

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ All changes are toggleable via config files.
     * **Lightning Fire Ticks:** Sets the duration in ticks lightning bolts set entities on fire
     * **No Lightning Fire:** Disables the creation of fire around lightning strikes
     * **No Lightning Flash:** Disables the flashing of skybox and ground brightness on lightning strikes
+    * **No Lighting Item Destruction:** Disables lightning bolts destroying items
 * **Linear XP Amount:** Sets the amount of XP needed for each level, effectively removing the increasing level scaling
 * **Load Sounds:** Plays sounds when the game or the world are loaded
 * **Mending Overpowered:** If mending fix is enabled, repairs entire damaged inventory with XP

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ All changes are toggleable via config files.
 * **Mending:** Only repairs damaged equipment with XP
 * **Mob Despawn Improvement:** Mobs carrying picked up items will drop their equipment and despawn properly
 * **More Banner Layers:** Sets the amount of applicable pattern layers for banners
+* **Mute Advancement Errors:** Silences advancement errors
 * **Mute Ore Dictionary Errors:** Silences ore dictionary errors
 * **Mute Texture Map Errors:** Silences texture map errors
 * **No Attack Cooldown:** Disables the 1.9 combat update attack cooldown

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1633,6 +1633,11 @@ public class UTConfigTweaks
         public boolean utWorldLoadingToggle = false;
         
         @Config.RequiresMcRestart
+        @Config.Name("Mute Advancement Errors")
+        @Config.Comment("Silences advancement errors")
+        public boolean utAdvancementCheckToggle = false;
+        
+        @Config.RequiresMcRestart
         @Config.Name("Mute Ore Dictionary Errors")
         @Config.Comment("Silences ore dictionary errors")
         public boolean utOreDictionaryCheckToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1382,7 +1382,7 @@ public class UTConfigTweaks
             
             @Config.RequiresMcRestart
             @Config.Name("No Lightning Item Destruction")
-            @Config.Comment("Disables lightning bolts destroying items")
+            @Config.Comment("Prevents lightning bolts from destroying items")
             public boolean utLightningItemDestructionToggle = false;
         }
 
@@ -1631,16 +1631,21 @@ public class UTConfigTweaks
                 "May have side effects such as slower chunk generation"
             })
         public boolean utWorldLoadingToggle = false;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Mute Ore Dictionary Errors")
+        @Config.Comment("Silences ore dictionary errors")
+        public boolean utOreDictionaryCheckToggle = false;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Mute Texture Map Errors")
+        @Config.Comment("Silences texture map errors")
+        public boolean utTextureMapCheckToggle = false;
 
         @Config.RequiresMcRestart
         @Config.Name("No Redstone Lighting")
         @Config.Comment("Disables lighting of active redstone, repeaters, and comparators to improve performance")
         public boolean utRedstoneLightingToggle = false;
-
-        @Config.RequiresMcRestart
-        @Config.Name("Suppress Ore Dictionary Errors")
-        @Config.Comment("Suppresses Forge's broken ore dictionary errors")
-        public boolean utOreDictionaryCheckToggle = false;
 
         @Config.RequiresMcRestart
         @Config.Name("Uncap FPS")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1379,6 +1379,11 @@ public class UTConfigTweaks
             @Config.Name("No Lightning Flash")
             @Config.Comment("Disables the flashing of skybox and ground brightness on lightning bolt strikes")
             public boolean utLightningFlashToggle = false;
+            
+            @Config.RequiresMcRestart
+            @Config.Name("No Lightning Item Destruction")
+            @Config.Comment("Disables lightning bolts destroying items")
+            public boolean utLightningItemDestructionToggle = false;
         }
 
         public static class LoadSoundsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -237,6 +237,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.performance.oredictionarycheck.json");
         configs.add("mixins.tweaks.performance.prefixcheck.json");
         configs.add("mixins.tweaks.performance.redstone.json");
+        configs.add("mixins.tweaks.performance.texturemapcheck.json");
         configs.add("mixins.tweaks.world.chunks.gen.json");
         configs.add("mixins.tweaks.world.loading.server.json");
         configs.add("mixins.tweaks.world.sealevel.json");
@@ -506,6 +507,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle;
             case "mixins.tweaks.performance.redstone.json":
                 return UTConfigTweaks.PERFORMANCE.utRedstoneLightingToggle;
+            case "mixins.tweaks.performance.texturemapcheck.json":
+                return UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle;
             case "mixins.tweaks.world.chunks.gen.json":
                 return UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle;
             case "mixins.tweaks.world.loading.server.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -231,6 +231,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.misc.xp.linear.json");
         configs.add("mixins.tweaks.misc.xp.smelting.json");
         configs.add("mixins.tweaks.misc.recipebook.server.json");
+        configs.add("mixins.tweaks.performance.advancementcheck.json");
         configs.add("mixins.tweaks.performance.autosave.json");
         configs.add("mixins.tweaks.performance.craftingcache.json");
         configs.add("mixins.tweaks.performance.dyeblending.json");
@@ -495,6 +496,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.MISC.utRecipeBookToggle;
             case "mixins.tweaks.misc.xp.smelting.json":
                 return UTConfigTweaks.MISC.utSmeltingXPToggle;
+            case "mixins.tweaks.performance.advancementcheck.json":
+                return UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
             case "mixins.tweaks.performance.autosave.json":
                 return UTConfigTweaks.PERFORMANCE.utAutoSaveInterval != 900;
             case "mixins.tweaks.performance.craftingcache.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/lightning/damage/UTLightningItemDestruction.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/lightning/damage/UTLightningItemDestruction.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.misc.lightning.damage;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+
+@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
+public class UTLightningItemDestruction
+{
+    @SubscribeEvent
+    public static void onLightningStrike(EntityStruckByLightningEvent event)
+    {
+        if (event.getEntity() instanceof EntityItem && UTConfigTweaks.MISC.LIGHTNING.utLightningItemDestructionToggle)
+        {
+        	if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTLightningItemDestruction ::: Lightning strike event");
+        	event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancementcheck/mixin/UTAdvancementManagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancementcheck/mixin/UTAdvancementManagerMixin.java
@@ -1,0 +1,54 @@
+package mod.acgaming.universaltweaks.tweaks.performance.advancementcheck.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.advancements.AdvancementManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+
+// Courtesy of fonnymunkey
+@Mixin(AdvancementManager.class)
+public abstract class UTAdvancementManagerMixin
+{
+    @WrapWithCondition(
+            method = "loadCustomAdvancements",
+            at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;)V",
+            remap = false)
+    )
+    public boolean utLoadCustomAdvancements0(Logger instance, String s)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
+    }
+
+    @WrapWithCondition(
+            method = "loadCustomAdvancements",
+            at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Throwable;)V",
+            remap = false)
+    )
+    public boolean utLoadCustomAdvancements1(Logger instance, String s, Throwable throwable)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
+    }
+
+    @WrapWithCondition(
+            method = "loadBuiltInAdvancements",
+            at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;)V",
+            remap = false)
+    )
+    public boolean utLoadBuiltInAdvanacements0(Logger instance, String s)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
+    }
+
+    @WrapWithCondition(
+            method = "loadBuiltInAdvancements",
+            at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Throwable;)V",
+            remap = false)
+    )
+    public boolean utLoadBuiltInAdvanacements1(Logger instance, String s, Throwable throwable)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancementcheck/mixin/UTForgeHooksMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancementcheck/mixin/UTForgeHooksMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.advancementcheck.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraftforge.common.ForgeHooks;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+
+// Courtesy of fonnymunkey
+@Mixin(ForgeHooks.class)
+public abstract class UTForgeHooksMixin
+{
+    @WrapWithCondition(
+            method = "lambda$loadAdvancements$0",
+            at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Throwable;)V"),
+            remap = false
+    )
+    private static boolean utLoadAdvancements(Logger instance, String s, Throwable throwable)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utAdvancementCheckToggle;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/texturemapcheck/mixin/UTTextureMapCheckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/texturemapcheck/mixin/UTTextureMapCheckMixin.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.WrapWithCondition;
 
 // Courtesy of Elephant_1214
 @Mixin(value = TextureMap.class, priority = 500)
-public abstract class UTTextureMapCheckMixin
+public class UTTextureMapCheckMixin
 {
     @WrapWithCondition(
             method = "*", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false),

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/texturemapcheck/mixin/UTTextureMapCheckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/texturemapcheck/mixin/UTTextureMapCheckMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.texturemapcheck.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.client.renderer.texture.TextureMap;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+
+// Courtesy of Elephant_1214
+@Mixin(value = TextureMap.class, priority = 500)
+public abstract class UTTextureMapCheckMixin
+{
+    @WrapWithCondition(
+            method = "*", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false),
+            require = 0
+    )
+    private boolean utCheckTexMap(Logger instance, String message, Object p0, Object p1)
+    {
+        return !UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -84,7 +84,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("movingquickly") && UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle) messages.add("MovingQuickly");
         if (Loader.isModLoaded("mtqfix") && UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle) messages.add("MTQFix");
         if (Loader.isModLoaded("mup")) messages.add("MUP / EigenCraft Unofficial Patch");
-        if (Loader.isModLoaded("muteuselesslogs") && UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle || UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle) messages.add("Mute Useless Logs");
+        if (Loader.isModLoaded("muteuselesslogs") && (UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle || UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle)) messages.add("Mute Useless Logs");
         if (Loader.isModLoaded("naturallychargedcreepers") && UTConfigTweaks.ENTITIES.utCreeperChargedChance > 0) messages.add("Naturally Charged Creepers");
         if (Loader.isModLoaded("nanfix") && UTConfigBugfixes.ENTITIES.utEntityNaNToggle) messages.add("NaN Entity Health Fix");
         if (Loader.isModLoaded("nanpolice") && UTConfigBugfixes.ENTITIES.utEntityNaNToggle) messages.add("NaNPolice");

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -84,6 +84,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("movingquickly") && UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle) messages.add("MovingQuickly");
         if (Loader.isModLoaded("mtqfix") && UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle) messages.add("MTQFix");
         if (Loader.isModLoaded("mup")) messages.add("MUP / EigenCraft Unofficial Patch");
+        if (Loader.isModLoaded("muteuselesslogs") && UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle || UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle) messages.add("Mute Useless Logs");
         if (Loader.isModLoaded("naturallychargedcreepers") && UTConfigTweaks.ENTITIES.utCreeperChargedChance > 0) messages.add("Naturally Charged Creepers");
         if (Loader.isModLoaded("nanfix") && UTConfigBugfixes.ENTITIES.utEntityNaNToggle) messages.add("NaN Entity Health Fix");
         if (Loader.isModLoaded("nanpolice") && UTConfigBugfixes.ENTITIES.utEntityNaNToggle) messages.add("NaNPolice");

--- a/src/main/resources/mixins.tweaks.performance.advancementcheck.json
+++ b/src/main/resources/mixins.tweaks.performance.advancementcheck.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.advancementcheck.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTAdvancementManagerMixin", "UTForgeHooksMixin"]
+}

--- a/src/main/resources/mixins.tweaks.performance.texturemapcheck.json
+++ b/src/main/resources/mixins.tweaks.performance.texturemapcheck.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.texturemapcheck.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTTextureMapCheckMixin"]
+}


### PR DESCRIPTION
All three tweaks are false by default. 'Suppress Ore Dictionary Errors' was renamed to 'Mute Ore Dictionary Errors'.
- **Mute Advancement Errors:** Silences advancement errors
- **Mute Texture Map Errors:** Silences texture map errors
- **No Lightning Item Destruction:** Prevents lightning bolts from destroying items