### PR TITLE
adds advanced Trample Control functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ All changes are toggleable via config files.
 * **Tidy Chunk:** Tidies newly generated chunks by removing scattered item entities
 * **Toast Control:** Enables the control of toasts (pop-up text boxes)
 * **Toggle Cheats Button:** Adds a button to the pause menu to toggle cheats
+* **Trample Control:** Controls how and when farmland is trampled
 * **Uncap FPS:** Removes the hardcoded 30 FPS limit in screens like the main menu
 * **Undead Horses**
     * **Burning:** Lets untamed undead horses burn in daylight

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -63,6 +63,16 @@ public class UTConfigTweaks
         HARD
     }
 
+    public enum TrampleOptions
+    {
+        DEFAULT,
+        NEVER,
+        ONLY_PLAYER,
+        NOT_PLAYER,
+        NOT_PLAYER_RESPECTS_MOB_GRIEFING,
+        FEATHER_FALLING
+    }
+
     public enum EnumBeacon
     {
         MODIFIER(false, true),
@@ -113,6 +123,19 @@ public class UTConfigTweaks
         @Config.Name("Better Harvest")
         @Config.Comment("Prevents breaking lower parts of sugar cane and cacti as well as unripe crops, unless sneaking")
         public boolean utBetterHarvestToggle = false;
+
+        @Config.Name("Farmland Trample")
+        @Config.Comment
+            ({
+                "Controls how farmland can be trampled and turning it into dirt",
+                "Default: Farmland is trampled as normal",
+                "Never: Farmland is never trampled",
+                "Only Player: Farmland is only possible to trample by an EntityPlayer",
+                "Not Player: Farmland is only possible to trample by a non-EntityPlayer",
+                "Not Player Respect Mob Griefing: Farmland is only possible to trample by a non-EntityPlayer, if the mobGriefing gamerule is false",
+                "Feather Falling: Farmland is trampled if the entity does not have the Feather Falling enchantment on equipped boots",
+            })
+        public TrampleOptions utFarmlandTrample = TrampleOptions.DEFAULT;
 
         @Config.RequiresMcRestart
         @Config.Name("Block Hit Delay")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -127,13 +127,13 @@ public class UTConfigTweaks
         @Config.Name("Farmland Trample")
         @Config.Comment
             ({
-                "Controls how farmland can be trampled and turning it into dirt",
-                "Default: Farmland is trampled as normal",
-                "Never: Farmland is never trampled",
-                "Only Player: Farmland is only possible to trample by an EntityPlayer",
-                "Not Player: Farmland is only possible to trample by a non-EntityPlayer",
-                "Not Player Respect Mob Griefing: Farmland is only possible to trample by a non-EntityPlayer, if the mobGriefing gamerule is false",
-                "Feather Falling: Farmland is trampled if the entity does not have the Feather Falling enchantment on equipped boots",
+                "Controls when and if farmland can be trampled into dirt",
+                "Default: Farmland is trampled normally (vanilla default)",
+                "Never: Farmland can never be trampled",
+                "Only Player: Prevents farmland from being trampled by a non-EntityPlayer",
+                "Not Player: Prevents farmland from being trampled by an EntityPlayer",
+                "Not Player Respects Mob Griefing: Prevents farmland from being trampled by a non-EntityPlayer if the mobGriefing gamerule is false",
+                "Feather Falling: Prevents farmland from being trampled if the entity has the Feather Falling enchantment on equipped boots",
             })
         public TrampleOptions utFarmlandTrample = TrampleOptions.DEFAULT;
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -69,7 +69,6 @@ public class UTConfigTweaks
         NEVER,
         ONLY_PLAYER,
         NOT_PLAYER,
-        NOT_PLAYER_RESPECTS_MOB_GRIEFING,
         FEATHER_FALLING
     }
 
@@ -132,7 +131,6 @@ public class UTConfigTweaks
                 "Never: Farmland can never be trampled",
                 "Only Player: Prevents farmland from being trampled by a non-EntityPlayer",
                 "Not Player: Prevents farmland from being trampled by an EntityPlayer",
-                "Not Player Respects Mob Griefing: Prevents farmland from being trampled by a non-EntityPlayer if the mobGriefing gamerule is false",
                 "Feather Falling: Prevents farmland from being trampled if the entity has the Feather Falling enchantment on equipped boots",
             })
         public TrampleOptions utFarmlandTrample = TrampleOptions.DEFAULT;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/farmlandtrample/UTFarmlandTrample.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/farmlandtrample/UTFarmlandTrample.java
