### PR TITLE
6th Batch of Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ All changes are toggleable via config files.
 * **Shear Mooshroom Dupe:** Fixes a duplication exploit connected to shearing mooshrooms
 * **Skeleton Aim:** Fixes skeletons not looking at their targets when strafing
 * **Sleep Resets Weather:** Fixes sleeping always resetting rain and thunder times
+* **Spectator Menu:** Fixes the spectator menu not showing player skins
 * **Tile Entity Map:** Replaces the chunk position data table to prevent tile entity related issues
 * **Villager Mantle:** Returns missing hoods to villager mantles
 * **Witch Huts:** Fixes witch hut structure data not accounting for the height it is generated at

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All changes are toggleable via config files.
 * **Chunk Saving:** Fixes loading of outdated chunks to prevent duplications, deletions and data corruption
 * **Comparator Timing:** Fixes inconsistent delays of comparators to prevent redstone timing issues
 * **Concurrent Entity AI Tasks:** Replaces linked entity AI task sets with concurrent sets to avoid mod exception concerning entity AI
+* **Crafted Item Statistics:** Fixes crafted item statistics not increasing correctly when items are crafted with shift-click or drop methods
 * **Death Time:** Fixes corrupted entities exceeding the allowed death time
 * **Depth Mask:** Fixes entity and particle rendering issues by enabling depth buffer writing
 * **Destroy Entity Packets:** Fixes lag caused by dead entities by sending additional packets when the player is not alive

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/piston/retraction/mixin/UTPistonBaseBlockMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/piston/retraction/mixin/UTPistonBaseBlockMixin.java
@@ -15,7 +15,7 @@ import static net.minecraft.block.BlockPistonBase.EXTENDED;
 
 // MC-88959
 // https://bugs.mojang.com/browse/MC-88959
-// Courtesy of mrgrim
+// Courtesy of Nessiesson
 @Mixin(BlockPistonBase.class)
 public abstract class UTPistonBaseBlockMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/crafteditemstatistics/mixin/UTSlotCraftingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/crafteditemstatistics/mixin/UTSlotCraftingMixin.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.bugfixes.misc.crafteditemstatistics.mixin;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.inventory.SlotCrafting;
