### PR TITLE
Creative Mill Harvestability

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ All changes are toggleable via config files.
 * **Extra Utilities 2**
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.
+    * **Creative Mill Harvestability:** Fixes the Creative Mill Generator not respecting the Creative Block Breaking config
 * **Forestry**
     * **Arborist Villager Trades:** Adds custom emerald to germling trades to the arborist villager
     * **Disable Bee Damage Armor Bypass:** Disables damage caused by bees bypassing player armor

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -396,6 +396,11 @@ public class UTConfigMods
         public boolean utDuplicationFixesToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Creative Mill Harvestability")
+        @Config.Comment("Fixes the Creative Mill Generator not respecting the Creative Block Breaking config")
+        public boolean utFixCreativeMillHarvestability = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Mutable Machine Block Drops")
         @Config.Comment("Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list")
         public boolean utMutableBlockDrops = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -47,6 +47,7 @@ public class UTMixinLoader implements ILateMixinLoader
         configs.add("mixins.mods.elenaidodge2.json");
         configs.add("mixins.mods.epicsiegemod.json");
         configs.add("mixins.mods.erebus.json");
+        configs.add("mixins.mods.extrautilities.breakcreativemill.json");
         configs.add("mixins.mods.extrautilities.mutabledrops.json");
         configs.add("mixins.mods.extrautilities.dupes.json");
         configs.add("mixins.mods.forestry.cocoa.json");
@@ -154,6 +155,8 @@ public class UTMixinLoader implements ILateMixinLoader
                 return Loader.isModLoaded("epicsiegemod");
             case "mixins.mods.erebus.json":
                 return Loader.isModLoaded("erebus");
+            case "mixins.mods.extrautilities.breakcreativemill.json":
+                return Loader.isModLoaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability;
             case "mixins.mods.extrautilities.mutabledrops.json":
                 return Loader.isModLoaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops;
             case "mixins.mods.extrautilities.dupes.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
@@ -1,25 +1,21 @@
 package mod.acgaming.universaltweaks.mods.extrautilities.breakcreativemill.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.rwtema.extrautils2.ExtraUtils2;
 import com.rwtema.extrautils2.backend.XUBlockStatic;
 import com.rwtema.extrautils2.blocks.BlockPassiveGenerator;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // Courtesy of WaitingIdly
 @Mixin(value = BlockPassiveGenerator.class, remap = false)
 public abstract class UTBreakableCreativeMill extends XUBlockStatic
 {
-    @Inject(method = "getBlockHardness", at = @At(value = "HEAD"), cancellable = true)
-    private void utBreakCreativeMill(IBlockState blockState, World worldIn, BlockPos pos, CallbackInfoReturnable<Float> cir)
+    @ModifyExpressionValue(method = "getBlockHardness", at = @At(value = "FIELD", target = "Lcom/rwtema/extrautils2/ExtraUtils2;allowCreativeBlocksToBeBroken:Z"))
+    private boolean utBreakCreativeMill(boolean original)
     {
-        if (!UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability) return;
-        if (ExtraUtils2.allowNonCreativeHarvest) cir.setReturnValue(super.getBlockHardness(blockState, worldIn, pos));
+        if (!UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability) return original;
+        return ExtraUtils2.allowNonCreativeHarvest;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.breakcreativemill.mixin;
+
+import com.rwtema.extrautils2.ExtraUtils2;
+import com.rwtema.extrautils2.backend.XUBlockStatic;
+import com.rwtema.extrautils2.blocks.BlockPassiveGenerator;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlockPassiveGenerator.class, remap = false)
+public abstract class UTBreakableCreativeMill extends XUBlockStatic
+{
+    @Inject(method = "getBlockHardness", at = @At(value = "HEAD"), cancellable = true)
+    private void utBreakCreativeMill(IBlockState blockState, World worldIn, BlockPos pos, CallbackInfoReturnable<Float> cir)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability) return;
+        if (ExtraUtils2.allowNonCreativeHarvest) cir.setReturnValue(super.getBlockHardness(blockState, worldIn, pos));
+    }
+}

--- a/src/main/resources/mixins.mods.extrautilities.breakcreativemill.json
+++ b/src/main/resources/mixins.mods.extrautilities.breakcreativemill.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.breakcreativemill.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBreakableCreativeMill"]
+}


### PR DESCRIPTION
the creative mill checks the config option `ExtraUtils2.allowCreativeBlocksToBeBroken` instead of `ExtraUtils2.allowNonCreativeHarvest`. 
`allowCreativeBlocksToBeBroken` is always false, and this is the only place it is used.