@@ -1,0 +1,51 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.farmlandtrample;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Enchantments;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+// Courtesy of WaitingIdly
+@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)
+public class UTFarmlandTrample
+{
+    @SubscribeEvent
+    public static void utFarmlandTrample(BlockEvent.FarmlandTrampleEvent event)
+    {
+         switch (UTConfigTweaks.BLOCKS.utFarmlandTrample)
+        {
+            case DEFAULT:
+                break;
+            case NEVER:
+                event.setCanceled(true);
+                break;
+            case ONLY_PLAYER:
+                if (event.getEntity() instanceof EntityPlayer) break;
+                event.setCanceled(true);
+                break;
+            case NOT_PLAYER:
+                if (event.getEntity() instanceof EntityPlayer) event.setCanceled(true);
+                break;
+            case NOT_PLAYER_RESPECTS_MOB_GRIEFING:
+                if (event.getEntity() instanceof EntityPlayer || event.getWorld().getGameRules().getBoolean("mobGriefing")) break;
+                event.setCanceled(true);
+                break;
+            case FEATHER_FALLING:
+                if (Enchantments.FEATHER_FALLING == null) break;
+                for (ItemStack slot : event.getEntity().getArmorInventoryList())
+                {
+                    if (slot.getItem() instanceof ItemArmor && ((ItemArmor) slot.getItem()).armorType == EntityEquipmentSlot.FEET && EnchantmentHelper.getEnchantmentLevel(Enchantments.FEATHER_FALLING, slot) >= 1)
+                    {
+                        event.setCanceled(true);
+                    }
+                }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/farmlandtrample/UTFarmlandTrample.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/farmlandtrample/UTFarmlandTrample.java
@@ -33,10 +33,6 @@ public class UTFarmlandTrample
             case NOT_PLAYER:
                 if (event.getEntity() instanceof EntityPlayer) event.setCanceled(true);
                 break;
-            case NOT_PLAYER_RESPECTS_MOB_GRIEFING:
-                if (event.getEntity() instanceof EntityPlayer || event.getWorld().getGameRules().getBoolean("mobGriefing")) break;
-                event.setCanceled(true);
-                break;
             case FEATHER_FALLING:
                 if (Enchantments.FEATHER_FALLING == null) break;
                 for (ItemStack slot : event.getEntity().getArmorInventoryList())

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -115,7 +115,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("tconfixes")) messages.add("TConFixes");
         if (Loader.isModLoaded("tidychunk") && UTConfigTweaks.WORLD.utTidyChunkToggle) messages.add("TidyChunk");
         if (Loader.isModLoaded("tinkersoredictcache") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) messages.add("TinkersOreDictCache");
-        if (Loader.isModLoaded("tramplestopper") && UTConfigTweaks.BLOCKS.utFarmlandTrample != UTConfigTweaks.TrampleOptions.DEFAULT) messages.add("TrampleStopper");
+        if (Loader.isModLoaded("tramplestopper")) messages.add("TrampleStopper");
         if (Loader.isModLoaded("toastcontrol") && UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle) messages.add("Toast Control");
         if (Loader.isModLoaded("unloader") && UTConfigTweaks.WORLD.DIMENSION_UNLOAD.utUnloaderToggle) messages.add("Unloader");
         if (Loader.isModLoaded("villagermantlefix") && UTConfigBugfixes.ENTITIES.utVillagerMantleToggle) messages.add("Villager Mantle Fix");

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -115,6 +115,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("tconfixes")) messages.add("TConFixes");
         if (Loader.isModLoaded("tidychunk") && UTConfigTweaks.WORLD.utTidyChunkToggle) messages.add("TidyChunk");
         if (Loader.isModLoaded("tinkersoredictcache") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) messages.add("TinkersOreDictCache");
+        if (Loader.isModLoaded("tramplestopper") && UTConfigTweaks.BLOCKS.utFarmlandTrample != UTConfigTweaks.TrampleOptions.DEFAULT) messages.add("TrampleStopper");
         if (Loader.isModLoaded("toastcontrol") && UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle) messages.add("Toast Control");
         if (Loader.isModLoaded("unloader") && UTConfigTweaks.WORLD.DIMENSION_UNLOAD.utUnloaderToggle) messages.add("Unloader");
         if (Loader.isModLoaded("villagermantlefix") && UTConfigBugfixes.ENTITIES.utVillagerMantleToggle) messages.add("Villager Mantle Fix");


### PR DESCRIPTION
adds the ability to control when farmland is trampled, with multiple different options, being: `DEFAULT`, `NEVER`, `ONLY_PLAYER`, `NOT_PLAYER`, `NOT_PLAYER_RESPECTS_MOB_GRIEFING`, `FEATHER_FALLING`.
the names are quite descriptive. 
also adds the modid `tramplestopper` to obsolete list, and there may be others that i couldnt find that implement similar features.
[Stronger Farmland](https://www.curseforge.com/minecraft/mc-mods/stronger-farmland) has a similar feature, but only prevents certain entities from trampling hydrated farmland.