+import net.minecraft.item.ItemStack;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// MC-65198, MC-161869
+// https://bugs.mojang.com/browse/MC-65198
+// https://bugs.mojang.com/browse/MC-161869
+// Courtesy of mrgrim
+@Mixin(SlotCrafting.class)
+public abstract class UTSlotCraftingMixin extends Slot
+{
+    @Shadow
+    private int amountCrafted;
+
+    public UTSlotCraftingMixin(IInventory inventoryIn, int index, int xPosition, int yPosition)
+    {
+        super(inventoryIn, index, xPosition, yPosition);
+    }
+
+    @Inject(method = "decrStackSize", at = @At("HEAD"), cancellable = true)
+    private void utFixCraftingStats(int amount, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (UTConfigBugfixes.MISC.utCraftedItemStatisticsToggle)
+        {
+            ItemStack ret = super.decrStackSize(amount);
+            this.amountCrafted += ret.getCount();
+
+            cir.setReturnValue(ret);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/spectatormenu/mixin/UTPlayerMenuObjectMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/spectatormenu/mixin/UTPlayerMenuObjectMixin.java
@@ -24,7 +24,7 @@ public abstract class UTPlayerMenuObjectMixin
     private GameProfile profile;
 
     @Redirect(method = "renderIcon", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/texture/TextureManager;bindTexture(Lnet/minecraft/util/ResourceLocation;)V"))
-    private void redirectbindTexture(TextureManager textureManager, ResourceLocation resource)
+    private void utRedirectBindTexture(TextureManager textureManager, ResourceLocation resource)
     {
         if (UTConfigBugfixes.MISC.utSpectatorMenuToggle)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/spectatormenu/mixin/UTPlayerMenuObjectMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/spectatormenu/mixin/UTPlayerMenuObjectMixin.java
@@ -1,0 +1,42 @@
+package mod.acgaming.universaltweaks.bugfixes.misc.spectator.mixin;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.spectator.PlayerMenuObject;
+import net.minecraft.client.network.NetworkPlayerInfo;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.util.ResourceLocation;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// MC-125157
+// https://bugs.mojang.com/browse/MC-125157
+// Courtesy of mrgrim
+@Mixin(PlayerMenuObject.class)
+public abstract class UTPlayerMenuObjectMixin
+{
+    @Shadow
+    @Final
+    private GameProfile profile;
+
+    @Redirect(method = "renderIcon", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/texture/TextureManager;bindTexture(Lnet/minecraft/util/ResourceLocation;)V"))
+    private void redirectbindTexture(TextureManager textureManager, ResourceLocation resource)
+    {
+        if (UTConfigBugfixes.MISC.utSpectatorMenuToggle)
+        {
+            final Minecraft mc = Minecraft.getMinecraft();
+            final NetworkPlayerInfo npi = mc.player.connection.getPlayerInfo(this.profile.getName());
+            if (npi != null)
+            {
+                mc.getTextureManager().bindTexture(npi.getLocationSkin());
+            }
+        } else
+        {
+            textureManager.bindTexture(resource);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -327,6 +327,11 @@ public class UTConfigBugfixes
         @Config.Name("Potion Amplifier Visibility")
         @Config.Comment("Fixes potion effects not displaying their level above 'IV'")
         public boolean utPotionAmplifierVisibilityToggle = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Spectator Menu")
+        @Config.Comment("Fixes the spectator menu not showing player skins")
+        public boolean utSpectatorMenuToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Packet Size")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -303,6 +303,11 @@ public class UTConfigBugfixes
         @Config.Name("Blast Protection Knockback")
         @Config.Comment("Fixes the blast protection enchantment not reducing knockback from explosions except at very high levels")
         public boolean utBlastProtectionKnockbackToggle = false;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Crafted Item Statistics")
+        @Config.Comment("Fixes crafted item statistics not increasing correctly when items are crafted with shift-click or drop methods")
+        public boolean utCraftedItemStatisticsToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Depth Mask")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1027,7 +1027,7 @@ public class UTConfigTweaks
 
             @Config.Name("[17] Slowed Movement")
             @Config.Comment("Slows how often item entities update their position to improve performance")
-            public boolean utIEUpdateToggle = true;
+            public boolean utIEUpdateToggle = false;
         }
 
         public static class MendingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -179,6 +179,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.entities.skeletonaim.json");
         configs.add("mixins.bugfixes.entities.suffocation.json");
         configs.add("mixins.bugfixes.entities.tracker.json");
+        configs.add("mixins.bugfixes.misc.crafteditemstatistics.json");
         configs.add("mixins.bugfixes.misc.enchantment.json");
         configs.add("mixins.bugfixes.misc.packetsize.json");
         configs.add("mixins.bugfixes.misc.particlespawning.json");
@@ -355,6 +356,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.BLOCKS.utPistonRetractionToggle;
             case "mixins.bugfixes.blocks.bed.json":
                 return UTConfigBugfixes.BLOCKS.utSleepResetsWeatherToggle;
+            case "mixins.bugfixes.misc.crafteditemstatistics.json":
+                return UTConfigBugfixes.MISC.utCraftedItemStatisticsToggle;
             case "mixins.bugfixes.misc.enchantment.json":
                 return UTConfigBugfixes.MISC.utBlastProtectionKnockbackToggle;
             case "mixins.bugfixes.misc.packetsize.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -114,6 +114,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             configs.add("mixins.bugfixes.misc.modelgap.json");
             configs.add("mixins.bugfixes.misc.potionamplifier.json");
             configs.add("mixins.bugfixes.misc.smoothlighting.json");
+            configs.add("mixins.bugfixes.misc.spectatormenu.json");
             configs.add("mixins.bugfixes.misc.startup.json");
             configs.add("mixins.bugfixes.world.frustumculling.json");
             configs.add("mixins.tweaks.entities.autojump.json");
@@ -280,6 +281,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                     return UTConfigBugfixes.MISC.utPotionAmplifierVisibilityToggle;
                 case "mixins.bugfixes.misc.smoothlighting.json":
                     return UTConfigBugfixes.MISC.utAccurateSmoothLighting;
+                case "mixins.bugfixes.misc.spectatormenu.json":
+                    return UTConfigBugfixes.MISC.utSpectatorMenuToggle;
                 case "mixins.bugfixes.misc.startup.json":
                     return UTConfigTweaks.PERFORMANCE.utFasterBackgroundStartupToggle;
                 case "mixins.bugfixes.world.frustumculling.json":

--- a/src/main/resources/mixins.bugfixes.misc.crafteditemstatistics.json
+++ b/src/main/resources/mixins.bugfixes.misc.crafteditemstatistics.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.misc.crafteditemstatistics.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTSlotCraftingMixin"]
+}

--- a/src/main/resources/mixins.bugfixes.misc.spectatormenu.json
+++ b/src/main/resources/mixins.bugfixes.misc.spectatormenu.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.misc.spectatormenu.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTPlayerMenuObjectMixin"]
+}


### PR DESCRIPTION
More MUP, more fixes.

- **Crafted Item Statistics:** Fixes crafted item statistics not increasing correctly when items are crafted with shift-click or drop methods
- **Spectator Menu:** Fixes the spectator menu not showing player skins
- Set **Slowed Item Entity Movement** to false by default.