### PR TITLE
display ping time in server tab overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ All changes are toggleable via config files.
     * Prevents the fire animation overlay from being displayed when the player is immune to fire
 * **Better Harvest:** Prevents breaking lower parts of sugar cane and cacti as well as unripe crops, unless sneaking
 * **Better Ignition:** Enables ignition of entities by right-clicking instead of awkwardly lighting the block under them
+* **Better Ping Display:** Displays the ping in milliseconds of players when viewing the server list
 * **Better Placement:** Removes the delay between placing blocks
 * **Block Dispenser:** Allows dispensers to place blocks
 * **Block Hit Delay:** Sets the delay in ticks between breaking blocks

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1274,6 +1274,11 @@ public class UTConfigTweaks
         public boolean utLANServerProperties = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Better Ping Display")
+        @Config.Comment("Displays the ping in milliseconds of players when viewing the server list")
+        public boolean utBetterPing = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Prevent Keybinds from Overflowing Screen")
         @Config.Comment("Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present")
         public boolean utPreventKeybindingEntryOverflow = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -56,6 +56,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.gui.keybindlistentry.json", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);
             put("mixins.tweaks.misc.gui.lanserverproperties.json", () -> UTConfigTweaks.MISC.utLANServerProperties);
             put("mixins.tweaks.misc.gui.overlaymessage.json", () -> UTConfigTweaks.MISC.utOverlayMessageHeight != -4);
+            put("mixins.tweaks.misc.gui.ping.json", () -> UTConfigTweaks.MISC.utBetterPing);
             put("mixins.tweaks.misc.gui.potionduration.json", () -> UTConfigTweaks.MISC.utPotionDurationToggle);
             put("mixins.tweaks.misc.gui.selecteditemtooltip.json", () -> UTConfigTweaks.MISC.utSelectedItemTooltipHeight != 59);
             put("mixins.tweaks.misc.lightning.flash.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFlashToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
@@ -8,14 +8,19 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = GuiPlayerTabOverlay.class)
 public abstract class UTGuiPlayerTabOverlayMixin
 {
+    @Unique
     private static final int PING_TEXT_RENDER_OFFSET = 13;
-    private static final int EXTRA_WIDTH = 33;
+    @Unique
+    private static final int EXTRA_WIDTH = 37;
 
     @Shadow
     @Final

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
@@ -1,0 +1,50 @@
+package mod.acgaming.universaltweaks.tweaks.misc.gui.ping.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiPlayerTabOverlay;
+import net.minecraft.client.network.NetworkPlayerInfo;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = GuiPlayerTabOverlay.class)
+public abstract class UTGuiPlayerTabOverlayMixin
+{
+    private static final int PING_TEXT_RENDER_OFFSET = 13;
+    private static final int EXTRA_WIDTH = 33;
+
+    @Shadow
+    @Final
+    private Minecraft mc;
+
+    private static int utColorForTime(int responseTime)
+    {
+        if (responseTime <= 0) return 0xFFFFFF; // white
+        if (responseTime <= 150) return 0x00FF00; // green
+        if (responseTime <= 300) return 0xFFBB00; // yellow
+        if (responseTime <= 600) return 0xFF8000; // orange
+        if (responseTime < 10000) return 0xFF0000; // red
+        return 0xFFFFFF; // white (again)
+    }
+
+    @ModifyConstant(method = "renderPlayerlist", constant = @Constant(intValue = 13))
+    private int utAdjustTotalWidth(int original)
+    {
+        if (!UTConfigTweaks.MISC.utBetterPing) return original;
+        return original + EXTRA_WIDTH;
+    }
+
+    @Inject(method = "drawPing", at = @At(value = "HEAD"))
+    private void utDrawTimeDisplay(int x0, int x1, int y, NetworkPlayerInfo player, CallbackInfo ci)
+    {
+        if (!UTConfigTweaks.MISC.utBetterPing) return;
+        int responseTime = player.getResponseTime();
+        // If the time is 0 or extremely long, it is probably inaccurate, and we should display ??? instead.
+        String pingTimeText = responseTime <= 0 || responseTime >= 10000 ? "???ms" : String.format("%dms", responseTime);
+        int pingStringWidth = mc.fontRenderer.getStringWidth(pingTimeText);
+        mc.fontRenderer.drawStringWithShadow(pingTimeText, x0 + x1 - pingStringWidth - PING_TEXT_RENDER_OFFSET, y, utColorForTime(responseTime));
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.network.NetworkPlayerInfo;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -20,6 +21,7 @@ public abstract class UTGuiPlayerTabOverlayMixin
     @Final
     private Minecraft mc;
 
+    @Unique
     private static int utColorForTime(int responseTime)
     {
         if (responseTime <= 0) return 0xFFFFFF; // white

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/ping/mixin/UTGuiPlayerTabOverlayMixin.java
@@ -20,7 +20,7 @@ public abstract class UTGuiPlayerTabOverlayMixin
     @Unique
     private static final int PING_TEXT_RENDER_OFFSET = 13;
     @Unique
-    private static final int EXTRA_WIDTH = 37;
+    private static final String MAXIMUM_EXTRA_WIDTH_STRING = "9999ms";
 
     @Shadow
     @Final
@@ -41,7 +41,7 @@ public abstract class UTGuiPlayerTabOverlayMixin
     private int utAdjustTotalWidth(int original)
     {
         if (!UTConfigTweaks.MISC.utBetterPing) return original;
-        return original + EXTRA_WIDTH;
+        return original + mc.fontRenderer.getStringWidth(MAXIMUM_EXTRA_WIDTH_STRING) + 3;
     }
 
     @Inject(method = "drawPing", at = @At(value = "HEAD"))

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -29,6 +29,7 @@ public class UTObsoleteModsHandler
             put("bedfix", () -> UTConfigTweaks.ENTITIES.SLEEPING.utSleepingTime != -1);
             put("bedsaynosleep", () -> UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle);
             put("betterburning", () -> UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBArrowsToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBCookedToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBExtinguishToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBOverlayToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBSpreadingToggle);
+            put("betterpingdisplay", () -> UTConfigTweaks.MISC.utBetterPing);
             put("betterplacement", () -> UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementToggle);
             put("biggerpacketsplz", () -> UTConfigBugfixes.MISC.utPacketSize > 0x200000);
             put("blockdispenser", () -> UTConfigTweaks.BLOCKS.BLOCK_DISPENSER.utBlockDispenserToggle);

--- a/src/main/resources/mixins.tweaks.misc.gui.ping.json
+++ b/src/main/resources/mixins.tweaks.misc.gui.ping.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.gui.ping.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiPlayerTabOverlayMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- adds the ms time display adjacent to the user names.
- if <= 0 or >= 10000, we presume that the number is unknown or incorrect and simply display `???ms`.
- color coded as <= 150 green, <= 300 yellow, <= 600 orange, < 10000 red. anything else is white.

![image](https://github.com/ACGaming/UniversalTweaks/assets/25394029/19585336-58c6-4e83-bca8-1764fb9f467a)
