### PR TITLE
Implement various vanilla performance tweaks, adapted from RLTweaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ All changes are toggleable via config files.
 * **Disable Wither Targeting AI:** Disables withers targeting animals
 * **Easy Breeding:** Enables easy breeding of animals by tossing food on the ground
 * **End Portal Parallax:** Re-implements parallax rendering of the end portal from 1.11 and older
+* **Entity Radius Check**
+    * These tweaks are only effective if you have mod(s) that increase `World.MAX_ENTITY_RADIUS`! (Lycanites Mobs, Advanced Rocketry, Immersive Railroading, etc.)
+    * Reduces the search size of various AABB functions for specified entity types to improve performance
+    * Reduces size of collision checks for most vanilla and specified entity types to improve performance
 * **Explosion Block Drop Chance:** Determines the numerator of the block drop formula on explosions
 * **Falling Block Lifespan:** Determines how long falling blocks remain in ticks until they are dropped under normal circumstances
 * **Fast Dye Blending:** Replaces color lookup for sheep to check a predefined table rather than querying the recipe registry
@@ -172,6 +176,7 @@ All changes are toggleable via config files.
 * **No Golems:** Disables the manual creation of golems and withers
 * **No Leftover Breath Bottles:** Disables dragon's breath from leaving off empty bottles when a stack is brewed with
 * **No Night Vision Flash:** Disables the flashing effect when the night vision potion effect is about to run out
+* **No Pathfinding Chunk Loading:** Disables mob pathfinding from loading new/unloaded chunks when building chunk caches to improve performance
 * **No Potion Shift:** Disables the inventory shift when potion effects are active
 * **No Portal Spawning:** Prevents zombie pigmen spawning from nether portals
 * **No Redstone Lighting:** Disables lighting of active redstone, repeaters, and comparators to improve performance

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -52,6 +52,7 @@ import mod.acgaming.universaltweaks.tweaks.misc.pickupnotification.UTPickupNotif
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
 import mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.UTTutorialToast;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
+import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
 import mod.acgaming.universaltweaks.tweaks.world.stronghold.UTStronghold;
 import mod.acgaming.universaltweaks.tweaks.world.stronghold.worldgen.SafeStrongholdWorldGenerator;
 import mod.acgaming.universaltweaks.util.UTPacketHandler;
@@ -205,6 +206,7 @@ public class UniversalTweaks
     public void onLoadComplete(FMLLoadCompleteEvent event)
     {
         if (Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) UTOreDictCache.onLoadComplete();
+        if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) UTEntityRadiusCheck.onLoadComplete();
         if (UTConfigGeneral.DEBUG.utLoadingTimeToggle) LOGGER.info("The game loaded in approximately {} seconds", (System.currentTimeMillis() - UTLoadingPlugin.launchTime) / 1000F);
         if (UTObsoleteModsHandler.showObsoleteMods && UTObsoleteModsHandler.obsoleteModsMessage().size() > 5 && !UTConfigGeneral.DEBUG.utBypassIncompatibilityToggle)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -206,7 +206,7 @@ public class UniversalTweaks
     public void onLoadComplete(FMLLoadCompleteEvent event)
     {
         if (Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) UTOreDictCache.onLoadComplete();
-        if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) UTEntityRadiusCheck.onLoadComplete();
+        if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle) UTEntityRadiusCheck.onLoadComplete();
         if (UTConfigGeneral.DEBUG.utLoadingTimeToggle) LOGGER.info("The game loaded in approximately {} seconds", (System.currentTimeMillis() - UTLoadingPlugin.launchTime) / 1000F);
         if (UTObsoleteModsHandler.showObsoleteMods && UTObsoleteModsHandler.obsoleteModsMessage().size() > 5 && !UTConfigGeneral.DEBUG.utBypassIncompatibilityToggle)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -21,6 +21,7 @@ import mod.acgaming.universaltweaks.tweaks.misc.incurablepotions.UTIncurablePoti
 import mod.acgaming.universaltweaks.tweaks.misc.loadsound.UTLoadSound;
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
+import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
 
 @Config(modid = UniversalTweaks.MODID, name = UniversalTweaks.NAME + " - Tweaks")
 public class UTConfigTweaks
@@ -1765,6 +1766,16 @@ public class UTConfigTweaks
             @Config.Name("[4] Less Collisions Toggle")
             @Config.Comment("Reduces size of collision checks for most vanilla entity types")
             public boolean utLessCollisionsToggle = true;
+
+            @Config.Name("[5] Less Collisions Extra Targets")
+            @Config.Comment
+                ({
+                    "The extra entity types to reduce the size of collision checks for",
+                    "Syntax - modid:name;radius",
+                    "Vanilla ids aren't allowed because they are already included",
+                    "Most types should be specified with the vanilla default radius: 2.0"
+                })
+            public String[] utLessCollisionsExtraTargets = new String[]{};
         }
     }
 
@@ -1864,6 +1875,11 @@ public class UTConfigTweaks
                 if (MISC.ARMOR_CURVE.utArmorCurveToggle) UTArmorCurve.initExpressions();
                 if (MISC.SWING_THROUGH_GRASS.utSwingThroughGrassToggle) UTSwingThroughGrassLists.initLists();
                 if (MISC.INCURABLE_POTIONS.utIncurablePotionsToggle) UTIncurablePotions.initPotionList();
