### PR TITLE
Machines Max Range Off-By-One Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Industrial Foregoing**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Machines Max Range Off-By-One Fix:** Fixes an off-by-one error where IF Machines would display the max tier of range addon as one less than the actual maximum
 * **Infernal Mobs**
     * **Sticky Recall Compatibility:** Enables compatibility between Infernal Mobs' Sticky effect and Capsule's Recall enchantment
     * **Sticky Pedestal Compatibility:** Enables compatibility between Infernal Mobs' Sticky effect and Reliquary's Pedestal

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -504,6 +504,11 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Machines Max Range Off-By-One Fix")
+        @Config.Comment("Fixes an off-by-one error where IF Machines would display the max tier of range addon as one less than the actual maximum")
+        public boolean utRangeAddonNumberFix = true;
     }
 
     public static class InfernalMobsCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -64,6 +64,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.forestry.json", () -> loaded("forestry"));
             put("mixins.mods.industrialcraft.dupes.json", () -> loaded("ic2") && UTConfigMods.INDUSTRIALCRAFT.utDuplicationFixesToggle);
             put("mixins.mods.industrialforegoing.dupes.json", () -> loaded("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utDuplicationFixesToggle);
+            put("mixins.mods.industrialforegoing.rangeaddon.json", () -> loaded("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utRangeAddonNumberFix);
             put("mixins.mods.infernalmobs.json", () -> loaded("infernalmobs"));
             put("mixins.mods.ironbackpacks.dupes.json", () -> loaded("ironbackpacks") && UTConfigMods.IRON_BACKPACKS.utDuplicationFixesToggle);
             put("mixins.mods.itemstages.json", () -> loaded("itemstages"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/rangeaddon/mixin/UTMachineMaxRangeAddon.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/rangeaddon/mixin/UTMachineMaxRangeAddon.java
@@ -6,6 +6,7 @@ import mod.acgaming.universaltweaks.config.UTConfigMods;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+// Courtesy of WaitingIdly
 @Mixin(value = CustomAreaOrientedBlock.class, remap = false)
 public class UTMachineMaxRangeAddon
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/rangeaddon/mixin/UTMachineMaxRangeAddon.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/rangeaddon/mixin/UTMachineMaxRangeAddon.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.mods.industrialforegoing.rangeaddon.mixin;
+
+import com.buuz135.industrial.tile.block.CustomAreaOrientedBlock;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = CustomAreaOrientedBlock.class, remap = false)
+public class UTMachineMaxRangeAddon
+{
+    @ModifyExpressionValue(method = "getTooltip", at = @At(value = "INVOKE", target = "Lcom/buuz135/industrial/tile/block/CustomAreaOrientedBlock;getMaxWidth()I"))
+    private int utFixMaxRangeAddonOfByOne(int original)
+    {
+        if (!UTConfigMods.INDUSTRIAL_FOREGOING.utRangeAddonNumberFix) return original;
+        return original + 1;
+    }
+}

--- a/src/main/resources/mixins.mods.industrialforegoing.rangeaddon.json
+++ b/src/main/resources/mixins.mods.industrialforegoing.rangeaddon.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.industrialforegoing.rangeaddon.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTMachineMaxRangeAddon"]
+}


### PR DESCRIPTION
changes in this PR:
- fixes an off-by-one issue where IF machine tooltips would state their max range addon as 1 less than their actual maximum. (default: `true`)