### PR TITLE
"Disable Narration" default cfg change

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1225,7 +1225,7 @@ public class UTConfigTweaks
         @Config.RequiresMcRestart
         @Config.Name("Disable Narrator")
         @Config.Comment("Disables the narrator functionality entirely")
-        public boolean utDisableNarratorToggle = true;
+        public boolean utDisableNarratorToggle = false;
 
         @Config.RequiresMcRestart
         @Config.Name("End Portal Parallax")


### PR DESCRIPTION
Narration is a vanilla accessibility option that allows for those who need it to enable an audio screen reader while playing the game. 

The UT option "Disable Narration" completely disables this option, preventing users from enabling it and toggling through its options (Shows "Not Available") 

The current default option is "true", which means if a modpack dev includes UT in a modpack and does not switch this option to "false", then this option remains inaccessible to players, potentially preventing those who need this accessibility option from being able to fully enjoy the game. 

By changing the default option to "false", modpack devs will have to consciously and deliberately disable it. Otherwise, it remains accessible to players by default.