### PR TITLE
Adds config to disable AbyssalCraft plague potion clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ All changes are toggleable via config files.
 
 * **AbyssalCraft**
     * **Optimized Item Transport:** Optimizes AbyssalCraft's item transport system to reduce tick overhead
+    * **Disable Plague Potion Clouds:** Disables AbyssalCraft's Plague-type mobs spawning lingering potion effects on death
 * **Actually Additions**
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Advent of Ascension**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -209,6 +209,10 @@ public class UTConfigMods
         @Config.Name("Optimized Item Transport")
         @Config.Comment("Optimizes AbyssalCraft's item transport system to reduce tick overhead")
         public boolean utOptimizedItemTransferToggle = true;
+
+        @Config.Name("Disable Plague Potion Clouds")
+        @Config.Comment("Disables AbyssalCraft's Plague-type mobs spawning lingering potion effects on death")
+        public boolean utDisablePlaguePotionClouds = false;
     }
 
     public static class ActuallyAdditionsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTPlagueEventHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/abyssalcraft/mixin/UTPlagueEventHandlerMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.mods.abyssalcraft.mixin;
+
+import com.shinoow.abyssalcraft.common.handlers.PlagueEventHandler;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = PlagueEventHandler.class, remap = false)
+public class UTPlagueEventHandlerMixin
+{
+    @Inject(method = "onDeath", at = @At(value = "HEAD"), cancellable = true)
+    private void utOnDeath(LivingDeathEvent event, CallbackInfo ci)
+    {
+        if (!UTConfigMods.ABYSSALCRAFT.utDisablePlaguePotionClouds) return;
+        ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.mods.abyssalcraft.json
+++ b/src/main/resources/mixins.mods.abyssalcraft.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTItemConfiguratorMixin", "UTItemTransferEventHandlerMixin"]
+  "mixins": ["UTItemConfiguratorMixin", "UTItemTransferEventHandlerMixin", "UTPlagueEventHandlerMixin"]
 }


### PR DESCRIPTION
- implements #417 via cancelling `PlagueEventHandler#onDeath` if the config is true.
- config defaults to `false`.