### PR TITLE
Config to Disable Rendering Items in Smeltery

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Insolator Custom Monoculture:** Adds Monoculture Cycle integration to desired phytogenic insolator recipes added by ModTweaker
 * **Tinkers' Construct**
+    * **Disable Rendering Items in Smeltery:** Disables rendering items in the world when they are inside the Smeltery to prevent lag while rendering
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Gaseous Fluids:** Excludes gaseous fluids from being transferable via faucets
     * **Material Blacklist:** Hides tool/bow materials in the 'Materials and You' book

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -790,6 +790,10 @@ public class UTConfigMods
         @Config.Comment("Excludes gaseous fluids from being transferable via faucets")
         public boolean utTConGaseousFluidsToggle = false;
 
+        @Config.Name("Disable Rendering Items in Smeltery")
+        @Config.Comment("Disables rendering items in the world when they are inside the Smeltery to prevent lag while rendering")
+        public boolean utDisableItemRenderingSmeltery = false;
+
         @Config.RequiresMcRestart
         @Config.Name("Material Blacklist")
         @Config.Comment

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -790,9 +790,14 @@ public class UTConfigMods
         @Config.Comment("Excludes gaseous fluids from being transferable via faucets")
         public boolean utTConGaseousFluidsToggle = false;
 
-        @Config.Name("Disable Rendering Items in Smeltery")
-        @Config.Comment("Disables rendering items in the world when they are inside the Smeltery to prevent lag while rendering")
-        public boolean utDisableItemRenderingSmeltery = false;
+        @Config.Name("Maximum Items to Render in Smeltery")
+        @Config.Comment
+            ({
+                "Determines the maximum number of possible items to display before not rendering any to prevent substantial lag",
+                "0 to disable rendering items in the smeltery entirely",
+                "-1 for the default, which is always rendering items"
+            })
+        public int utMaximumItemRendersInSmeltery = -1;
 
         @Config.RequiresMcRestart
         @Config.Name("Material Blacklist")

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/SmelteryRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/SmelteryRendererMixin.java
@@ -9,14 +9,18 @@ import slimeknights.tconstruct.smeltery.client.SmelteryRenderer;
 import slimeknights.tconstruct.smeltery.client.SmelteryTankRenderer;
 import slimeknights.tconstruct.smeltery.tileentity.TileSmeltery;
 
+import javax.annotation.Nonnull;
+
 // Courtesy of WaitingIdly
 @Mixin(value = SmelteryRenderer.class, remap = false)
 public abstract class SmelteryRendererMixin extends SmelteryTankRenderer<TileSmeltery>
 {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lslimeknights/tconstruct/smeltery/client/SmelteryRenderer;renderFluids(Lslimeknights/tconstruct/library/smeltery/SmelteryTank;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;DDD)V", shift = At.Shift.AFTER), cancellable = true)
-    public void utRender(CallbackInfo ci)
+    public void utRender(@Nonnull TileSmeltery smeltery, double x, double y, double z, float partialTicks, int destroyStage, float alpha, CallbackInfo ci)
     {
-        if (!UTConfigMods.TINKERS_CONSTRUCT.utDisableItemRenderingSmeltery) return;
-        ci.cancel();
+        if (UTConfigMods.TINKERS_CONSTRUCT.utMaximumItemRendersInSmeltery == -1) return;
+        if (smeltery.getSizeInventory() > UTConfigMods.TINKERS_CONSTRUCT.utMaximumItemRendersInSmeltery) {
+            ci.cancel();
+        }
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/SmelteryRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/SmelteryRendererMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import slimeknights.tconstruct.smeltery.client.SmelteryRenderer;
+import slimeknights.tconstruct.smeltery.client.SmelteryTankRenderer;
+import slimeknights.tconstruct.smeltery.tileentity.TileSmeltery;
+
+// Courtesy of WaitingIdly
+@Mixin(value = SmelteryRenderer.class, remap = false)
+public abstract class SmelteryRendererMixin extends SmelteryTankRenderer<TileSmeltery>
+{
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lslimeknights/tconstruct/smeltery/client/SmelteryRenderer;renderFluids(Lslimeknights/tconstruct/library/smeltery/SmelteryTank;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;DDD)V", shift = At.Shift.AFTER), cancellable = true)
+    public void utRender(CallbackInfo ci)
+    {
+        if (!UTConfigMods.TINKERS_CONSTRUCT.utDisableItemRenderingSmeltery) return;
+        ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.mods.tconstruct.json
+++ b/src/main/resources/mixins.mods.tconstruct.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["MaterialAccessor", "UTEntityProjectileBaseMixin", "UTFaucetMixin", "UTLongSwordMixin", "UTRapierMixin"]
+  "mixins": ["MaterialAccessor", "UTEntityProjectileBaseMixin", "UTFaucetMixin", "UTLongSwordMixin", "UTRapierMixin", "SmelteryRendererMixin"]
 }


### PR DESCRIPTION
- implements #419 via adding a config to stop the `render` function after it runs `renderFluids`. 
- config defaults to `-1`, which is the default behavior
- it could also make sense to make the default value be a high but unobtrusive number, such as `1000`, which would reduce the ability to have extreme lag.