### PR TITLE
add more Infinity enchantment tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ All changes are toggleable via config files.
 * **Infinity:**
     * **Bow Infinity Remedy:** Bows enchanted with Infinity no longer require arrows
     * **Mending and Infinity:** Allows the Infinity Enchantment to be combined with Mending
+    * **Infinity Affects All Arrows:** Allows the Infinity Enchantment to apply to all arrows (e.g. Tipped Arrows)
 * **Breakable Bedrock:** Allows customizable mining of bedrock
 * **Burning Baby Zombies:** Lets baby zombies burn in daylight as in Minecraft 1.13+
 * **Charged Creeper Spawning:** Sets the chance for creepers to spawn charged

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ All changes are toggleable via config files.
 * **Block Dispenser:** Allows dispensers to place blocks
 * **Block Hit Delay:** Sets the delay in ticks between breaking blocks
 * **Boat Speed:** Sets the acceleration value for controlling boats
-* **Bow Infinity Remedy:** Bows enchanted with Infinity no longer require arrows
+* **Infinity:**
+    * **Bow Infinity Remedy:** Bows enchanted with Infinity no longer require arrows
+    * **Mending and Infinity:** Allows the Infinity Enchantment to be combined with Mending
 * **Breakable Bedrock:** Allows customizable mining of bedrock
 * **Burning Baby Zombies:** Lets baby zombies burn in daylight as in Minecraft 1.13+
 * **Charged Creeper Spawning:** Sets the chance for creepers to spawn charged

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -888,6 +888,10 @@ public class UTConfigTweaks
         @Config.Name("Attack Cooldown")
         public final AttackCooldownCategory ATTACK_COOLDOWN = new AttackCooldownCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.items.infinity")
+        @Config.Name("Mending")
+        public final InfinityCategory INFINITY = new InfinityCategory();
+
         @Config.LangKey("cfg.universaltweaks.tweaks.items.itementities")
         @Config.Name("Item Entities")
         public final ItemEntitiesCategory ITEM_ENTITIES = new ItemEntitiesCategory();
@@ -922,10 +926,6 @@ public class UTConfigTweaks
         @Config.Name("No Leftover Breath Bottles")
         @Config.Comment("Disables dragon's breath from being a container item and leaving off empty bottles when a stack is brewed with")
         public boolean utLeftoverBreathBottleToggle = true;
-
-        @Config.Name("Bow Infinity")
-        @Config.Comment("Bows enchanted with Infinity no longer require arrows")
-        public boolean utBowInfinityToggle = true;
 
         @Config.Name("Custom Rarity")
         @Config.Comment
@@ -1012,6 +1012,17 @@ public class UTConfigTweaks
             @Config.Name("[3] Hide Attack Speed Tooltip")
             @Config.Comment("Hides attack speed tooltips of weapons")
             public boolean utAttackCooldownTooltips = true;
+        }
+
+        public static class InfinityCategory
+        {
+            @Config.Name("[1] Arrowless Infinity")
+            @Config.Comment("Bows enchanted with Infinity no longer require arrows")
+            public boolean utBowInfinityToggle = true;
+
+            @Config.Name("[2] Infinity Conflict")
+            @Config.Comment("Allows the Infinity Enchantment to be combined with Mending")
+            public boolean utInfinityEnchantmentConflicts = false;
         }
 
         public static class ItemEntitiesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1023,6 +1023,10 @@ public class UTConfigTweaks
             @Config.Name("[2] Infinity Conflict")
             @Config.Comment("Allows the Infinity Enchantment to be combined with Mending")
             public boolean utInfinityEnchantmentConflicts = false;
+
+            @Config.Name("[3] Infinity Affects All Arrows")
+            @Config.Comment("Allows the Infinity Enchantment to apply to all arrows (e.g. Tipped Arrows)")
+            public boolean utAllArrowsAreInfinite = false;
         }
 
         public static class ItemEntitiesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -162,6 +162,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
             put("mixins.tweaks.items.eating.json", () -> UTConfigTweaks.ITEMS.utAlwaysEatToggle);
             put("mixins.tweaks.items.hardcorebuckets.json", () -> UTConfigTweaks.ITEMS.utHardcoreBucketsToggle);
