### PR TITLE
Weaken Wither Structure Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ All changes are toggleable via config files.
     * **Taming:** Allows taming of undead horses
 * **Village Distance:** Sets the village generation distance in chunks
 * **Water Fall Damage:** Re-implements an improved version of pre-1.4 fall damage in water
+* **Weaken Wither Structure Requirements:** Allows creating Withers with non-air blocks in the bottom corners of the structure
 * **XP Bottle Amount:** Sets the amount of experience spawned by bottles o' enchanting
 * **XP Level Cap:** Sets the maximum experience level players can reach
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -496,6 +496,11 @@ public class UTConfigTweaks
         public boolean utWitherAIToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Weaken Wither Structure Requirements")
+        @Config.Comment("Allows creating Withers with non-air blocks in the bottom corners of the structure")
+        public boolean utWitherPlacement = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("First Person Burning Overlay")
         @Config.Comment("Sets the offset for the fire overlay in first person when the player is burning")
         public double utFirstPersonBurningOverlay = -0.3D;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -84,6 +84,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.blocks.overhaulbeacon.json", () -> UTConfigTweaks.BLOCKS.OVERHAUL_BEACON.utOverhaulBeaconToggle);
             put("mixins.tweaks.blocks.pumpkinplacing.json", () -> UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing);
             put("mixins.tweaks.blocks.sapling.json", () -> UTConfigTweaks.BLOCKS.SAPLING_BEHAVIOR.utSaplingBehaviorToggle);
+            put("mixins.tweaks.blocks.witherstructure.json", () -> UTConfigTweaks.ENTITIES.utWitherPlacement);
             put("mixins.tweaks.entities.ai.json", () -> UTConfigTweaks.ENTITIES.utAIReplacementToggle);
             put("mixins.tweaks.entities.ai.saddledwandering.json", () -> UTConfigTweaks.ENTITIES.utSaddledWanderingToggle);
             put("mixins.tweaks.entities.ai.wither.json", () -> UTConfigTweaks.ENTITIES.utWitherAIToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/witherstructure/mixin/UTWitherFormationMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/witherstructure/mixin/UTWitherFormationMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.witherstructure.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.block.BlockSkull;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.block.state.pattern.FactoryBlockPattern;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BlockSkull.class)
+public abstract class UTWitherFormationMixin
+{
+    @WrapWithCondition(method = "checkWitherSpawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Z", ordinal = 1))
+    private boolean utOverrideRemovalLogic(World world, BlockPos pos, IBlockState newState, int flags, @Local(ordinal = 0) int j, @Local(ordinal = 1) int k)
+    {
+        if (!UTConfigTweaks.ENTITIES.utWitherPlacement) return true;
+        return k != 2 || (j != 0 && j != 2);
+    }
+
+    @ModifyReceiver(method = {"getWitherPattern", "getWitherBasePattern"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/pattern/FactoryBlockPattern;build()Lnet/minecraft/block/state/pattern/BlockPattern;"))
+    private FactoryBlockPattern utReplaceAirRequirementWithAny(FactoryBlockPattern receiver)
+    {
+        if (!UTConfigTweaks.ENTITIES.utWitherPlacement) return receiver;
+        return receiver.where('~', unused -> true);
+    }
+}

--- a/src/main/resources/mixins.tweaks.blocks.witherstructure.json
+++ b/src/main/resources/mixins.tweaks.blocks.witherstructure.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.witherstructure.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTWitherFormationMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- made is so the wither pattern applies `'~', unused -> true` instead of `BlockWorldState.hasState(BlockMaterialMatcher.forMaterial(Material.AIR))`, meaning any blocks will match it, not just AIR.
- made is so forming the wither will not replace the side bottom blocks.
- tied to a single config option (default: `false`)