+                if (PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle)
+                {
+                    if (PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) UTEntityRadiusCheck.initSearchTargets();
+                    if (PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle) UTEntityRadiusCheck.initCollisionTargets();
+                }
                 if (ITEMS.utCustomRarities.length > 0) UTCustomRarity.initItemRarityMap();
                 if (ITEMS.utCustomUseDurations.length > 0) UTCustomUseDuration.initItemUseMaps();
                 if (ITEMS.PARRY.utParryToggle) UTParry.initProjectileList();

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1651,6 +1651,10 @@ public class UTConfigTweaks
 
     public static class PerformanceCategory
     {
+        @Config.LangKey("cfg.universaltweaks.tweaks.performance.entityradiuscheck")
+        @Config.Name("Entity Radius Check")
+        public final EntityRadiusCheckCategory ENTITY_RADIUS_CHECK = new EntityRadiusCheckCategory();
+
         @Config.RequiresMcRestart
         @Config.Name("Auto Save Interval")
         @Config.Comment("Determines the interval in ticks between world auto saves")
@@ -1729,6 +1733,30 @@ public class UTConfigTweaks
         @Config.Name("Uncap FPS")
         @Config.Comment("Removes the hardcoded 30 FPS limit in screens like the main menu")
         public boolean utUncapFPSToggle = true;
+
+        public static class EntityRadiusCheckCategory
+        {
+            @Config.Name("Reduce Search Size Toggle")
+            @Config.Comment
+                ({
+                    "Reduces the search size of various getEntitiesWithinAABB functions for specified entity types",
+                    "Only useful if you have a mod that increases World.MAX_ENTITY_RADIUS",
+                    "(Lycanites Mobs, Advanced Rocketry, Immersive Railroading, etc.)"
+                })
+            public boolean utReduceSearchSizeToggle = true;
+
+            @Config.Name("Reduce Search Size Targets")
+            @Config.Comment
+                ({
+                    "The entity types to reduce the search size for",
+                    "Specify by the fully qualified class name"
+                })
+            public String[] utReduceSearchSizeTargets = new String[]
+                {
+                    "net.minecraft.entity.item.EntityItem",
+                    "net.minecraft.entity.player.EntityPlayer"
+                };
+        }
     }
 
     public static class WorldCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1754,12 +1754,12 @@ public class UTConfigTweaks
             @Config.Comment
                 ({
                     "The entity types to reduce the search size for",
-                    "Specify by their fully qualified class name"
+                    "Syntax - modid:name"
                 })
             public String[] utReduceSearchSizeTargets = new String[]
                 {
-                    "net.minecraft.entity.item.EntityItem",
-                    "net.minecraft.entity.player.EntityPlayer"
+                    "minecraft:item",
+                    "minecraft:player"
                 };
 
             @Config.Name("[4] Less Collisions Toggle")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1736,6 +1736,7 @@ public class UTConfigTweaks
 
         public static class EntityRadiusCheckCategory
         {
+            @Config.RequiresMcRestart
             @Config.Name("[1] Entity Radius Check Toggle")
             @Config.Comment
                 ({

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1722,7 +1722,7 @@ public class UTConfigTweaks
 
         @Config.RequiresMcRestart
         @Config.Name("No Pathfinding Chunk Loading")
-        @Config.Comment("Prevents mob pathfinding from loading new/unloaded chunks when building chunk caches")
+        @Config.Comment("Disables mob pathfinding from loading new/unloaded chunks when building chunk caches")
         public boolean utPathfindingChunkCacheFixToggle = true;
 
         @Config.RequiresMcRestart
@@ -1764,7 +1764,7 @@ public class UTConfigTweaks
                 };
 
             @Config.Name("[4] Less Collisions Toggle")
-            @Config.Comment("Reduces size of collision checks for most vanilla entity types")
+            @Config.Comment("Reduces size of collision checks for most vanilla and specified entity types")
             public boolean utLessCollisionsToggle = true;
 
             @Config.Name("[5] Less Collisions Extra Targets")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1736,26 +1736,34 @@ public class UTConfigTweaks
 
         public static class EntityRadiusCheckCategory
         {
-            @Config.Name("Reduce Search Size Toggle")
+            @Config.Name("[1] Entity Radius Check Toggle")
             @Config.Comment
                 ({
-                    "Reduces the search size of various getEntitiesWithinAABB functions for specified entity types",
-                    "Only useful if you have a mod that increases World.MAX_ENTITY_RADIUS",
+                    "Toggles all tweaks in this category",
+                    "IMPORTANT: These tweaks are only effective if you have mod(s) that increase World.MAX_ENTITY_RADIUS!",
                     "(Lycanites Mobs, Advanced Rocketry, Immersive Railroading, etc.)"
                 })
+            public boolean utEntityRadiusCheckCategoryToggle = true;
+
+            @Config.Name("[2] Reduce Search Size Toggle")
+            @Config.Comment("Reduces the search size of various AABB functions for specified entity types")
             public boolean utReduceSearchSizeToggle = true;
 
-            @Config.Name("Reduce Search Size Targets")
+            @Config.Name("[3] Reduce Search Size Targets")
             @Config.Comment
                 ({
                     "The entity types to reduce the search size for",
-                    "Specify by the fully qualified class name"
+                    "Specify by their fully qualified class name"
                 })
             public String[] utReduceSearchSizeTargets = new String[]
                 {
                     "net.minecraft.entity.item.EntityItem",
                     "net.minecraft.entity.player.EntityPlayer"
                 };
+
+            @Config.Name("[4] Less Collisions Toggle")
+            @Config.Comment("Reduces size of collision checks for most vanilla entity types")
+            public boolean utLessCollisionsToggle = true;
         }
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1716,6 +1716,11 @@ public class UTConfigTweaks
         public boolean utTextureMapCheckToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("No Pathfinding Chunk Loading")
+        @Config.Comment("Prevents mob pathfinding from loading new/unloaded chunks when building chunk caches")
+        public boolean utPathfindingChunkCacheFixToggle = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("No Redstone Lighting")
         @Config.Comment("Disables lighting of active redstone, repeaters, and comparators to improve performance")
         public boolean utRedstoneLightingToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -224,6 +224,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.performance.autosave.json");
         configs.add("mixins.tweaks.performance.craftingcache.json");
         configs.add("mixins.tweaks.performance.dyeblending.json");
+        configs.add("mixins.tweaks.performance.entityradiuscheck.lesscollisions.json");
         configs.add("mixins.tweaks.performance.entityradiuscheck.reducesearchsize.json");
         configs.add("mixins.tweaks.performance.oredictionarycheck.json");
         configs.add("mixins.tweaks.performance.pathfinding.json");
@@ -515,6 +516,10 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.PERFORMANCE.utCraftingCacheToggle;
             case "mixins.tweaks.performance.dyeblending.json":
                 return UTConfigTweaks.PERFORMANCE.utDyeBlendingToggle;
+            case "mixins.tweaks.performance.entityradiuscheck.lesscollisions.json":
+                return UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle;
+            case "mixins.tweaks.performance.entityradiuscheck.reducesearchsize.json":
+                return UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle;
             case "mixins.tweaks.performance.oredictionarycheck.json":
                 return UTConfigTweaks.PERFORMANCE.utOreDictionaryCheckToggle;
             case "mixins.tweaks.performance.prefixcheck.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -522,6 +522,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 return UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle;
             case "mixins.tweaks.performance.oredictionarycheck.json":
                 return UTConfigTweaks.PERFORMANCE.utOreDictionaryCheckToggle;
+            case "mixins.tweaks.performance.pathfinding.json":
+                return UTConfigTweaks.PERFORMANCE.utPathfindingChunkCacheFixToggle;
             case "mixins.tweaks.performance.prefixcheck.json":
                 return UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle;
             case "mixins.tweaks.performance.redstone.json":

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -224,6 +224,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.performance.autosave.json");
         configs.add("mixins.tweaks.performance.craftingcache.json");
         configs.add("mixins.tweaks.performance.dyeblending.json");
+        configs.add("mixins.tweaks.performance.entityradiuscheck.reducesearchsize.json");
         configs.add("mixins.tweaks.performance.oredictionarycheck.json");
         configs.add("mixins.tweaks.performance.pathfinding.json");
         configs.add("mixins.tweaks.performance.prefixcheck.json");

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -247,6 +247,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         configs.add("mixins.tweaks.performance.craftingcache.json");
         configs.add("mixins.tweaks.performance.dyeblending.json");
         configs.add("mixins.tweaks.performance.oredictionarycheck.json");
+        configs.add("mixins.tweaks.performance.pathfinding.json");
         configs.add("mixins.tweaks.performance.prefixcheck.json");
         configs.add("mixins.tweaks.performance.redstone.json");
         configs.add("mixins.tweaks.performance.texturemapcheck.json");

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -14,6 +14,7 @@ import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 import zone.rong.mixinbooter.IEarlyMixinLoader;
 
 @IFMLLoadingPlugin.Name("UniversalTweaksCore")
@@ -38,33 +39,10 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             Locale.setDefault(Locale.ENGLISH);
         }
 
-        try
-        {
-            Class.forName("com.therandomlabs.randompatches.core.RPCore");
-            randomPatchesLoaded = true;
-        }
-        catch (ClassNotFoundException ignored) {}
-
-        try
-        {
-            Class.forName("meldexun.renderlib.RenderLib");
-            renderLibLoaded = true;
-        }
-        catch (ClassNotFoundException ignored) {}
-
-        try
-        {
-            Class.forName("org.spongepowered.mod.util.CompatibilityException");
-            spongeForgeLoaded = true;
-        }
-        catch (ClassNotFoundException ignored) {}
-
-        try
-        {
-            Class.forName("net.darkhax.surge.core.SurgeLoadingPlugin");
-            surgeLoaded = true;
-        }
-        catch (ClassNotFoundException ignored) {}
+        randomPatchesLoaded = UTReflectionUtil.isClassLoaded("com.therandomlabs.randompatches.core.RPCore");
+        renderLibLoaded = UTReflectionUtil.isClassLoaded("meldexun.renderlib.RenderLib");
+        spongeForgeLoaded = UTReflectionUtil.isClassLoaded("org.spongepowered.mod.util.CompatibilityException");
+        surgeLoaded = UTReflectionUtil.isClassLoaded("net.darkhax.surge.core.SurgeLoadingPlugin");
     }
 
     @Override

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/autosave/UTAutoSaveOFCompat.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/autosave/UTAutoSaveOFCompat.java
@@ -12,6 +12,7 @@ import net.minecraft.launchwrapper.Launch;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
+import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTAutoSaveOFCompat
 {
@@ -20,9 +21,9 @@ public class UTAutoSaveOFCompat
     public static void updateOFConfig()
     {
         if (!UTLoadingPlugin.isClient) return;
+        if (!UTReflectionUtil.isClassLoaded("optifine.OptiFineTweaker")) return;
         try
         {
-            Class.forName("optifine.OptiFineTweaker");
             UniversalTweaks.LOGGER.info("OptiFine detected, updating config file...");
 
             Path ofConfigPath = Paths.get(rootFolder + File.separator + "optionsof.txt");

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+
+import com.google.common.collect.ImmutableList;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTReflectionUtil;
+
+public class UTEntityRadiusCheck
+{
+    public static List<Class<? extends Entity>> searchTargets = ImmutableList.of();
+
+    public static void onLoadComplete()
+    {
+        searchTargets = new ArrayList<>();
+        // Read config for classes
+        for (String className : UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeTargets)
+        {
+            try
+            {
+                Class<?> clazz = UTReflectionUtil.getClassLoaded(className);
+                if (clazz == null)
+                {
+                    UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Invalid class name " + className + "! Skipping this entry.");
+                    continue;
+                }
+                Class<? extends Entity> target = clazz.asSubclass(Entity.class);
+                searchTargets.add(target);
+            }
+            catch (ClassCastException ex)
+            {
+                UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Class " + className + " is not an Entity! Skipping this entry.");
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
@@ -1,22 +1,47 @@
 package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.boss.EntityDragon;
+import net.minecraft.entity.boss.EntityWither;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.item.EntityItemFrame;
+import net.minecraft.entity.item.EntityPainting;
+import net.minecraft.entity.item.EntityXPOrb;
+import net.minecraft.entity.passive.AbstractHorse;
+import net.minecraft.entity.passive.EntityWolf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.registries.RegistryManager;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTEntityRadiusCheck
 {
-    public static List<Class<? extends Entity>> searchTargets = ImmutableList.of();
+    public static Set<Class<? extends Entity>> searchTargets = Collections.emptySet();
+    public static Set<Class<? extends Entity>> collisionTargets = Collections.emptySet();
 
     public static void onLoadComplete()
     {
-        searchTargets = new ArrayList<>();
+        if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) initSearchTargets();
+        if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle) initCollisionTargets();
+    }
+
+    private static void initSearchTargets()
+    {
+        searchTargets = new HashSet<>();
         // Read config for classes
         for (String className : UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeTargets)
         {
@@ -36,5 +61,48 @@ public class UTEntityRadiusCheck
                 UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Class " + className + " is not an Entity! Skipping this entry.");
             }
         }
+    }
+
+    private static void initCollisionTargets()
+    {
+        // Conditions taken from RLTweaker's JsonConfigLessCollisions.
+        // (1) No combat allies or offensive tools
+        // (2) No mountables, except for pigs.
+        // (3) No projectiles of any kind
+        // (4) Caution with entities that may become the owner of explosions
+        Predicate<Class<? extends Entity>> livingPredicate = new Predicate<Class<? extends Entity>>()
+        {
+            @Override
+            public boolean test(Class<? extends Entity> entityClazz)
+            {
+                return EntityLivingBase.class.isAssignableFrom(entityClazz) &&
+                    !(entityClazz == EntityWolf.class ||        // (1)
+                        AbstractHorse.class.isAssignableFrom(entityClazz) || // (2)
+                        entityClazz == EntityPlayer.class ||
+                        entityClazz == EntityDragon.class ||    // (4)
+                        entityClazz == EntityWither.class       // (4)
+                    );
+            }
+        };
+        Predicate<Class<? extends Entity>> miscPredicate = new Predicate<Class<? extends Entity>>()
+        {
+            @Override
+            public boolean test(Class<? extends Entity> entityClazz)
+            {
+                Collection<Class<? extends Entity>> allowed = ImmutableSet.of(
+                    EntityItem.class,
+                    EntityItemFrame.class,
+                    EntityPainting.class,
+                    EntityXPOrb.class
+                );
+                return allowed.contains(entityClazz);
+            }
+        };
+        // TODO: Add custom predicate reading entities from config?
+        Collection<?> vanillaEntities = RegistryManager.VANILLA.getRegistry(new ResourceLocation("entities")).getValuesCollection();
+        collisionTargets = vanillaEntities.stream()
+            .map(entry -> ((EntityEntry) entry).getEntityClass())
+            .filter(livingPredicate.or(miscPredicate))
+            .collect(Collectors.toCollection(HashSet::new));
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
@@ -40,7 +40,6 @@ public class UTEntityRadiusCheck
     {
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) initSearchTargets();
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle) initCollisionTargets();
-        World.MAX_ENTITY_RADIUS = 200;
     }
 
     public static void initSearchTargets()

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/UTEntityRadiusCheck.java
@@ -1,11 +1,10 @@
 package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -25,34 +24,33 @@ import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.registries.RegistryManager;
 
 import com.google.common.collect.ImmutableSet;
+import it.unimi.dsi.fastutil.objects.Reference2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Reference2DoubleMaps;
+import it.unimi.dsi.fastutil.objects.Reference2DoubleOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 
 public class UTEntityRadiusCheck
 {
     public static Set<Class<? extends Entity>> searchTargets = Collections.emptySet();
-    public static Set<Class<? extends Entity>> collisionTargets = Collections.emptySet();
+    public static Reference2DoubleMap<Class<? extends Entity>> collisionTargets = Reference2DoubleMaps.emptyMap();
 
     public static void onLoadComplete()
     {
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) initSearchTargets();
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle) initCollisionTargets();
+        World.MAX_ENTITY_RADIUS = 200;
     }
 
-    private static void initSearchTargets()
+    public static void initSearchTargets()
     {
         final ResourceLocation playerId = new ResourceLocation("player");
-        Set<Class<? extends Entity>> out = new HashSet<>();
+        Set<Class<? extends Entity>> out = new ReferenceOpenHashSet<>();
         // Read config for classes
         for (String entityId : UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeTargets)
         {
-            // Special case of player
-            if (entityId.equals(playerId.toString()))
-            {
-                out.add(EntityPlayer.class);
-                continue;
-            }
-            Class<? extends Entity> entityClazz = EntityList.getClass(new ResourceLocation(entityId));
+            Class<? extends Entity> entityClazz = getEntityType(entityId, playerId, false);
             if (entityClazz == null)
             {
                 UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Invalid entity id " + entityId + "in \"[3] Reduce Search Size Targets\"! Skipping this entry.");
@@ -63,7 +61,72 @@ public class UTEntityRadiusCheck
         if (!out.isEmpty()) searchTargets = out;
     }
 
-    private static void initCollisionTargets()
+    public static void initCollisionTargets()
+    {
+        final ResourceLocation ignored = new ResourceLocation("");
+        // To avoid auto-unboxing later
+        collisionTargets = new Reference2DoubleOpenHashMap<>();
+        Set<?> vanillaEntities = (Set<?>) RegistryManager.VANILLA.getRegistry(new ResourceLocation("entities")).getValuesCollection();
+        Predicate<Class<? extends Entity>> vanillaPredicate = buildVanillaPredicate();
+        // Add vanilla entity types
+        for (Object entry : vanillaEntities)
+        {
+            Class<? extends Entity> clazz = ((EntityEntry) entry).getEntityClass();
+            if (vanillaPredicate.test(clazz))
+            {
+                collisionTargets.put(clazz, 2.0D);
+            }
+        }
+        // Add config's entity types
+        for (String entry : UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsExtraTargets)
+        {
+            // Parsing
+            int separator = entry.indexOf(";");
+            if (separator == -1)
+            {
+                UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Unexpected format " + entry + "in \"[5] Less Collisions Extra Targets\"! Skipping this entry.");
+                continue;
+            }
+            String entityId = entry.substring(0, separator);
+            double radius;
+            try
+            {
+                radius = Double.parseDouble(entry.substring(separator + 1));
+            }
+            catch (NumberFormatException ex)
+            {
+                UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Unexpected format " + entry + "in \"[5] Less Collisions Extra Targets\"! Skipping this entry.");
+                continue;
+            }
+            // Verifying
+            Class<? extends Entity> entityClazz = getEntityType(entityId, ignored, true);
+            if (entityClazz == null)
+            {
+                UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Invalid entity id " + entityId + "in \"[5] Less Collisions Extra Targets\"! Skipping this entry.");
+                continue;
+            }
+            if (radius <= 0.0D)
+            {
+                UniversalTweaks.LOGGER.warn("UTEntityRadiusCheck ::: Invalid radius " + radius + "in \"[5] Less Collisions Extra Targets\"! Skipping this entry.");
+                continue;
+            }
+            collisionTargets.put(entityClazz, radius);
+        }
+    }
+
+    private static @Nullable Class<? extends Entity> getEntityType(String entityId, ResourceLocation playerId, boolean nonVanillaOnly)
+    {
+        ResourceLocation entityLoc = new ResourceLocation(entityId);
+        if (nonVanillaOnly && entityLoc.getNamespace().equals("minecraft")) return null;
+        // Special case of player
+        if (entityId.equals(playerId.toString()))
+        {
+            return EntityPlayer.class;
+        }
+        return EntityList.getClass(entityLoc);
+    }
+
+    private static Predicate<Class<? extends Entity>> buildVanillaPredicate()
     {
         // Conditions taken from RLTweaker's JsonConfigLessCollisions.
         // (1) No combat allies or offensive tools
@@ -98,11 +161,6 @@ public class UTEntityRadiusCheck
                 return allowed.contains(entityClazz);
             }
         };
