### PR TITLE
Add tweak to disable Railcraft beta warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Quark**
     * **Duplication Fixes:** Fixes various duplication exploits
+* **Railcraft**
+  * **No Beta Warning:** Disables the beta message warning on world join
 * **RFTools Dimension**
     * **Properly Unregister Dimensions:** Fixes a bug where joining a world or server with any RFTools Dimension registered would disallow entering another world without that dimension until restarting.
 * **Roost**

--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,7 @@ dependencies {
     compileOnly 'curse.maven:projectredbase-228702:2745545'
     compileOnly 'curse.maven:projectredworld-229049:2745551'
     compileOnly 'curse.maven:quark-243121:2924091'
+    compileOnly 'curse.maven:railcraft-51195:3853491'
     compileOnly 'curse.maven:simplyjetpacks2-251792:3294422'
     compileOnly 'curse.maven:tardis-290247:2903453'
     compileOnly 'curse.maven:teslacorelib-254602:2891841'

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -58,6 +58,7 @@ import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntit
 import mod.acgaming.universaltweaks.util.UTKeybindings;
 import mod.acgaming.universaltweaks.util.UTPacketHandler;
 import mod.acgaming.universaltweaks.util.compat.UTObsoleteModsHandler;
+import mods.railcraft.common.core.BetaMessageTickHandler;
 import net.tardis.mod.proxy.ClientProxy;
 import tonius.simplyjetpacks.network.NetworkHandler;
 
@@ -102,6 +103,7 @@ public class UniversalTweaks
         + "after:plustic;"
         + "after:projectred-exploration;"
         + "after:quark;"
+        + "after:railcraft;"
         + "after:roost;"
         + "after:simplyjetpacks;"
         + "after:spiceoflife;"
@@ -140,6 +142,10 @@ public class UniversalTweaks
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());
         if (Loader.isModLoaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle) UTMekanismFixes.fixBinRecipes();
         if (Loader.isModLoaded("projectred-exploration") && UTConfigMods.PROJECTRED.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTProjectRedWorldEvents());
+        // Unregister reason: disable beta warning.
+        if (Loader.isModLoaded("railcraft") && UTConfigMods.RAILCRAFT.utNoBetaWarningToggle) {
+            MinecraftForge.EVENT_BUS.unregister(BetaMessageTickHandler.INSTANCE);
+        }
         if (Loader.isModLoaded("simplyjetpacks") && UTConfigMods.SIMPLY_JETPACKS.utMemoryLeakFixToggle)
         {
             MinecraftForge.EVENT_BUS.register(new UTSimplyJetpacksEvents());

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -151,6 +151,10 @@ public class UTConfigMods
     @Config.Name("Quark")
     public static final QuarkCategory QUARK = new QuarkCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.railcraft")
+    @Config.Name("Railcraft")
+    public static final RailcraftCategory RAILCRAFT = new RailcraftCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.rftoolsdimensions")
     @Config.Name("RFTools Dimensions")
     public static final RFToolsDimensionsCategory RFTOOLS_DIMENSIONS = new RFToolsDimensionsCategory();
@@ -614,6 +618,14 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+    }
+
+    public static class RailcraftCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("No Beta Warning")
+        @Config.Comment("Disables the beta message warning on world join")
+        public boolean utNoBetaWarningToggle = true;
     }
 
     public static class RoostCategory

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -80,6 +80,7 @@ cfg.universaltweaks.modintegration.nuclearcraft=NuclearCraft
 cfg.universaltweaks.modintegration.projectred=ProjectRed
 cfg.universaltweaks.modintegration.quark=Quark
 cfg.universaltweaks.modintegration.rftoolsdimensions=RFTools Dimensions
+cfg.universaltweaks.modintegration.railcraft=Railcraft
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.sd=Storage Drawers
 cfg.universaltweaks.modintegration.simpledifficulty=Simple Difficulty


### PR DESCRIPTION
Adds simple tweak to disable the red text warnings on world join when using a beta version of Railcraft.