### PR TITLE
make Extra Utilities 2 Machine Block drops mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ All changes are toggleable via config files.
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.
 * **Forestry**
     * **Arborist Villager Trades:** Adds custom emerald to germling trades to the arborist villager
     * **Disable Bee Damage Armor Bypass:** Disables damage caused by bees bypassing player armor

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -394,6 +394,11 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Mutable Block Drops")
+        @Config.Comment("Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list")
+        public boolean utMutableBlockDrops = true;
     }
 
     public static class ForestryCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -396,7 +396,7 @@ public class UTConfigMods
         public boolean utDuplicationFixesToggle = true;
 
         @Config.RequiresMcRestart
-        @Config.Name("Mutable Block Drops")
+        @Config.Name("Mutable Machine Block Drops")
         @Config.Comment("Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list")
         public boolean utMutableBlockDrops = true;
     }

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -47,6 +47,7 @@ public class UTMixinLoader implements ILateMixinLoader
         configs.add("mixins.mods.elenaidodge2.json");
         configs.add("mixins.mods.epicsiegemod.json");
         configs.add("mixins.mods.erebus.json");
+        configs.add("mixins.mods.extrautilities.mutabledrops.json");
         configs.add("mixins.mods.extrautilities.dupes.json");
         configs.add("mixins.mods.forestry.cocoa.json");
         configs.add("mixins.mods.forestry.dupes.json");
@@ -153,6 +154,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("epicsiegemod");
             case "mixins.mods.erebus.json":
                 return Loader.isModLoaded("erebus");
+            case "mixins.mods.extrautilities.mutabledrops.json":
+                return Loader.isModLoaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops;
             case "mixins.mods.extrautilities.dupes.json":
                 return Loader.isModLoaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle;
             case "mixins.mods.forestry.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/mutabledrops/mixin/UTMutableBlockMachineDrops.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/mutabledrops/mixin/UTMutableBlockMachineDrops.java
@@ -1,0 +1,23 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.mutabledrops.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.rwtema.extrautils2.machine.BlockMachine;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlockMachine.class, remap = false)
+public abstract class UTMutableBlockMachineDrops
+{
+    @ModifyReturnValue(method = "getDrops", at = @At(value = "RETURN"))
+    private List<ItemStack> utEnforceMutableDrops(List<ItemStack> original)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops) return original;
+        return new ArrayList<>(original);
+    }
+}

--- a/src/main/resources/mixins.mods.extrautilities.mutabledrops.json
+++ b/src/main/resources/mixins.mods.extrautilities.mutabledrops.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.mutabledrops.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTMutableBlockMachineDrops"]
+}


### PR DESCRIPTION
when breaking Extra Utilities 2 Machines, they return an ImmutableList. this causes issues for anything attempting to remove entries from the list, causing an `UnsupportedOperationException`. in addition to other, unknown things, this impacts the EnderIO Direct upgrade (both upgrade & Tinkers modifier) and the Astral Sorcery Scorching enchantment.

here is the issue reported to EnderIO: https://github.com/SleepyTrousers/EnderIO-1.5-1.12/issues/5360
heres the issue with the Direct upgrade and Astral Sorcery Scorching enchantment (both things modifying the list) being reported elsewhere: https://github.com/Divine-Journey-2/Divine-Journey-2/issues/1138, https://github.com/Divine-Journey-2/Divine-Journey-2/issues/345