-        // TODO: Add custom predicate reading entities from config?
-        Collection<?> vanillaEntities = RegistryManager.VANILLA.getRegistry(new ResourceLocation("entities")).getValuesCollection();
-        collisionTargets = vanillaEntities.stream()
-            .map(entry -> ((EntityEntry) entry).getEntityClass())
-            .filter(livingPredicate.or(miscPredicate))
-            .collect(Collectors.toCollection(HashSet::new));
+        return livingPredicate.or(miscPredicate);
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTEntityLivingBaseMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTEntityLivingBaseMixin.java
@@ -16,6 +16,7 @@ import mod.acgaming.universaltweaks.util.UTEntityAABBUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+// Courtesy of jchung01
 @Mixin(value = EntityLivingBase.class)
 public class UTEntityLivingBaseMixin
 {
@@ -23,10 +24,14 @@ public class UTEntityLivingBaseMixin
     private List<Entity> utReducedRadiusAABBCall(World instance, Entity entityIn, AxisAlignedBB aabb, Predicate<? super Entity> predicate, Operation<List<Entity>> original)
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
-        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle && entityIn != null && UTEntityRadiusCheck.collisionTargets.contains(entityIn.getClass()))
+        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle && entityIn != null)
         {
-            // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods that only originate from this call would be messy, just redirect.
-            return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, ORIGINAL_MAX_ENTITY_RADIUS);
+            double newRadius = UTEntityRadiusCheck.collisionTargets.getDouble(entityIn.getClass());
+            if (newRadius > 0.0D)
+            {
+                // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods that only originate from this call would be messy, just redirect.
+                return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, newRadius);
+            }
         }
         return original.call(instance, entityIn, aabb, predicate);
     }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTEntityLivingBaseMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTEntityLivingBaseMixin.java
