### PR TITLE
Improve Toast Control capability

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -55,6 +55,7 @@ import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFComp
 import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
 import mod.acgaming.universaltweaks.tweaks.world.stronghold.UTStronghold;
 import mod.acgaming.universaltweaks.tweaks.world.stronghold.worldgen.SafeStrongholdWorldGenerator;
+import mod.acgaming.universaltweaks.util.UTKeybindings;
 import mod.acgaming.universaltweaks.util.UTPacketHandler;
 import mod.acgaming.universaltweaks.util.compat.UTObsoleteModsHandler;
 import net.tardis.mod.proxy.ClientProxy;
@@ -163,6 +164,7 @@ public class UniversalTweaks
         if (UTConfigTweaks.MISC.utLANServerProperties) MinecraftForge.EVENT_BUS.register(UTLanServerProperties.class);
         if (UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) UTPickupNotificationOverlay.init();
         if (Loader.isModLoaded("botania")) MinecraftForge.EVENT_BUS.register(UTBotaniaFancySkybox.class);
+        UTKeybindings.initialize();
     }
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -165,6 +165,7 @@ public class UniversalTweaks
         if (UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) UTPickupNotificationOverlay.init();
         if (Loader.isModLoaded("botania")) MinecraftForge.EVENT_BUS.register(UTBotaniaFancySkybox.class);
         UTKeybindings.initialize();
+        LOGGER.info(NAME + " client initialized");
     }
 
     @Mod.EventHandler
@@ -190,6 +191,7 @@ public class UniversalTweaks
         if (UTConfigTweaks.MISC.LOAD_SOUNDS.utLoadSoundMode != UTConfigTweaks.MiscCategory.LoadSoundsCategory.EnumSoundModes.NOTHING) UTLoadSound.initLists();
         if (UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlTutorialToggle) UTTutorialToast.utTutorialToast();
         if (Loader.isModLoaded("botania")) UTBotaniaFancySkybox.initDimList();
+        LOGGER.info(NAME + " client post-initialized");
     }
 
     @Mod.EventHandler

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1682,6 +1682,27 @@ public class UTConfigTweaks
             @Config.Name("[5] Disable Tutorial Toasts")
             @Config.Comment("Determines if tutorial toasts are blocked. Blocks useless things like use WASD to move.")
             public boolean utToastControlTutorialToggle = true;
+
+            @Config.Name("[6] Toast Control List")
+            @Config.Comment
+                    ({
+                            "List of class names of Toasts to prevent displaying",
+                            "Behavior depends on the list mode",
+                            "Syntax: full class name"
+                    })
+            public String[] utToastControlClassList = new String[] {};
+
+            @Config.Name("[7] List Mode")
+            @Config.Comment
+                    ({
+                            "Blacklist Mode: Toast classes which can't be added to the queue, others can",
+                            "Whitelist Mode: Toast classes which can be added to the queue, others can't"
+                    })
+            public EnumLists utToastControlClassListMode = EnumLists.BLACKLIST;
+
+            @Config.Name("[8] Debug Logging")
+            @Config.Comment("Enables debug logging to log class names of displayed toasts to the log")
+            public boolean utToastNameLogging = false;
         }
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1703,6 +1703,10 @@ public class UTConfigTweaks
             @Config.Name("[8] Debug Logging")
             @Config.Comment("Enables debug logging to log class names of displayed toasts to the log")
             public boolean utToastNameLogging = false;
