### PR TITLE
prevent keybinds from overflowing left side of GUI

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1243,6 +1243,11 @@ public class UTConfigTweaks
         public boolean utLANServerProperties = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Prevent Keybinds from Overflowing Screen")
+        @Config.Comment("Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present")
+        public boolean utPreventKeybindingEntryOverflow = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Compact Messages")
         @Config.Comment("Removes duplicate messages and instead put a number behind the message how often it was repeated")
         public boolean utCompactMessagesToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -128,6 +128,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             configs.add("mixins.tweaks.misc.commands.seed.json");
             configs.add("mixins.tweaks.misc.credits.json");
             configs.add("mixins.tweaks.misc.difficulty.client.json");
+            configs.add("mixins.tweaks.misc.gui.keybindlistentry.json");
             configs.add("mixins.tweaks.misc.gui.lanserverproperties.json");
             configs.add("mixins.tweaks.misc.gui.overlaymessage.json");
             configs.add("mixins.tweaks.misc.gui.potionduration.json");
@@ -312,6 +313,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                     return UTConfigTweaks.MISC.utCopyWorldSeedToggle;
                 case "mixins.tweaks.misc.credits.json":
                     return UTConfigTweaks.MISC.utSkipCreditsToggle;
+                case "mixins.tweaks.misc.gui.keybindlistentry.json":
+                    return UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow;
                 case "mixins.tweaks.misc.gui.lanserverproperties.json":
                     return UTConfigTweaks.MISC.utLANServerProperties;
                 case "mixins.tweaks.misc.gui.overlaymessage.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/keybindlist/mixin/UTKeyEntryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/keybindlist/mixin/UTKeyEntryMixin.java
@@ -1,0 +1,17 @@
+package mod.acgaming.universaltweaks.tweaks.misc.gui.keybindlist.mixin;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiKeyBindingList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = GuiKeyBindingList.KeyEntry.class)
+public abstract class UTKeyEntryMixin
+{
+    @Redirect(method = "drawEntry", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I"))
+    public int utIndentEntryText(FontRenderer f, String text, int x, int y, int color)
+    {
+        return f.drawString(text, Math.max(x, 5), y, color);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -75,6 +75,7 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("ikwid") && UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle) messages.add("I Know What I'm Doing");
         if (Loader.isModLoaded("insomniac") && UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle) messages.add("Insomniac");
         if (Loader.isModLoaded("inventoryspam") && UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) messages.add("Inventory Spam");
+        if (Loader.isModLoaded("keydescfix") && UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow) messages.add("Keybind Description Fix");
         if (Loader.isModLoaded("lanserverproperties") && UTConfigTweaks.MISC.utLANServerProperties) messages.add("LAN Server Properties");
         if (Loader.isModLoaded("leafdecay") && UTConfigTweaks.BLOCKS.utLeafDecayToggle) messages.add("Leaf Decay Accelerator");
         if (Loader.isModLoaded("letmedespawn") && UTConfigTweaks.ENTITIES.utMobDespawnToggle) messages.add("Let Me Despawn");

--- a/src/main/resources/mixins.tweaks.misc.gui.keybindlistentry.json
+++ b/src/main/resources/mixins.tweaks.misc.gui.keybindlistentry.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.gui.keybindlist.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTKeyEntryMixin"]
+}


### PR DESCRIPTION
always indent the keybind name slightly in from the page border. uses 5 because 20, as in the obsolete mod, seemed unneeded and too much indentation on small screens set to large GUI.
option is `true` by default
marks `keydescfix` as obsolete
as discussed in https://github.com/ACGaming/UniversalTweaks/discussions/57