### PR TITLE
Fix Effortless Building ignoring Metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ dependencies {
     compileOnly 'curse.maven:tinkerscomplement-272671:2843439'
     compileOnly 'curse.maven:tinyprogressions-250850:2721018'
     compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
+    compileOnly 'curse.maven:effortlessbuilding-302113:2847346'
     // implementation 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
 
     if (project.use_mixins.toBoolean()) {

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -79,6 +79,7 @@ public class UniversalTweaks
         + "after:collective;"
         + "after:compactmachines3;"
         + "after:contenttweaker;"
+        + "after:effortlessbuilding;"
         + "after:element;"
         + "after:elenaidodge2;"
         + "after:enderio;"

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -63,6 +63,10 @@ public class UTConfigMods
     @Config.Name("Compact Machines")
     public static final CompactMachinesCoreCategory COMPACT_MACHINES = new CompactMachinesCoreCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.effortlessbuilding")
+    @Config.Name("Effortless Building")
+    public static final EffortlessBuildingCategory EFFORTLESS_BUILDING = new EffortlessBuildingCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.elementarystaffs")
     @Config.Name("Elementary Staffs")
     public static final ElementaryStaffsCategory ELEMENTARY_STAFFS = new ElementaryStaffsCategory();
@@ -312,6 +316,14 @@ public class UTConfigMods
         @Config.Name("Invisible Wall Render Fix")
         @Config.Comment("Fixes some compact machine walls being invisible if Nothirium 0.2.x (and up) or Vintagium is installed")
         public boolean utCMRenderFixToggle = true;
+    }
+
+    public static class EffortlessBuildingCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Block Transmutation Fix")
+        @Config.Comment("Fixes Effortless Building ignoring Metadata when checking for items in inventory")
+        public boolean utEFTransmutationFixToggle = true;
     }
 
     public static class ElementaryStaffsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -41,6 +41,7 @@ public class UTMixinLoader implements ILateMixinLoader
         configs.add("mixins.mods.cofhcore.json");
         configs.add("mixins.mods.collective.json");
         configs.add("mixins.mods.cqrepoured.json");
+        configs.add("mixins.mods.effortlessbuilding.json");
         configs.add("mixins.mods.elementarystaffs.json");
         configs.add("mixins.mods.elenaidodge2.json");
         configs.add("mixins.mods.epicsiegemod.json");

--- a/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTInventoryHelperMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTInventoryHelperMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.mods.effortlessbuilding.mixin;
+
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import nl.requios.effortlessbuilding.helper.InventoryHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(InventoryHelper.class)
+public class UTInventoryHelperMixin {
+
+    @Inject(method = "findItemStackInInventory", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void utFindItemStackInInventory(EntityPlayer player, Block block, CallbackInfoReturnable<ItemStack> cir) {
+        if (UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle) cir.setReturnValue(ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTSurvivalHelperMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTSurvivalHelperMixin.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.mods.effortlessbuilding.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import nl.requios.effortlessbuilding.helper.SurvivalHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SurvivalHelper.class)
+public class UTSurvivalHelperMixin {
+
+    @Inject(method = "placeBlock", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void utPlaceBlock(World world, EntityPlayer player, BlockPos pos, IBlockState blockState, ItemStack origstack, EnumFacing facing, Vec3d hitVec, boolean skipPlaceCheck, boolean skipCollisionCheck, boolean playSound, CallbackInfoReturnable<Boolean> cir) {
+        if (!UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle) return;
+        int meta = blockState.getBlock().damageDropped(blockState);
+        origstack = ItemStack.EMPTY;
+        for (int i = 0; i < player.inventory.mainInventory.size(); i++) {
+            ItemStack stack = player.inventory.mainInventory.get(i);
+            if (stack.getItem().equals(Item.getItemFromBlock(blockState.getBlock())) && stack.getMetadata() == meta) {
+                origstack = stack;
+                break;
+            }
+        }
+        if (origstack.equals(ItemStack.EMPTY)) cir.setReturnValue(false);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTUndoRedoMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/effortlessbuilding/mixin/UTUndoRedoMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.effortlessbuilding.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import nl.requios.effortlessbuilding.buildmodifier.UndoRedo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(UndoRedo.class)
+public class UTUndoRedoMixin {
+
+    @Inject(method = "findItemStackInInventory", at = @At("HEAD"),  cancellable = true, remap = false)
+    private static void utFindItemStackInInventory(EntityPlayer player, IBlockState blockState, CallbackInfoReturnable<ItemStack> cir) {
+        if (!UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle) return;
+        int meta = blockState.getBlock().damageDropped(blockState);
+        ItemStack stack = ItemStack.EMPTY;
+        for (int i = 0; i < player.inventory.mainInventory.size(); i++) {
+            ItemStack stack1 = player.inventory.mainInventory.get(i);
+            if (stack1.getItem().equals(Item.getItemFromBlock(blockState.getBlock())) && stack1.getMetadata() == meta) {
+                stack = stack1;
+                break;
+            }
+        }
+        cir.setReturnValue(stack);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -54,6 +54,7 @@ cfg.universaltweaks.modintegration.chisel=Chisel
 cfg.universaltweaks.modintegration.cofhcore=CoFH Core
 cfg.universaltweaks.modintegration.compactmachines=Compact Machines
 cfg.universaltweaks.modintegration.cqrepoured=Chocolate Quest Repoured
+cfg.universaltweaks.modintegration.effortlessbuilding=Effortless Building
 cfg.universaltweaks.modintegration.elementarystaffs=Elementary Staffs
 cfg.universaltweaks.modintegration.elenaidodge2=Elenai Dodge 2
 cfg.universaltweaks.modintegration.erebus=The Erebus

--- a/src/main/resources/mixins.mods.effortlessbuilding.json
+++ b/src/main/resources/mixins.mods.effortlessbuilding.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.effortlessbuilding.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTInventoryHelperMixin", "UTSurvivalHelperMixin", "UTUndoRedoMixin"]
+}


### PR DESCRIPTION
This PR adds an fix for Effortless Building which fixes that Effortless Building will ignore Metadata when scanning the inventory.