### PR TITLE
use proper crafttweaker partial nbt matching code

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/itemstages/mixin/UTStageCompareMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/itemstages/mixin/UTStageCompareMixin.java
@@ -19,7 +19,7 @@ public class UTStageCompareMixin
         if (!UTConfigMods.ITEM_STAGES.utIngredientMatching) return;
         if (second instanceof ItemStack)
         {
-            cir.setReturnValue(CraftTweakerMC.matches(CraftTweakerMC.getIItemStackForMatching(entryStack), (ItemStack) second));
+            cir.setReturnValue(CraftTweakerMC.getIItemStackForMatching(((ItemStack) second)).matches(CraftTweakerMC.getIItemStackForMatching(entryStack)));
         }
     }
 }


### PR DESCRIPTION
It seems that `CraftTweakerMC#matches` is a deprecated method, it doesn't implement partial nbt matching properly. The method is only be used once in oredict in CraftTweaker project. This PR changes to `IItemStack#matches`, which is widely used.
Fixes #402 