@@ -3,6 +3,7 @@ package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.lessco
 import java.util.List;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.World;
 
@@ -15,11 +16,10 @@ import mod.acgaming.universaltweaks.util.UTEntityAABBUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-// Courtesy of jchung01
-@Mixin(value = World.class)
-public class UTWorldMixin
+@Mixin(value = EntityLivingBase.class)
+public class UTEntityLivingBaseMixin
 {
-    @WrapOperation(method = "getEntitiesWithinAABBExcludingEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntitiesInAABBexcluding(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;"))
+    @WrapOperation(method = "collideWithNearbyEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntitiesInAABBexcluding(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;"))
     private List<Entity> utReducedRadiusAABBCall(World instance, Entity entityIn, AxisAlignedBB aabb, Predicate<? super Entity> predicate, Operation<List<Entity>> original)
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
@@ -23,10 +23,14 @@ public class UTWorldMixin
     private List<Entity> utReducedRadiusAABBCall(World instance, Entity entityIn, AxisAlignedBB aabb, Predicate<? super Entity> predicate, Operation<List<Entity>> original)
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
-        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle && entityIn != null && UTEntityRadiusCheck.collisionTargets.contains(entityIn.getClass()))
+        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle && entityIn != null)
         {
-            // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods that only originate from this call would be messy, just redirect.
-            return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, ORIGINAL_MAX_ENTITY_RADIUS);
+            double newRadius = UTEntityRadiusCheck.collisionTargets.getDouble(entityIn.getClass());
+            if (newRadius > 0.0D)
+            {
+                // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods that only originate from this call would be messy, just redirect.
+                return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, newRadius);
+            }
         }
         return original.call(instance, entityIn, aabb, predicate);
     }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
