### PR TITLE
Fix Laser Upgrade Voiding with size == 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ All changes are toggleable via config files.
     * **Optimized Item Transport:** Optimizes AbyssalCraft's item transport system to reduce tick overhead
 * **Actually Additions**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Laser Upgrade Voiding:** Fixes Laser Upgrades voiding instead of applying if there is only one item in the stack
 * **Advent of Ascension**
     * **Improved Player Tick:** Improves AoA player ticking by only sending inventory changes when necessary
 * **Arcane Archives**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -217,6 +217,10 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.Name("Laser Upgrade Voiding")
+        @Config.Comment("Fixes Laser Upgrades voiding instead of applying if there is only one item in the stack")
+        public boolean utLaserUpgradeVoid = true;
     }
 
     public static class ArcaneArchivesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -29,6 +29,7 @@ public class UTMixinLoader implements ILateMixinLoader
         configs.add("mixins.mods.aoa3.json");
         configs.add("mixins.mods.abyssalcraft.json");
         configs.add("mixins.mods.actuallyadditions.dupes.json");
+        configs.add("mixins.mods.actuallyadditions.json");
         configs.add("mixins.mods.arcanearchives.dupes.json");
         configs.add("mixins.mods.biomesoplenty.json");
         configs.add("mixins.mods.bloodmagic.dupes.json");
@@ -117,6 +118,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("abyssalcraft");
             case "mixins.mods.actuallyadditions.dupes.json":
                 return Loader.isModLoaded("actuallyadditions") && UTConfigMods.ACTUALLY_ADDITIONS.utDuplicationFixesToggle;
+            case "mixins.mods.actuallyadditions.json":
+                return Loader.isModLoaded("actuallyadditions");
             case "mixins.mods.arcanearchives.dupes.json":
                 return Loader.isModLoaded("arcanearchives") && UTConfigMods.ARCANE_ARCHIVES.utDuplicationFixesToggle;
             case "mixins.mods.biomesoplenty.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/mixin/UTBlockLaserRelayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/mixin/UTBlockLaserRelayMixin.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.mods.actuallyadditions.mixin;
+
+import de.ellpeck.actuallyadditions.mod.blocks.BlockLaserRelay;
+import de.ellpeck.actuallyadditions.mod.tile.TileEntityLaserRelay;
+import de.ellpeck.actuallyadditions.mod.util.StackUtil;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlockLaserRelay.class, remap = false)
+public abstract class UTBlockLaserRelayMixin
+{
+    @Inject(method = "onBlockActivated", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isCreative()Z"))
+    public void utOnBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing par6, float par7, float par8, float par9, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigMods.ACTUALLY_ADDITIONS.utLaserUpgradeVoid) return;
+        TileEntity tile = world.getTileEntity(pos);
+        if (tile instanceof TileEntityLaserRelay) {
+            ItemStack stack = player.getHeldItem(hand);
+            ItemStack set = stack.copy();
+            set.setCount(1);
+            ((TileEntityLaserRelay) tile).inv.setStackInSlot(0, set);
+            if (!player.isCreative()) {
+                player.setHeldItem(hand, StackUtil.shrink(stack, 1));
+            }
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/mixins.mods.actuallyadditions.json
+++ b/src/main/resources/mixins.mods.actuallyadditions.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.actuallyadditions.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBlockLaserRelayMixin"]
+}


### PR DESCRIPTION
- implements a fix for https://github.com/ACGaming/UniversalTweaks/discussions/421 via injecting into right before the isCreative check and cancelling (returning true) if the config is true.
- config defaults to `true`, as this is a straightforward voiding bugfix.