### PR TITLE
Disable Mob Spawner Entity Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ All changes are toggleable via config files.
 * **Disable Audio Debug:** Improves loading times by removing debug code for missing sounds and subtitles
 * **Disable Creeper Music Discs:** Disables creepers dropping music discs when slain by skeletons
 * **Disable Fancy Missing Model:** Improves rendering performance by removing the resource location text on missing models
+* **Disable Mob Spawner Entity Render:** Disables rendering an entity inside of Mob Spawners
 * **Disable Narrator:** Disables the narrator functionality entirely
 * **Disable Sleeping:** Disables skipping night by using a bed while making it still able to set spawn
 * **Disable Villager Trade Leveling:** Disables leveling of villager careers, only allowing base level trades

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1702,6 +1702,11 @@ public class UTConfigTweaks
         public boolean utDisableFancyMissingModelToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Disable Mob Spawner Entity")
+        @Config.Comment("Improves rendering performance by disabling rendering the entity inside mob spawners")
+        public boolean utDisableMobSpawnerRendering = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Faster Background Startup")
         @Config.Comment("Fixes slow background startup edge case caused by checking tooltips during the loading process")
         public boolean utFasterBackgroundStartupToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -142,6 +142,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             configs.add("mixins.tweaks.performance.audioreload.json");
             configs.add("mixins.tweaks.performance.fps.json");
             configs.add("mixins.tweaks.performance.missingmodel.json");
+            configs.add("mixins.tweaks.performance.mobspawnerrender.json");
             configs.add("mixins.tweaks.performance.resourcemanager.json");
             configs.add("mixins.tweaks.world.loading.client.json");
         }
@@ -341,6 +342,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                     return UTConfigTweaks.PERFORMANCE.utUncapFPSToggle;
                 case "mixins.tweaks.performance.missingmodel.json":
                     return UTConfigTweaks.PERFORMANCE.utDisableFancyMissingModelToggle;
+                case "mixins.tweaks.performance.mobspawnerrender.json":
+                    return UTConfigTweaks.PERFORMANCE.utDisableMobSpawnerRendering;
                 case "mixins.tweaks.performance.resourcemanager.json":
                     return UTConfigTweaks.PERFORMANCE.utCheckAnimatedModelsToggle;
                 case "mixins.tweaks.world.loading.client.json":

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/mobspawnerrender/mixin/UTTileEntityMobSpawnerRenderer.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/mobspawnerrender/mixin/UTTileEntityMobSpawnerRenderer.java
@@ -1,0 +1,20 @@
+package mod.acgaming.universaltweaks.tweaks.performance.mobspawnerrender.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.client.renderer.tileentity.TileEntityMobSpawnerRenderer;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = TileEntityMobSpawnerRenderer.class)
+public abstract class UTTileEntityMobSpawnerRenderer
+{
+    @Inject(method = "render(Lnet/minecraft/tileentity/TileEntityMobSpawner;DDDFIF)V", at = @At("HEAD"), cancellable = true)
+    private void utDisableEntityRendering(TileEntityMobSpawner te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, CallbackInfo ci)
+    {
+        if (!UTConfigTweaks.PERFORMANCE.utDisableMobSpawnerRendering) return;
+        ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.tweaks.performance.mobspawnerrender.json
+++ b/src/main/resources/mixins.tweaks.performance.mobspawnerrender.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.mobspawnerrender.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTTileEntityMobSpawnerRenderer"]
+}


### PR DESCRIPTION
adds the ability to disable rendering the entity inside of mob spawners. this prevents observing what entity will be spawned by the spawner.
this is primarily a performance change, as rendering a large number of mob spawners can otherwise tank FPS. testing with a 16\*16\*54 area of pig mob spawners, i get extremely low FPS (more SPF), and with this change it hovers a bit better than 30 FPS.
however, another possible user of this is map makers, who may wish to hide what mob will be spawned.
option is `false` by default.

i dont see a huge amount of use for this outside of "i really need any performance i can get and i cant break a spawner" players. however, i do think those players exist.