@@ -23,7 +23,7 @@ public class UTWorldMixin
     private List<Entity> utReducedRadiusAABBCall(World instance, Entity entityIn, AxisAlignedBB aabb, Predicate<? super Entity> predicate, Operation<List<Entity>> original)
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
-        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle && entityIn != null && UTEntityRadiusCheck.collisionTargets.contains(entityIn.getClass()))
+        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utLessCollisionsToggle && entityIn != null && UTEntityRadiusCheck.collisionTargets.contains(entityIn.getClass()))
         {
             // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods would be messy, just redirect.
             return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, ORIGINAL_MAX_ENTITY_RADIUS);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/lesscollisions/mixin/UTWorldMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.lesscollisions.mixin;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
+
+import com.google.common.base.Predicate;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
+import mod.acgaming.universaltweaks.util.UTEntityAABBUtil;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = World.class)
+public class UTWorldMixin
+{
+    @WrapOperation(method = "getEntitiesWithinAABBExcludingEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntitiesInAABBexcluding(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;"))
+    private List<Entity> utReducedRadiusAABBCall(World instance, Entity entityIn, AxisAlignedBB aabb, Predicate<? super Entity> predicate, Operation<List<Entity>> original)
+    {
+        final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
+        if (World.MAX_ENTITY_RADIUS != ORIGINAL_MAX_ENTITY_RADIUS && UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle && entityIn != null && UTEntityRadiusCheck.collisionTargets.contains(entityIn.getClass()))
+        {
+            // Trying to modify the actual MAX_ENTITY_RADIUS across multiple methods would be messy, just redirect.
+            return UTEntityAABBUtil.getEntitiesInAABBexcluding(instance, entityIn, aabb, predicate, ORIGINAL_MAX_ENTITY_RADIUS);
+        }
+        return original.call(instance, entityIn, aabb, predicate);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTChunkMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTChunkMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.reducesearchsize.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.chunk.Chunk;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = Chunk.class)
+public class UTChunkMixin
+{
+    @ModifyExpressionValue(method = "getEntitiesOfTypeWithinAABB", at = @At(value = "FIELD", opcode = Opcodes.GETSTATIC, target = "Lnet/minecraft/world/World;MAX_ENTITY_RADIUS:D", remap = false))
+    private <T extends Entity> double utReduceMaxEntityRadius(double original, Class<? extends T> clazz)
+    {
+        final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
+        if (original == ORIGINAL_MAX_ENTITY_RADIUS || !UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) return original;
+
+        for (Class<? extends Entity> target : UTEntityRadiusCheck.searchTargets)
+        {
+            if (clazz.equals(target)) return ORIGINAL_MAX_ENTITY_RADIUS;
+        }
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTChunkMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTChunkMixin.java
@@ -19,11 +19,6 @@ public class UTChunkMixin
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
         if (original == ORIGINAL_MAX_ENTITY_RADIUS || !UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) return original;
-
-        for (Class<? extends Entity> target : UTEntityRadiusCheck.searchTargets)
-        {
-            if (clazz.equals(target)) return ORIGINAL_MAX_ENTITY_RADIUS;
-        }
-        return original;
+        return UTEntityRadiusCheck.searchTargets.contains(clazz) ? ORIGINAL_MAX_ENTITY_RADIUS : original;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTWorldMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.reducesearchsize.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = World.class)
+public class UTWorldMixin
+{
+    @ModifyExpressionValue(method = "getEntitiesWithinAABB(Ljava/lang/Class;Lnet/minecraft/util/math/AxisAlignedBB;Lcom/google/common/base/Predicate;)Ljava/util/List;", at = @At(value = "FIELD", opcode = Opcodes.GETSTATIC, target = "Lnet/minecraft/world/World;MAX_ENTITY_RADIUS:D", remap = false))
+    private <T extends Entity> double utReduceMaxEntityRadius(double original, Class<? extends T> clazz)
+    {
+        final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
+        if (original == ORIGINAL_MAX_ENTITY_RADIUS || !UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) return original;
+
+        for (Class<? extends Entity> target : UTEntityRadiusCheck.searchTargets)
+        {
+            if (clazz.equals(target)) return ORIGINAL_MAX_ENTITY_RADIUS;
+        }
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/entityradiuscheck/reducesearchsize/mixin/UTWorldMixin.java
@@ -19,11 +19,6 @@ public class UTWorldMixin
     {
         final double ORIGINAL_MAX_ENTITY_RADIUS = 2.0D;
         if (original == ORIGINAL_MAX_ENTITY_RADIUS || !UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utReduceSearchSizeToggle) return original;
-
-        for (Class<? extends Entity> target : UTEntityRadiusCheck.searchTargets)
-        {
-            if (clazz.equals(target)) return ORIGINAL_MAX_ENTITY_RADIUS;
-        }
-        return original;
+        return UTEntityRadiusCheck.searchTargets.contains(clazz) ? ORIGINAL_MAX_ENTITY_RADIUS : original;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathfindingChunkCacheMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathfindingChunkCacheMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.tweaks.performance.pathfinding.mixin;
+
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.ChunkProviderServer;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = ChunkCache.class)
+public class UTPathfindingChunkCacheMixin
+{
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getChunk(II)Lnet/minecraft/world/chunk/Chunk;"))
+    private Chunk utCheckChunkLoaded(World instance, int chunkX, int chunkZ, Operation<Chunk> original)
+    {
+        // Pathfinding is the only server-side use of ChunkCache (in vanilla).
+        if (!instance.isRemote && UTConfigTweaks.PERFORMANCE.utPathfindingChunkCacheFixToggle && !((ChunkProviderServer) instance.getChunkProvider()).chunkExists(chunkX, chunkZ))
+        {
+            return null;
+        }
+        return original.call(instance, chunkX, chunkZ);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTEntityAABBUtil.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTEntityAABBUtil.java
@@ -1,0 +1,90 @@
+package mod.acgaming.universaltweaks.util;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ClassInheritanceMultiMap;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+
+/**
+ * Util class mirroring a few AABB functions.
+ * Necessary for lessCollisions tweak.
+ * Credit goes to Charles445, this is basically straight from RLTweaker's WorldRadiusUtil.
+ */
+public class UTEntityAABBUtil
+{
+    /**
+     * Copy of {@link World#getEntitiesInAABBexcluding} using variable entity radius.
+     */
+    public static List<Entity> getEntitiesInAABBexcluding(World world, @Nullable Entity entityIn, AxisAlignedBB boundingBox, @Nullable Predicate<? super Entity > predicate, double size)
+    {
+        List<Entity> list = Lists.<Entity>newArrayList();
+        int j2 = MathHelper.floor((boundingBox.minX - size) / 16.0D);
+        int k2 = MathHelper.floor((boundingBox.maxX + size) / 16.0D);
+        int l2 = MathHelper.floor((boundingBox.minZ - size) / 16.0D);
+        int i3 = MathHelper.floor((boundingBox.maxZ + size) / 16.0D);
+
+        for (int j3 = j2; j3 <= k2; ++j3)
+        {
+            for (int k3 = l2; k3 <= i3; ++k3)
+            {
+                Chunk chunk = world.getChunkProvider().getLoadedChunk(j3, k3);
+                if (chunk != null)
+                {
+                    getEntitiesWithinAABBForEntity(chunk, entityIn, boundingBox, list, predicate, size);
+                }
+            }
+        }
+
+        return list;
+    }
+
+    /**
+     * Copy of {@link Chunk#getEntitiesWithinAABBForEntity} using variable entity radius.
+     */
+    public static void getEntitiesWithinAABBForEntity(Chunk chunk, @Nullable Entity entityIn, AxisAlignedBB aabb, List<Entity> listToFill, Predicate <? super Entity > filter, double size)
+    {
+        ClassInheritanceMultiMap<Entity>[] entityLists = chunk.getEntityLists();
+        int i = MathHelper.floor((aabb.minY - size) / 16.0D);
+        int j = MathHelper.floor((aabb.maxY + size) / 16.0D);
+        i = MathHelper.clamp(i, 0, entityLists.length - 1);
+        j = MathHelper.clamp(j, 0, entityLists.length - 1);
+
+        for (int k = i; k <= j; ++k)
+        {
+            if (!entityLists[k].isEmpty())
+            {
+                for (Entity entity : entityLists[k])
+                {
+                    if (entity.getEntityBoundingBox().intersects(aabb) && entity != entityIn)
+                    {
+                        if (filter == null || filter.apply(entity))
+                        {
+                            listToFill.add(entity);
+                        }
+
+                        Entity[] aentity = entity.getParts();
+
+                        if (aentity != null)
+                        {
+                            for (Entity entity1 : aentity)
+                            {
+                                if (entity1 != entityIn && entity1.getEntityBoundingBox().intersects(aabb) && (filter == null || filter.apply(entity1)))
+                                {
+                                    listToFill.add(entity1);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTReflectionUtil.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTReflectionUtil.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.util;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+
+public class UTReflectionUtil
+{
+    public static boolean isClassLoaded(String className)
+    {
+        return getClassLoaded(className) != null;
+    }
+
+    public static Class<?> getClassLoaded(String className)
+    {
+        try
+        {
+            return Class.forName(className);
+        }
+        catch (ClassNotFoundException ignored)
+        {
+            if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTReflectionUtil ::: Could not find class with name " + className);
+            return null;
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.common.Loader;
 import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTObsoleteModsHandler
 {
@@ -120,25 +121,12 @@ public class UTObsoleteModsHandler
         if (Loader.isModLoaded("villagermantlefix") && UTConfigBugfixes.ENTITIES.utVillagerMantleToggle) messages.add("Villager Mantle Fix");
         if (Loader.isModLoaded("watercontrolextreme") && UTConfigTweaks.BLOCKS.FINITE_WATER.utFiniteWaterToggle) messages.add("Water Control Extreme");
         // Mods checked by class
-        if (isClassLoaded("com.chocohead.biab.BornInABarn")) messages.add("Born in a Barn");
-        if (isClassLoaded("io.github.jikuja.LocaleTweaker") && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
-        if (isClassLoaded("com.cleanroommc.blockdelayremover.BlockDelayRemoverCore") && UTConfigTweaks.BLOCKS.utBlockHitDelay != 5) messages.add("Block Delay Remover");
-        if (isClassLoaded("io.github.barteks2x.chunkgenlimiter.ChunkGenLimitMod") && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");
+        if (UTReflectionUtil.isClassLoaded("com.chocohead.biab.BornInABarn")) messages.add("Born in a Barn");
+        if (UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleTweaker") && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
+        if (UTReflectionUtil.isClassLoaded("com.cleanroommc.blockdelayremover.BlockDelayRemoverCore") && UTConfigTweaks.BLOCKS.utBlockHitDelay != 5) messages.add("Block Delay Remover");
+        if (UTReflectionUtil.isClassLoaded("io.github.barteks2x.chunkgenlimiter.ChunkGenLimitMod") && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");
         messages.add("");
         messages.add(new TextComponentTranslation("msg.universaltweaks.obsoletemods.warning3").getFormattedText());
         return messages;
-    }
-
-    private static boolean isClassLoaded(String className)
-    {
-        try
-        {
-            Class.forName(className);
-            return true;
-        }
-        catch (ClassNotFoundException ignored)
-        {
-            return false;
-        }
     }
 }

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -128,5 +128,6 @@ cfg.universaltweaks.tweaks.misc.pickupnotification=Pickup Notification
 cfg.universaltweaks.tweaks.misc.smoothscrolling=Smooth Scrolling
 cfg.universaltweaks.tweaks.misc.stg=Swing Through Grass
 cfg.universaltweaks.tweaks.misc.toastcontrol=Toast Control
+cfg.universaltweaks.tweaks.performance.entityradiuscheck=Entity Radius Check
 cfg.universaltweaks.tweaks.world.chunkgenlimit=Chunk Gen Limit
 cfg.universaltweaks.tweaks.world.dimensionunload=Dimension Unload

--- a/src/main/resources/mixins.tweaks.performance.entityradiuscheck.lesscollisions.json
+++ b/src/main/resources/mixins.tweaks.performance.entityradiuscheck.lesscollisions.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.lesscollisions.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTWorldMixin"]
+}

--- a/src/main/resources/mixins.tweaks.performance.entityradiuscheck.lesscollisions.json
+++ b/src/main/resources/mixins.tweaks.performance.entityradiuscheck.lesscollisions.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTWorldMixin"]
+  "mixins": ["UTEntityLivingBaseMixin", "UTWorldMixin"]
 }

--- a/src/main/resources/mixins.tweaks.performance.entityradiuscheck.reducesearchsize.json
+++ b/src/main/resources/mixins.tweaks.performance.entityradiuscheck.reducesearchsize.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.reducesearchsize.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTChunkMixin", "UTWorldMixin"]
+}

--- a/src/main/resources/mixins.tweaks.performance.pathfinding.json
+++ b/src/main/resources/mixins.tweaks.performance.pathfinding.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.pathfinding.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTPathfindingChunkCacheMixin"]
+}


### PR DESCRIPTION
Based on various tweaks from RLTweaker with the same names:
- [1] Pathfinding Chunk Cache: prevents mobs from loading new/unloaded chunks when pathfinding
- [2a] Reduced Search Size: reduces search sizes for specified entities in AABB functions
  - With the default config, this helps with dropped item performance and various AI checks for the player
- [2b] Less Collisions: reduces sizes of collision checks for most vanilla entities and specified entities

The config allows for adding new targets to either tweak labeled [2].
The tweaks labeled [2] only help with performance if you have a mod that changes `World.MAX_ENTITY_RADIUS`, which includes, but is not limited to, Lycanites Mobs, Advanced Rocketry, and Immersive Railroading.

RLTweaker(2) and AIReducer should still be compatible, as their modifications should be taking priority.

Also refactors class load checks to its own util class `UTReflectionUtil`.