### PR TITLE
Fixes Cabbage not dropping the correct items in some situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Memory Leak Fix:** Fixes a client-side memory leak when wearing Void Fortress armor
 * **The Erebus**
+    * **Fix Cabbage Drop:** Fixes Cabbage not dropping the correct items in some situations
     * **Preserved Blocks Fix:** Prevents HWYLA/TOP crashes with preserved blocks
 * **The Farlanders**
     * **Duplication Fixes:** Fixes various duplication exploits

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -387,6 +387,11 @@ public class UTConfigMods
     public static class ErebusCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Fix Cabbage Drop")
+        @Config.Comment("Fixes Cabbage not dropping the correct items in some situations")
+        public boolean utCabbageDrop = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Preserved Blocks Fix")
         @Config.Comment("Prevents HWYLA/TOP crashes with preserved blocks")
         public boolean utEBPreservedBlocksToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -51,6 +51,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
             put("mixins.mods.epicsiegemod.json", () -> loaded("epicsiegemod"));
+            put("mixins.mods.erebus.cabbage.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utCabbageDrop);
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -1,0 +1,74 @@
+package mod.acgaming.universaltweaks.mods.erebus.cabbage.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import erebus.ModItems;
+import erebus.blocks.BlockCabbage;
+import erebus.items.ItemErebusFood;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.block.BlockCrops;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Random;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlockCabbage.class, remap = false)
+public abstract class UTCabbageMixin extends BlockCrops
+{
+    @Inject(method = "getDrops", at = @At("RETURN"), cancellable = true)
+    private void utOverrideDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune, CallbackInfoReturnable<List<ItemStack>> cir)
+    {
+        if (!UTConfigMods.EREBUS.utCabbageDrop) return;
+        NonNullList<ItemStack> drops = NonNullList.create();
+        getDrops(drops, world, pos, state, fortune);
+        cir.setReturnValue(drops);
+    }
+
+    @Override
+    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune)
+    {
+        if (!UTConfigMods.EREBUS.utCabbageDrop) return;
+        Random rand = world instanceof World ? ((World) world).rand : RANDOM;
+        int age = getAge(state);
+
+        int count = quantityDropped(state, 0, rand);
+        for (int i = 0; i < count; i++)
+        {
+            Item item = this.getItemDropped(state, rand, 0);
+            if (item != Items.AIR)
+            {
+                drops.add(new ItemStack(item, 1, ItemErebusFood.EnumFoodType.CABBAGE.ordinal()));
+            }
+        }
+
+        if (age >= getMaxAge())
+        {
+            for (int i = 0; i < 3 + fortune; ++i)
+            {
+                if (rand.nextInt(2 * getMaxAge()) <= age)
+                {
+                    drops.add(new ItemStack(this.getSeed(), 1, 0));
+                }
+            }
+        }
+    }
+
+    @ModifyReturnValue(method = "getCrop", at = @At("RETURN"))
+    private Item utGetCrop(Item original)
+    {
+        if (!UTConfigMods.EREBUS.utCabbageDrop) return original;
+        return ModItems.EREBUS_FOOD;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -37,32 +37,10 @@ public abstract class UTCabbageMixin extends BlockCrops
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune)
+    public int damageDropped(IBlockState blockState)
     {
-        if (!UTConfigMods.EREBUS.utCabbageDrop) return;
-        Random rand = world instanceof World ? ((World) world).rand : RANDOM;
-        int age = getAge(state);
-
-        int count = quantityDropped(state, 0, rand);
-        for (int i = 0; i < count; i++)
-        {
-            Item item = this.getItemDropped(state, rand, 0);
-            if (item != Items.AIR)
-            {
-                drops.add(new ItemStack(item, 1, ItemErebusFood.EnumFoodType.CABBAGE.ordinal()));
-            }
-        }
-
-        if (age >= getMaxAge())
-        {
-            for (int i = 0; i < 3 + fortune; ++i)
-            {
-                if (rand.nextInt(2 * getMaxAge()) <= age)
-                {
-                    drops.add(new ItemStack(this.getSeed(), 1, 0));
-                }
-            }
-        }
+        if (!UTConfigMods.EREBUS.utCabbageDrop) return 0;
+        return ItemErebusFood.EnumFoodType.CABBAGE.ordinal();
     }
 
     @ModifyReturnValue(method = "getCrop", at = @At("RETURN"))

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -35,7 +35,7 @@ public abstract class UTCabbageMixin extends BlockCrops
     @Override
     public int damageDropped(IBlockState blockState)
     {
-        if (!UTConfigMods.EREBUS.utCabbageDrop) return 0;
+        if (!UTConfigMods.EREBUS.utCabbageDrop) return super.damageDropped(blockState);
         return ItemErebusFood.EnumFoodType.CABBAGE.ordinal();
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Mixin(value = BlockCabbage.class, remap = false)
 public abstract class UTCabbageMixin extends BlockCrops
 {
-    @Inject(method = "getDrops", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "getDrops", at = @At("HEAD"), cancellable = true)
     private void utOverrideDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune, CallbackInfoReturnable<List<ItemStack>> cir)
     {
         if (!UTConfigMods.EREBUS.utCabbageDrop) return;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -7,21 +7,17 @@ import erebus.items.ItemErebusFood;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Random;
 
 // Courtesy of WaitingIdly
 @Mixin(value = BlockCabbage.class, remap = false)

--- a/src/main/resources/mixins.mods.erebus.cabbage.json
+++ b/src/main/resources/mixins.mods.erebus.cabbage.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.erebus.cabbage.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTCabbageMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- overrides the `damageDropped` method to return the erebus food ordinal instead of 0.
- injects and directs the outdated `getDrops` method (no List input) to the current `getDrops` method.
- defaults to `true`.
- this should simply restore the drop logic to that of all crops, just dropping the correct cabbage items.

this should fix mods that only use the modern getDrops method for various reasons (eg Agricraft, right click harvest mods, Roots Harvest Spell) dropping nothing/the wrong item.