### PR TITLE
Fix tiny Quake Hammer Texture

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ All changes are toggleable via config files.
     * **Memory Leak Fix:** Fixes a client-side memory leak when wearing Void Fortress armor
 * **The Erebus**
     * **Preserved Blocks Fix:** Prevents HWYLA/TOP crashes with preserved blocks
+    * **Fix Quake Hammer Texture:** Fixes the Quake Hammer using the incorrect config option to control its size
 * **The Farlanders**
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Thermal Expansion**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -390,6 +390,11 @@ public class UTConfigMods
         @Config.Name("Preserved Blocks Fix")
         @Config.Comment("Prevents HWYLA/TOP crashes with preserved blocks")
         public boolean utEBPreservedBlocksToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Fix Quake Hammer Texture")
+        @Config.Comment("Fixes the Quake Hammer using the incorrect config option to control its size")
+        public boolean utFixQuakeHammerTexture = true;
     }
 
     public static class ExtraUtilitiesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -52,6 +52,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
             put("mixins.mods.epicsiegemod.json", () -> loaded("epicsiegemod"));
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
+            put("mixins.mods.erebus.quakehammer.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utFixQuakeHammerTexture);
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
             put("mixins.mods.extrautilities.mutabledrops.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/quakehammer/mixin/UTQuakeHammerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/quakehammer/mixin/UTQuakeHammerMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.erebus.quakehammer.mixin;
+
+import erebus.core.handler.configs.ConfigHandler;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraftforge.common.config.Configuration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ConfigHandler.class, remap = false)
+public class UTQuakeHammerMixin
+{
+    @Shadow
+    public Configuration config;
+
+    @Shadow
+    public float getHammer_renderSizeChargedMultiplier;
+
+    @Redirect(method = "syncConfigs", at = @At(value = "FIELD", target = "Lerebus/core/handler/configs/ConfigHandler;hammer_renderSize:F", ordinal = 1))
+    private void utFixRenderSize(ConfigHandler configHandler, float original)
+    {
+        if (!UTConfigMods.EREBUS.utFixQuakeHammerTexture) return;
+        this.getHammer_renderSizeChargedMultiplier = this.config.getFloat("Quake Hammer charged render size", "Quake Hammer", 0.03F, 0.0F, Float.MAX_VALUE, "");
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/quakehammer/mixin/UTQuakeHammerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/quakehammer/mixin/UTQuakeHammerMixin.java
@@ -2,9 +2,7 @@ package mod.acgaming.universaltweaks.mods.erebus.quakehammer.mixin;
 
 import erebus.core.handler.configs.ConfigHandler;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
-import net.minecraftforge.common.config.Configuration;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
@@ -12,16 +10,10 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(value = ConfigHandler.class, remap = false)
 public class UTQuakeHammerMixin
 {
-    @Shadow
-    public Configuration config;
-
-    @Shadow
-    public float getHammer_renderSizeChargedMultiplier;
-
     @Redirect(method = "syncConfigs", at = @At(value = "FIELD", target = "Lerebus/core/handler/configs/ConfigHandler;hammer_renderSize:F", ordinal = 1))
     private void utFixRenderSize(ConfigHandler configHandler, float original)
     {
         if (!UTConfigMods.EREBUS.utFixQuakeHammerTexture) return;
-        this.getHammer_renderSizeChargedMultiplier = this.config.getFloat("Quake Hammer charged render size", "Quake Hammer", 0.03F, 0.0F, Float.MAX_VALUE, "");
+        configHandler.getHammer_renderSizeChargedMultiplier = original;
     }
 }

--- a/src/main/resources/mixins.mods.erebus.quakehammer.json
+++ b/src/main/resources/mixins.mods.erebus.quakehammer.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.erebus.quakehammer.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTQuakeHammerMixin"]
+}


### PR DESCRIPTION
the Quake Hammer has two config values for its rendering size, one of which defaults to `1.75` and the other defaults to `0.03`. the same config option, `hammer_renderSize` is set by both of these in that order, resulting in the default appearance being nearly invisible. the latter option should be setting `getHammer_renderSizeChargedMultiplier`.

heres some issues solved by this change:
https://github.com/vadis365/TheErebus/issues/791, https://github.com/vadis365/TheErebus/issues/798, https://github.com/Divine-Journey-2/Divine-Journey-2/issues/229