+            put("mixins.tweaks.items.infinitymending.json", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("mixins.tweaks.items.itementities.server.json", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
             put("mixins.tweaks.items.repairing.json", () -> UTConfigTweaks.ITEMS.utCraftingRepairToggle);
             put("mixins.tweaks.items.xpbottle.json", () -> UTConfigTweaks.ITEMS.utXPBottleAmount != -1);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -162,6 +162,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
             put("mixins.tweaks.items.eating.json", () -> UTConfigTweaks.ITEMS.utAlwaysEatToggle);
             put("mixins.tweaks.items.hardcorebuckets.json", () -> UTConfigTweaks.ITEMS.utHardcoreBucketsToggle);
+            put("mixins.tweaks.items.infinityallarrows.json", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);
             put("mixins.tweaks.items.infinitymending.json", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("mixins.tweaks.items.itementities.server.json", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
             put("mixins.tweaks.items.repairing.json", () -> UTConfigTweaks.ITEMS.utCraftingRepairToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/UTBowInfinity.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/UTBowInfinity.java
@@ -23,7 +23,7 @@ public class UTBowInfinity
     @SubscribeEvent
     public static void utBowInfinity(ArrowNockEvent event)
     {
-        if (!UTConfigTweaks.ITEMS.utBowInfinityToggle) return;
+        if (!UTConfigTweaks.ITEMS.INFINITY.utBowInfinityToggle) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTBowInfinity ::: Arrow nock event");
         if (EnchantmentHelper.getEnchantmentLevel(INFINITY, event.getBow()) > 0)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/infinityallarrows/mixin/UTItemArrowMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/infinityallarrows/mixin/UTItemArrowMixin.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.tweaks.items.bowinfinity.infinityallarrows.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.ItemArrow;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemArrow.class)
+public abstract class UTItemArrowMixin
+{
+    @ModifyReturnValue(method = "isInfinite", at = @At("RETURN"), remap = false)
+    public boolean utIsInfinite(boolean original, @Local LocalIntRef enchant)
+    {
+        if (!UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite) return original;
+        return enchant.get() > 0;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/mending/mixin/UTEnchantmentArrowInfiniteMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bowinfinity/mending/mixin/UTEnchantmentArrowInfiniteMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.tweaks.items.bowinfinity.mending.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.enchantment.EnchantmentArrowInfinite;
+import net.minecraft.enchantment.EnchantmentMending;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+
+// Courtesy of WaitingIdly
+@Mixin(value = EnchantmentArrowInfinite.class)
+public abstract class UTEnchantmentArrowInfiniteMixin
+{
+    @WrapOperation(method = "canApplyTogether", constant = @Constant(classValue = EnchantmentMending.class))
+    public boolean utMixinModifyConstant(Object ench, Operation<Boolean> original)
+    {
+        if (!UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts) return original.call(ench);
+        return false;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -35,7 +35,7 @@ public class UTObsoleteModsHandler
             put("blockfire", () -> UTConfigBugfixes.ENTITIES.utBlockFireToggle);
             put("blockoverlayfix", () -> UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle);
             put("bottomsugarcanharvest", () -> UTConfigTweaks.BLOCKS.utSugarCaneSize != 3);
-            put("bowinfinityfix", () -> UTConfigTweaks.ITEMS.utBowInfinityToggle);
+            put("bowinfinityfix", () -> UTConfigTweaks.ITEMS.INFINITY.utBowInfinityToggle);
             put("breedablekillerrabbit", () -> UTConfigTweaks.ENTITIES.utRabbitKillerChance > 0.0D);
             put("burnbabyburn", () -> UTConfigTweaks.ENTITIES.utBurningBabyZombiesToggle);
             put("chickensshed", () -> UTConfigTweaks.ENTITIES.CHICKEN_SHEDDING.utChickenSheddingToggle);
@@ -74,6 +74,7 @@ public class UTObsoleteModsHandler
             put("horsefallfix", () -> UTConfigBugfixes.ENTITIES.utHorseFallingToggle);
             put("horsestandstill", () -> UTConfigTweaks.ENTITIES.utSaddledWanderingToggle);
             put("ikwid", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle);
+            put("infwithmend", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("insomniac", () -> UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle);
             put("inventoryspam", () -> UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle);
             put("keydescfix", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -76,6 +76,7 @@ public class UTObsoleteModsHandler
             put("ikwid", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle);
             put("infwithmend", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("insomniac", () -> UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle);
+            put("infinityworkswithallarrows", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);
             put("inventoryspam", () -> UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle);
             put("keydescfix", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);
             put("lanserverproperties", () -> UTConfigTweaks.MISC.utLANServerProperties);

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -74,9 +74,9 @@ public class UTObsoleteModsHandler
             put("horsefallfix", () -> UTConfigBugfixes.ENTITIES.utHorseFallingToggle);
             put("horsestandstill", () -> UTConfigTweaks.ENTITIES.utSaddledWanderingToggle);
             put("ikwid", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle);
+            put("infinityworkswithallarrows", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);
             put("infwithmend", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("insomniac", () -> UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle);
-            put("infinityworkswithallarrows", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);
             put("inventoryspam", () -> UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle);
             put("keydescfix", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);
             put("lanserverproperties", () -> UTConfigTweaks.MISC.utLANServerProperties);

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -119,6 +119,7 @@ cfg.universaltweaks.tweaks.entities.spawncaps=Spawn Caps
 cfg.universaltweaks.tweaks.entities.undeadhorses=Undead Horses
 cfg.universaltweaks.tweaks.entities.waterfalldamage=Water Fall Damage
 cfg.universaltweaks.tweaks.items.attackcooldown=Attack Cooldown
+cfg.universaltweaks.tweaks.items.infinity=Infinity
 cfg.universaltweaks.tweaks.items.itementities=Item Entities
 cfg.universaltweaks.tweaks.items.mending=Mending
 cfg.universaltweaks.tweaks.items.parry=Shield Parry

--- a/src/main/resources/mixins.tweaks.items.infinityallarrows.json
+++ b/src/main/resources/mixins.tweaks.items.infinityallarrows.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.bowinfinity.infinityallarrows.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemArrowMixin"]
+}

--- a/src/main/resources/mixins.tweaks.items.infinitymending.json
+++ b/src/main/resources/mixins.tweaks.items.infinitymending.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.bowinfinity.mending.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEnchantmentArrowInfiniteMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- moves `utBowInfinityToggle` to new config category.
- adds option to allow infinity and mending together (default: `false`).
- adds option to have all arrows (eg tipped arrows) function as infinite if shot with infinity (default: `false`).