### PR TITLE
Blacklist irregular entities from desync fix

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/IPrevMotion.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/IPrevMotion.java
@@ -14,4 +14,10 @@ public interface IPrevMotion
     double getPrevMotionZ();
 
     void setPrevMotionZ(double prevMotionZ);
+
+    /**
+     * Checks if this entity has ever called super.onUpdate(). This should adequately determine if it should be ignored by the desync fix.
+     * @return true if the implementing class calls super.onUpdate()
+     */
+    boolean hasSuperUpdate();
 }

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/UTEntityDesync.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/UTEntityDesync.java
@@ -36,6 +36,6 @@ public class UTEntityDesync
 
     public static boolean isBlacklisted(Entity entity)
     {
-        return blacklistedEntityEntries.contains(EntityRegistry.getEntry(entity.getClass()));
+        return blacklistedEntityEntries.contains(EntityRegistry.getEntry(entity.getClass())) || !(((IPrevMotion) entity).hasSuperUpdate());
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/mixin/UTEntityMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/mixin/UTEntityMixin.java
@@ -27,11 +27,14 @@ public class UTEntityMixin implements IPrevMotion
     private double prevMotionY;
     @Unique
     private double prevMotionZ;
+    @Unique
+    private boolean universalTweaks$superUpdate = false;
 
     @Inject(method = "onUpdate", at = @At("HEAD"))
     public void utOnUpdate(CallbackInfo info)
     {
         if (UTEntityDesync.isBlacklisted(((Entity) (Object) this))) return;
+        if (!universalTweaks$superUpdate) universalTweaks$superUpdate = true;
         prevMotionX = motionX;
         prevMotionY = motionY;
         prevMotionZ = motionZ;
@@ -71,5 +74,11 @@ public class UTEntityMixin implements IPrevMotion
     public void setPrevMotionZ(double prevMotionZ)
     {
         this.prevMotionZ = prevMotionZ;
+    }
+
+    @Override
+    public boolean hasSuperUpdate()
+    {
+        return universalTweaks$superUpdate;
     }
 }


### PR DESCRIPTION
Fixes #262 by ignoring entities that do not update prevPos. Assume these are entities that don't call Entity#onUpdate(). The main issue was that `utGetDistanceSq()` was reliant on those values being updated, which explains the weird behavior once the entities went far enough.

If you would like some reasoning for this assumption, specifically for Immersive Vehicles you can see [here](https://github.com/DonBruce64/MinecraftTransportSimulator/blob/master/mcinterfaceforge1122/src/main/java/mcinterface1122/ABuilderEntityBase.java#L60) that the vehicles do not call `super.onUpdate()` or `super.onEntityUpdate()`, the latter of which normally updates prevPos in `Entity`.