### PR TITLE
Untipped Arrow Particles Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All changes are toggleable via config files.
 * **Sleep Resets Weather:** Fixes sleeping always resetting rain and thunder times
 * **Spectator Menu:** Fixes the spectator menu not showing player skins
 * **Tile Entity Map:** Replaces the chunk position data table to prevent tile entity related issues
+* **Untipped Arrow Particles:** Fixes untipped arrows emitting blue tipped arrow particles upon reloading a world
 * **Villager Mantle:** Returns missing hoods to villager mantles
 * **Witch Huts:** Fixes witch hut structure data not accounting for the height it is generated at
 

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/arrow/mixin/UTEntityTippedArrowMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/arrow/mixin/UTEntityTippedArrowMixin.java
@@ -27,7 +27,7 @@ public abstract class UTEntityTippedArrowMixin
     private Set<PotionEffect> customPotionEffects;
 
     @Redirect(method = "refreshColor", at = @At(value = "INVOKE", target = "Ljava/lang/Integer;valueOf(I)Ljava/lang/Integer;"))
-    public Integer rlmixins_vanillaEntityTippedArrow_refreshColor(int i)
+    public Integer utTippedArrowRefreshColor(int i)
     {
         if (UTConfigBugfixes.ENTITIES.utUntippedArrowParticlesToggle && potion == PotionTypes.EMPTY && customPotionEffects.isEmpty()) return -1;
         return i;

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/arrow/mixin/UTEntityTippedArrowMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/arrow/mixin/UTEntityTippedArrowMixin.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.bugfixes.entities.arrow.mixin;
+
+import net.minecraft.entity.projectile.EntityTippedArrow;
+import net.minecraft.init.PotionTypes;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionType;
+
+import java.util.Set;
+
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// MC-107941
+// https://bugs.mojang.com/browse/MC-107941
+// Courtesy of fonnymunkey
+@Mixin(EntityTippedArrow.class)
+public abstract class UTEntityTippedArrowMixin
+{
+    @Shadow
+    private PotionType potion; 
+    @Shadow
+    @Final
+    private Set<PotionEffect> customPotionEffects;
+
+    @Redirect(method = "refreshColor", at = @At(value = "INVOKE", target = "Ljava/lang/Integer;valueOf(I)Ljava/lang/Integer;"))
+    public Integer rlmixins_vanillaEntityTippedArrow_refreshColor(int i)
+    {
+        if (UTConfigBugfixes.ENTITIES.utUntippedArrowParticlesToggle && potion == PotionTypes.EMPTY && customPotionEffects.isEmpty()) return -1;
+        return i;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -256,6 +256,11 @@ public class UTConfigBugfixes
         @Config.Name("Skeleton Aim")
         @Config.Comment("Fixes skeletons not looking at their targets when strafing")
         public boolean utSkeletonAimToggle = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Untipped Arrow Particles")
+        @Config.Comment("Fixes untipped arrows emitting blue tipped arrow particles upon reloading a world")
+        public boolean utUntippedArrowParticlesToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Villager Mantle Hoods")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -179,6 +179,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.bugfixes.entities.skeletonaim.json");
         configs.add("mixins.bugfixes.entities.suffocation.json");
         configs.add("mixins.bugfixes.entities.tracker.json");
+        configs.add("mixins.bugfixes.entities.untippedarrowparticles.json");
         configs.add("mixins.bugfixes.misc.crafteditemstatistics.json");
         configs.add("mixins.bugfixes.misc.enchantment.json");
         configs.add("mixins.bugfixes.misc.packetsize.json");
@@ -404,6 +405,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigBugfixes.ENTITIES.utEntitySuffocationToggle;
             case "mixins.bugfixes.entities.tracker.json":
                 return UTConfigBugfixes.ENTITIES.utEntityTrackerToggle && !spongeForgeLoaded;
+            case "mixins.bugfixes.entities.untippedarrowparticles.json":
+                return UTConfigBugfixes.ENTITIES.utUntippedArrowParticlesToggle;
             case "mixins.bugfixes.world.chunksaving.json":
                 return UTConfigBugfixes.WORLD.utChunkSavingToggle && !spongeForgeLoaded;
             case "mixins.bugfixes.world.tileentities.json":

--- a/src/main/resources/mixins.bugfixes.entities.untippedarrowparticles.json
+++ b/src/main/resources/mixins.bugfixes.entities.untippedarrowparticles.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.entities.arrow.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEntityTippedArrowMixin"]
+}


### PR DESCRIPTION
Fixes [MC-107941](https://bugs.mojang.com/browse/MC-107941) - Shooting, summoning or editing an arrow and reloading the world gives potion particles.