+
+            @Config.Name("[9] Clear Toast Keybind")
+            @Config.Comment("Enables a keybind (default: CTRL+0) to clear all active toasts")
+            public boolean utClearToastKeybind = true;
         }
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.misc.toastcontrol;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTKeybindings;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.input.Keyboard;
+
+public class UTClearToastKeybind extends UTKeybindings.Key
+{
+    public UTClearToastKeybind()
+    {
+        super("clear_toasts", KeyConflictContext.IN_GAME, KeyModifier.CONTROL, Keyboard.KEY_0);
+    }
+
+    public static void createKeybind()
+    {
+        if (UTConfigTweaks.MISC.TOAST_CONTROL.utClearToastKeybind) UTKeybindings.addKey(new UTClearToastKeybind());
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void handleKeybind()
+    {
+        Minecraft.getMinecraft().getToastGui().clear();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
@@ -18,7 +18,7 @@ public class UTClearToastKeybind extends UTKeybindings.Key
 
     public static void createKeybind()
     {
-        if (UTConfigTweaks.MISC.TOAST_CONTROL.utClearToastKeybind) UTKeybindings.addKey(new UTClearToastKeybind());
+        if (UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle && UTConfigTweaks.MISC.TOAST_CONTROL.utClearToastKeybind) UTKeybindings.addKey(new UTClearToastKeybind());
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/UTClearToastKeybind.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Keyboard;
 
+@SideOnly(Side.CLIENT)
 public class UTClearToastKeybind extends UTKeybindings.Key
 {
     public UTClearToastKeybind()

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/mixin/UTGuiToastMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/toastcontrol/mixin/UTGuiToastMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.mixin;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.client.gui.toasts.GuiToast;
+import net.minecraft.client.gui.toasts.IToast;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Mixin(value = GuiToast.class)
+public abstract class UTGuiToastMixin
+{
+    @Inject(method = "add", at = @At(value = "HEAD"), cancellable = true)
+    private void utFilterToasts(IToast toastIn, CallbackInfo ci)
+    {
+        if (UTConfigTweaks.MISC.TOAST_CONTROL.utToastNameLogging) UniversalTweaks.LOGGER.info("UTGuiToastMixin ::: Displaying Toast: " + toastIn.getClass().getName());
+        boolean isWhitelist = UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlClassListMode == UTConfigTweaks.EnumLists.WHITELIST;
+        if (Arrays.asList(UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlClassList).contains(toastIn.getClass().getName()) != isWhitelist) ci.cancel();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
@@ -1,0 +1,125 @@
+package mod.acgaming.universaltweaks.util;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.UTClearToastKeybind;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.IKeyConflictContext;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.InputEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID, value = Side.CLIENT)
+@SideOnly(Side.CLIENT)
+public class UTKeybindings extends KeyBinding
+{
+    private static final List<Key> keys = new ArrayList<>();
+
+    protected UTKeybindings(UTKeybindings.Key key)
+    {
+        super(key.getDescription(), key.getKeyConflictContext(), key.getKeyModifier(), key.getKeyCode(), UniversalTweaks.NAME);
+        ClientRegistry.registerKeyBinding(this);
+    }
+
+    public static void addKey(UTKeybindings.Key key)
+    {
+        keys.add(key);
+    }
+
+    public static void initialize()
+    {
+        for (Key key : keys)
+        {
+            key.getKey();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onKeyInput(InputEvent event)
+    {
+        if (!Minecraft.getMinecraft().inGameHasFocus) return;
+
+        for (Key key : keys)
+        {
+            if (key.getKey().isPressed()) key.handleKeybind();
+        }
+    }
+
+    public static abstract class Key
+    {
+        private final String name;
+        private final IKeyConflictContext keyConflictContext;
+        private final KeyModifier keyModifier;
+        private final int keyCode;
+
+        @SideOnly(Side.CLIENT)
+        private KeyBinding key;
+
+        public Key(String name, int keyCode)
+        {
+            this(name, KeyConflictContext.UNIVERSAL, keyCode);
+        }
+
+        public Key(String name, IKeyConflictContext keyConflictContext, int keyCode)
+        {
+            this(name, keyConflictContext, KeyModifier.NONE, keyCode);
+        }
+
+        public Key(String name, IKeyConflictContext keyConflictContext, KeyModifier keyModifier, int keyCode)
+        {
+            this.name = name;
+            this.keyConflictContext = keyConflictContext;
+            this.keyModifier = keyModifier;
+            this.keyCode = keyCode;
+        }
+
+        @SideOnly(Side.CLIENT)
+        public abstract void handleKeybind();
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public IKeyConflictContext getKeyConflictContext()
+        {
+            return keyConflictContext;
+        }
+
+        public KeyModifier getKeyModifier()
+        {
+            return keyModifier;
+        }
+
+        public int getKeyCode()
+        {
+            return keyCode;
+        }
+
+        @SideOnly(Side.CLIENT)
+        public KeyBinding getKey()
+        {
+            if (key == null) key = new UTKeybindings(this);
+            return key;
+        }
+
+        @SideOnly(Side.CLIENT)
+        public void setKey(KeyBinding key)
+        {
+            this.key = key;
+        }
+
+        public String getDescription()
+        {
+            return String.format("keybind.%s.%s", UniversalTweaks.MODID, name);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
@@ -36,6 +36,8 @@ public class UTKeybindings extends KeyBinding
 
     public static void initialize()
     {
+        UTClearToastKeybind.createKeybind();
+
         for (Key key : keys)
         {
             key.getKey();

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -3,6 +3,8 @@ msg.universaltweaks.obsoletemods.warning1=Universal Tweaks has replaced and impr
 msg.universaltweaks.obsoletemods.warning2=Therefore, the following mods are now incompatible with Universal Tweaks:
 msg.universaltweaks.obsoletemods.warning3=Consider removing them from your game or disabling the respective features.
 
+# KEYBINDS
+
 # TOGGLE CHEATS
 btn.universaltweaks.cheats.enabled=Cheats: ON
 btn.universaltweaks.cheats.disabled=Cheats: OFF

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -4,6 +4,7 @@ msg.universaltweaks.obsoletemods.warning2=Therefore, the following mods are now 
 msg.universaltweaks.obsoletemods.warning3=Consider removing them from your game or disabling the respective features.
 
 # KEYBINDS
+keybind.universaltweaks.clear_toasts=Clear Toasts
 
 # TOGGLE CHEATS
 btn.universaltweaks.cheats.enabled=Cheats: ON

--- a/src/main/resources/mixins.tweaks.misc.toastcontrol.json
+++ b/src/main/resources/mixins.tweaks.misc.toastcontrol.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["UTAdvancementToastMixin", "UTRecipeToastMixin", "UTSystemToastMixin"]
+  "client": ["UTAdvancementToastMixin", "UTGuiToastMixin", "UTRecipeToastMixin", "UTSystemToastMixin"]
 }


### PR DESCRIPTION
changes in this PR:
- adds a `UTKeybinds` class, to store Universal Tweaks keybinds
- a keybind to clear all active toasts (default: `CTRL+0`)
- ability to block specific toasts by class
- ability to log class names of toasts (default: `false`)




resolves #210