### PR TITLE
Improve crafting speed for NBT items by caching the last matching recipe

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -53,6 +53,7 @@ import mod.acgaming.universaltweaks.tweaks.misc.pickupnotification.UTPickupNotif
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
 import mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.UTTutorialToast;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
+import mod.acgaming.universaltweaks.tweaks.performance.craftingcache.UTCraftingCache;
 import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
 import mod.acgaming.universaltweaks.util.UTKeybindings;
 import mod.acgaming.universaltweaks.util.UTPacketHandler;
@@ -196,6 +197,7 @@ public class UniversalTweaks
     public void onServerStarting(FMLServerStartingEvent event)
     {
         if (UTConfigBugfixes.MISC.utHelpToggle) UTHelp.onServerStarting(event);
+        if (UTConfigTweaks.PERFORMANCE.utCraftingCacheToggle) UTCraftingCache.resetCache();
     }
 
     @Mod.EventHandler


### PR DESCRIPTION
- Cache the most recent successfully matched recipe and try it first before iterating all recipes (unconditionally)
- Cache the Loader.isModLoaded call
- Reset crafting cache on server starting to make sure it doesn't contain stale recipes if e.g. different scripts are loaded

Tested in Nomifactory CEU, makes GT tool crafting of full stacks take less than 0.5s instead of 3-5s for me.