### PR TITLE
allow placing unsupported pumpkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ All changes are toggleable via config files.
 * **Overlay Message Height:** Sets the Y value of the overlay message (action bar), displayed for playing records etc.
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
+* **Pumpkin Placing:** Allows placing Pumpkins without a supporting block
 * **Rabbit Killer Spawning:** Configurable chance for rabbits to spawn as the killer bunny variant
 * **Rabbit Toast Spawning:** Configurable chance for rabbits to spawn as the Toast variant
 * **Rally Health:** Adds Bloodborne's Rally system to Minecraft, regain lost health when attacking back within the risk time

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ All changes are toggleable via config files.
 * **Overlay Message Height:** Sets the Y value of the overlay message (action bar), displayed for playing records etc.
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
-* **Pumpkin Placing:** Allows placing Pumpkins without a supporting block
+* **Pumpkin Placing:** Allows placing Pumpkins and Jack'O'Lanterns without a supporting block
 * **Rabbit Killer Spawning:** Configurable chance for rabbits to spawn as the killer bunny variant
 * **Rabbit Toast Spawning:** Configurable chance for rabbits to spawn as the Toast variant
 * **Rally Health:** Adds Bloodborne's Rally system to Minecraft, regain lost health when attacking back within the risk time

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -175,7 +175,7 @@ public class UTConfigTweaks
         public boolean utLenientPathsToggle = true;
 
         @Config.Name("Unsupported Pumpkin Placing")
-        @Config.Comment("Allows placing Pumpkins without a supporting block")
+        @Config.Comment("Allows placing Pumpkins and Jack'O'Lanterns without a supporting block")
         public boolean utUnsupportedPumpkinPlacing = false;
 
         @Config.RequiresMcRestart

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -174,6 +174,10 @@ public class UTConfigTweaks
         @Config.Comment("Allows the creation of grass paths everywhere (beneath fence gates, trapdoors, ...)")
         public boolean utLenientPathsToggle = true;
 
+        @Config.Name("Unsupported Pumpkin Placing")
+        @Config.Comment("Allows placing Pumpkins without a supporting block")
+        public boolean utUnsupportedPumpkinPlacing = false;
+
         @Config.RequiresMcRestart
         @Config.Name("Sugar Cane Size")
         @Config.Comment("Determines how tall sugar cane can grow")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -199,6 +199,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.blocks.leafdecay.json");
         configs.add("mixins.tweaks.blocks.lenientpaths.json");
         configs.add("mixins.tweaks.blocks.overhaulbeacon.json");
+        configs.add("mixins.tweaks.blocks.pumpkinplacing.json");
         configs.add("mixins.tweaks.blocks.sapling.json");
         configs.add("mixins.tweaks.entities.ai.json");
         configs.add("mixins.tweaks.entities.ai.saddledwandering.json");
@@ -442,6 +443,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.BLOCKS.utLenientPathsToggle;
             case "mixins.tweaks.blocks.overhaulbeacon.json":
                 return UTConfigTweaks.BLOCKS.OVERHAUL_BEACON.utOverhaulBeaconToggle;
+            case "mixins.tweaks.blocks.pumpkinplacing.json":
+                return UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing;
             case "mixins.tweaks.blocks.sapling.json":
                 return UTConfigTweaks.BLOCKS.SAPLING_BEHAVIOR.utSaplingBehaviorToggle;
             case "mixins.tweaks.entities.ai.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/pumpkinplacing/mixin/UTUnsupportedPumpkinPlacing.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/pumpkinplacing/mixin/UTUnsupportedPumpkinPlacing.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.pumpkinplacing.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.block.BlockPumpkin;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = BlockPumpkin.class)
+public abstract class UTUnsupportedPumpkinPlacing
+{
+    @Inject(method = "canPlaceBlockAt", at = @At(value = "HEAD"), cancellable = true)
+    public void utUnsupportedPlacingOverride(World worldIn, BlockPos pos, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing) return;
+        cir.setReturnValue(worldIn.getBlockState(pos).getBlock().isReplaceable(worldIn, pos));
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -101,6 +101,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("pathundergates") && UTConfigTweaks.BLOCKS.utLenientPathsToggle) messages.add("Path Under Gates");
         if (Loader.isModLoaded("pickupnotifier") && UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) messages.add("Pick Up Notifier");
         if (Loader.isModLoaded("portaldupebegone") && UTConfigBugfixes.WORLD.utPortalTravelingDupeToggle) messages.add("PortalDupeBegone");
+        if (Loader.isModLoaded("ppa") && UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing) messages.add("PlacePumpkinAnywhere");
         if (Loader.isModLoaded("preventghost") && UTConfigBugfixes.BLOCKS.MINING_GLITCH.utMiningGlitchToggle) messages.add("Prevent Ghost Blocks");
         if (Loader.isModLoaded("quickleafdecay") && UTConfigTweaks.BLOCKS.utLeafDecayToggle) messages.add("Quick Leaf Decay");
         if (Loader.isModLoaded("rallyhealth") && UTConfigTweaks.ENTITIES.RALLY_HEALTH.utRallyHealthToggle) messages.add("Rally Health");

--- a/src/main/resources/mixins.tweaks.blocks.pumpkinplacing.json
+++ b/src/main/resources/mixins.tweaks.blocks.pumpkinplacing.json
@@ -1,0 +1,9 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.pumpkinplacing.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "UTUnsupportedPumpkinPlacing"
+  ]
+}


### PR DESCRIPTION
adds the ability to place pumpkins without needing a supporting block below
marks a mod which adds this ability this as obsolete
brought up here https://github.com/ACGaming/UniversalTweaks/discussions/97