### PR TITLE
allow placing End Crystals on any block

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ All changes are toggleable via config files.
 * **Disable Villager Trade Restock:** Disables restocking of villager trades, only allowing one trade per offer
 * **Disable Wither Targeting AI:** Disables withers targeting animals
 * **Easy Breeding:** Enables easy breeding of animals by tossing food on the ground
+* **End Crystal Placing:** Allows placing End Crystals without requiring Obsidian or Bedrock below
 * **End Portal Parallax:** Re-implements parallax rendering of the end portal from 1.11 and older
 * **Explosion Block Drop Chance:** Determines the numerator of the block drop formula on explosions
 * **Falling Block Lifespan:** Determines how long falling blocks remain in ticks until they are dropped under normal circumstances

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -179,6 +179,11 @@ public class UTConfigTweaks
         public boolean utUnsupportedPumpkinPlacing = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("End Crystal Placing")
+        @Config.Comment("Allows placing End Crystals without requiring Obsidian or Bedrock below")
+        public boolean utEndCrystalAnywherePlacing = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Sugar Cane Size")
         @Config.Comment("Determines how tall sugar cane can grow")
         public int utSugarCaneSize = 3;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -200,6 +200,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.blocks.lenientpaths.json");
         configs.add("mixins.tweaks.blocks.overhaulbeacon.json");
         configs.add("mixins.tweaks.blocks.pumpkinplacing.json");
+        configs.add("mixins.tweaks.blocks.endcrystal.json");
         configs.add("mixins.tweaks.blocks.sapling.json");
         configs.add("mixins.tweaks.entities.ai.json");
         configs.add("mixins.tweaks.entities.ai.saddledwandering.json");
@@ -445,6 +446,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.BLOCKS.OVERHAUL_BEACON.utOverhaulBeaconToggle;
             case "mixins.tweaks.blocks.pumpkinplacing.json":
                 return UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing;
+            case "mixins.tweaks.blocks.endcrystal.json":
+                return UTConfigTweaks.BLOCKS.utEndCrystalAnywherePlacing;
             case "mixins.tweaks.blocks.sapling.json":
                 return UTConfigTweaks.BLOCKS.SAPLING_BEHAVIOR.utSaplingBehaviorToggle;
             case "mixins.tweaks.entities.ai.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endcrystal/mixin/UTEndCrystalPlacing.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endcrystal/mixin/UTEndCrystalPlacing.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.endcrystal.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemEndCrystal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemEndCrystal.class)
+public abstract class UTEndCrystalPlacing
+{
+    // Pretend every block is Obsidian when trying to place
+    @ModifyExpressionValue(method = "onItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/IBlockState;getBlock()Lnet/minecraft/block/Block;", ordinal = 0))
+    public Block utEndCrystalPlacingOverride(Block original)
+    {
+        if (!UTConfigTweaks.BLOCKS.utEndCrystalAnywherePlacing) return original;
+        return Blocks.OBSIDIAN;
+    }
+}

--- a/src/main/resources/mixins.tweaks.blocks.endcrystal.json
+++ b/src/main/resources/mixins.tweaks.blocks.endcrystal.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.endcrystal.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEndCrystalPlacing"]
+}


### PR DESCRIPTION
adds the ability to place End Crystals without needing either Obsidian or Bedrock below it. keeps the rest of the placement logic.
does this by telling minecraft that actually, every block is Obsidian for the first check.
the mod `placeableendcrystals`, linked in the discussion, also enacts a similar change, but as it adds more features, i havent placed it in the Obsolete Mods list.
brought up here https://github.com/ACGaming/UniversalTweaks/discussions/97
