### PR TITLE
Fix update logic for slowed item entities tweak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     compileOnly 'curse.maven:codechickenlib-242818:2779848'
     compileOnly 'curse.maven:cofhworld-271384:2920434'
     compileOnly 'curse.maven:compactmachines-224218:2707509'
+    compileOnly 'curse.maven:effortlessbuilding-302113:2847346'
     compileOnly 'curse.maven:endercore-231868:2972849'
     compileOnly 'curse.maven:enderio-64578:2989201'
     compileOnly 'curse.maven:extrautilities-225561:2678374'
@@ -197,7 +198,6 @@ dependencies {
     compileOnly 'curse.maven:tinkerscomplement-272671:2843439'
     compileOnly 'curse.maven:tinyprogressions-250850:2721018'
     compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
-    compileOnly 'curse.maven:effortlessbuilding-302113:2847346'
     // implementation 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
 
     if (project.use_mixins.toBoolean()) {

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -139,6 +139,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("collective");
             case "mixins.mods.cqrepoured.json":
                 return Loader.isModLoaded("cqrepoured");
+            case "mixins.mods.effortlessbuilding.json":
+                return Loader.isModLoaded("effortlessbuilding");
             case "mixins.mods.elementarystaffs.json":
                 return Loader.isModLoaded("element");
             case "mixins.mods.elenaidodge2.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/itementities/mixin/UTEntityItemMixin.java
@@ -163,7 +163,8 @@ public abstract class UTEntityItemMixin extends Entity
     @WrapWithCondition(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityItem;move(Lnet/minecraft/entity/MoverType;DDD)V"))
     public boolean utIEOnUpdate(EntityItem instance, MoverType moverType, double dx, double dy, double dz)
     {
+        if (!UTConfigTweaks.ITEMS.ITEM_ENTITIES.utIEUpdateToggle) return true;
         // Run on odd ticks to not skip the '% 25' check
-        return UTConfigTweaks.ITEMS.ITEM_ENTITIES.utIEUpdateToggle && instance.ticksExisted % 2 != 0;
+        return instance.ticksExisted % 2 != 0;
     }
 }


### PR DESCRIPTION
The previous logic was causing no movement updates to items if the tweak was disabled (which is default). Also adds missed loader check for Effortless Building, I believe there are other formatting issues for that mod tweak but I'll leave that to you.