### PR TITLE
Hide Personal Effect Particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ All changes are toggleable via config files.
 * **First Person Burning Overlay:** Sets the offset for the fire overlay in first person when the player is burning
 * **Growth Size:** Configurable growth height/length for sugar cane, cacti and vines
 * **Hardcore Buckets:** Prevents placing of liquid source blocks in the world
+* **Hide Personal Effect Particles:** Disables potion effect particles emitting from yourself
 * **Horizontal Collision Damage:** Applies horizontal collision damage to the player akin to elytra collision
 * **Husk & Stray Spawning:** Lets husks and strays spawn underground like regular zombies and skeletons
 * **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1325,6 +1325,11 @@ public class UTConfigTweaks
         public boolean utPotionShiftToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Hide Personal Effect Particles")
+        @Config.Comment("Disables potion effect particles emitting from yourself")
+        public boolean utPoVEffectParticles = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("No Smelting XP")
         @Config.Comment("Disables the experience reward when smelting items in furnaces")
         public boolean utSmeltingXPToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -65,6 +65,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.music.json", () -> UTConfigTweaks.MISC.utInfiniteMusicToggle);
             put("mixins.tweaks.misc.narrator.json", () -> UTConfigTweaks.MISC.utDisableNarratorToggle);
             put("mixins.tweaks.misc.nightvisionflash.json", () -> UTConfigTweaks.MISC.utNightVisionFlashToggle);
+            put("mixins.tweaks.misc.personalpotionparticles.json", () -> UTConfigTweaks.MISC.utPoVEffectParticles);
             put("mixins.tweaks.misc.recipebook.client.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);
             put("mixins.tweaks.misc.smoothscrolling.json", () -> UTConfigTweaks.MISC.SMOOTH_SCROLLING.utSmoothScrollingToggle);
             put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/potionparticles/mixin/UTPersonalPotionParticles.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/potionparticles/mixin/UTPersonalPotionParticles.java
@@ -1,0 +1,36 @@
+package mod.acgaming.universaltweaks.tweaks.misc.potionparticles.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@SuppressWarnings("ConstantValue")
+@Mixin(value = EntityLivingBase.class)
+public abstract class UTPersonalPotionParticles
+{
+    @ModifyExpressionValue(method = "updatePotionEffects", at = @At(value = "INVOKE", target = "Ljava/lang/Integer;intValue()I"))
+    public int utDisablePersonalEffectParticles(int integer)
+    {
+        if (!UTConfigTweaks.MISC.utPoVEffectParticles) return integer;
+        if (Minecraft.getMinecraft().player != null && (Object) this instanceof EntityPlayer && Minecraft.getMinecraft().player.getUniqueID().equals(((EntityPlayer) (Object) this).getUniqueID()))
+        {
+            return 0;
+        }
+        return integer;
+    }
+
+    @ModifyExpressionValue(method = "updatePotionEffects", at = @At(value = "INVOKE", target = "Ljava/lang/Boolean;booleanValue()Z"))
+    public boolean utDisablePersonalEffectParticles(boolean bool)
+    {
+        if (!UTConfigTweaks.MISC.utPoVEffectParticles) return bool;
+        if (Minecraft.getMinecraft().player != null && (Object) this instanceof EntityPlayer && Minecraft.getMinecraft().player.getUniqueID().equals(((EntityPlayer) (Object) this).getUniqueID()))
+        {
+            return true;
+        }
+        return bool;
+    }
+}

--- a/src/main/resources/mixins.tweaks.misc.personalpotionparticles.json
+++ b/src/main/resources/mixins.tweaks.misc.personalpotionparticles.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.potionparticles.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTPersonalPotionParticles"]
+}


### PR DESCRIPTION
changes in this PR:
- allows disabling the particle effects of the PoV player. works via checking the UUID of `Minecraft.getMinecraft().player`. (default: `false`).

was rather a pain to test this, since i have to be on a server + have two accounts join (with different usernames).