### PR TITLE
Implement ModularRouters particle thread fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Mob Stages**
     * **Spawning Rules Fixes:** Fixes mob replacement ignoring entity spawning rules
+* **Modular Routers**
+    * **Particle Thread Fix:** Fixes particles being added from the wrong thread which corrupted the particle manager
 * **MrTJPCore**
     * **Memory Leak Fix:** Fixes a memory leak associated with EntityPlayer
 * **Nether Chest**

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,7 @@ dependencies {
     compileOnly 'curse.maven:industrialcraft-242638:3078604'
     compileOnly 'curse.maven:ironbackpacks-227049:2564573'
     compileOnly 'curse.maven:mekanism-268560:2835175'
+    compileOnly 'curse.maven:modular-routers-250294:2954953'
     compileOnly 'curse.maven:mrtjpcore-229002:2735197'
     compileOnly 'curse.maven:netherchest-268888:2655413'
     compileOnly 'curse.maven:netherrocks-226140:2628297'
@@ -203,7 +204,7 @@ dependencies {
     compileOnly 'curse.maven:tinkerscomplement-272671:2843439'
     compileOnly 'curse.maven:tinyprogressions-250850:2721018'
     compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
-    // implementation 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
+    // runtimeOnly 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
 
     if (project.use_mixins.toBoolean()) {
         String mixin = modUtils.enableMixins("zone.rong:mixinbooter:9.1", "universaltweaks.refmap.json")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -119,6 +119,10 @@ public class UTConfigMods
     @Config.Name("Mob Stages")
     public static final MobStagesCategory MOB_STAGES = new MobStagesCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.modularrouters")
+    @Config.Name("Modular Routers")
+    public static final ModularRoutersCategory MODULAR_ROUTERS = new ModularRoutersCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.mrtjpcore")
     @Config.Name("MrTJPCore")
     public static final MrTJPCoreCategory MRTJPCORE = new MrTJPCoreCategory();
@@ -508,6 +512,14 @@ public class UTConfigMods
         @Config.Name("Spawning Rules Fixes")
         @Config.Comment("Fixes mob replacement ignoring entity spawning rules")
         public boolean utSpawningRules = true;
+    }
+
+    public static class ModularRoutersCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Particle Thread Fix")
+        @Config.Comment("Fixes particles being added from the wrong thread which corrupted the particle manager")
+        public boolean utParticleThreadToggle = true;
     }
 
     public static class MrTJPCoreCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -21,6 +21,7 @@ public class UTMixinLoader implements ILateMixinLoader
             configs.add("mixins.mods.compactmachines.json");
             configs.add("mixins.mods.crafttweaker.json");
             configs.add("mixins.mods.hwyla.json");
+            configs.add("mixins.mods.modularrouters.json");
             configs.add("mixins.mods.roost.json");
             configs.add("mixins.mods.storagedrawers.client.json");
             configs.add("mixins.mods.thaumcraft.entities.client.json");
@@ -105,6 +106,8 @@ public class UTMixinLoader implements ILateMixinLoader
                     return Loader.isModLoaded("crafttweaker");
                 case "mixins.mods.hwyla.json":
                     return Loader.isModLoaded("waila");
+                case "mixins.mods.modularrouters.json":
+                    return Loader.isModLoaded("modularrouters") && UTConfigMods.MODULAR_ROUTERS.utParticleThreadToggle;
                 case "mixins.mods.roost.json":
                     return Loader.isModLoaded("roost") && Loader.isModLoaded("contenttweaker");
                 case "mixins.mods.storagedrawers.client.json":

--- a/src/main/java/mod/acgaming/universaltweaks/mods/modularrouters/mixin/UTParticleBeamMessageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/modularrouters/mixin/UTParticleBeamMessageMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.mods.modularrouters.mixin;
+
+
+import java.awt.Color;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.desht.modularrouters.client.fx.Vector3;
+import me.desht.modularrouters.network.ParticleBeamMessage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = ParticleBeamMessage.Handler.class, remap = false)
+public class UTParticleBeamMessageMixin
+{
+    @WrapOperation(method = "onMessage(Lme/desht/modularrouters/network/ParticleBeamMessage;Lnet/minecraftforge/fml/common/network/simpleimpl/MessageContext;)Lnet/minecraftforge/fml/common/network/simpleimpl/IMessage;", at = @At(value = "INVOKE", target = "Lme/desht/modularrouters/client/fx/ParticleBeam;doParticleBeam(Lnet/minecraft/world/World;Lme/desht/modularrouters/client/fx/Vector3;Lme/desht/modularrouters/client/fx/Vector3;Ljava/awt/Color;F)V"))
+    private void utScheduleParticle(World world, Vector3 orig, Vector3 end, Color flatColor, float size, Operation<Void> original)
+    {
+        Minecraft.getMinecraft().addScheduledTask(() ->
+        {
+           original.call(world, orig, end, flatColor, size);
+        });
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -68,6 +68,7 @@ cfg.universaltweaks.modintegration.ironbackpacks=Iron Backpacks
 cfg.universaltweaks.modintegration.itemstages=Item Stages
 cfg.universaltweaks.modintegration.mekanism=Mekanism
 cfg.universaltweaks.modintegration.mobstages=Mob Stages
+cfg.universaltweaks.modintegration.modularrouters=Modular Routers
 cfg.universaltweaks.modintegration.mrtjpcore=MrTJPCore
 cfg.universaltweaks.modintegration.netherchest=Nether Chest
 cfg.universaltweaks.modintegration.netherrocks=Netherrocks

--- a/src/main/resources/mixins.mods.modularrouters.json
+++ b/src/main/resources/mixins.mods.modularrouters.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.modularrouters.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTParticleBeamMessageMixin"]
+}


### PR DESCRIPTION
Fixes Modular Routers adding particles [from the network thread](https://github.com/desht/ModularRouters/blob/MC1.12-master/src/main/java/me/desht/modularrouters/network/ParticleBeamMessage.java#L71) by scheduling the action on the main client thread. The particle manager's queue is not thread-safe, so this eventually corrupted the queue, no longer spawning particles and eventually filling up the game's memory. Finding other mods that do this and fixing them is preferable as opposed to making the particle queue thread-safe which RLTweaker does.