### PR TITLE
Weaken Golem Structure Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ All changes are toggleable via config files.
 * **Village Distance:** Sets the village generation distance in chunks
 * **Void Fog:** Re-implements pre-1.8 void fog and void particles
 * **Water Fall Damage:** Re-implements an improved version of pre-1.4 fall damage in water
+* **Weaken Golem Structure Requirements:** Allows creating Golem with non-air blocks in the bottom corners of the structure
 * **Weaken Wither Structure Requirements:** Allows creating Withers with non-air blocks in the bottom corners of the structure
 * **XP Bottle Amount:** Sets the amount of experience spawned by bottles o' enchanting
 * **XP Level Cap:** Sets the maximum experience level players can reach

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -501,6 +501,11 @@ public class UTConfigTweaks
         public boolean utWitherPlacement = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Weaken Golem Structure Requirements")
+        @Config.Comment("Allows creating Iron Golems with non-air blocks in the bottom corners of the structure")
+        public boolean utGolemPlacement = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("First Person Burning Overlay")
         @Config.Comment("Sets the offset for the fire overlay in first person when the player is burning")
         public double utFirstPersonBurningOverlay = -0.3D;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -77,6 +77,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.blocks.endcrystal.json", () -> UTConfigTweaks.BLOCKS.utEndCrystalAnywherePlacing);
             put("mixins.tweaks.blocks.explosion.json", () -> UTConfigTweaks.BLOCKS.utExplosionDropChance != 1.0D);
             put("mixins.tweaks.blocks.falling.json", () -> UTConfigTweaks.BLOCKS.utFallingBlockLifespan != 600);
+            put("mixins.tweaks.blocks.golemstructure.json", () -> UTConfigTweaks.ENTITIES.utGolemPlacement);
             put("mixins.tweaks.blocks.growthsize.json", () -> UTConfigTweaks.BLOCKS.utCactusSize != 3 && UTConfigTweaks.BLOCKS.utSugarCaneSize != 3 && UTConfigTweaks.BLOCKS.utVineSize != 0);
             put("mixins.tweaks.blocks.hitdelay.json", () -> UTConfigTweaks.BLOCKS.utBlockHitDelay != 5);
             put("mixins.tweaks.blocks.leafdecay.json", () -> UTConfigTweaks.BLOCKS.utLeafDecayToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/golemstructure/mixin/UTGolemFormationMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/golemstructure/mixin/UTGolemFormationMixin.java
@@ -19,7 +19,7 @@ public abstract class UTGolemFormationMixin
     private boolean utOverrideRemovalLogic(World world, BlockPos pos, IBlockState newState, int flags, @Local(ordinal = 0) int j, @Local(ordinal = 1) int k)
     {
         if (!UTConfigTweaks.ENTITIES.utGolemPlacement) return true;
-        return k != 2 || (j != 0 && j != 2);
+        return (k != 0 && k != 2) || (j != 0 && j != 2);
     }
 
     @ModifyReceiver(method = {"getGolemPattern", "getGolemBasePattern"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/pattern/FactoryBlockPattern;build()Lnet/minecraft/block/state/pattern/BlockPattern;"))

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/golemstructure/mixin/UTGolemFormationMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/golemstructure/mixin/UTGolemFormationMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.golemstructure.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.block.BlockPumpkin;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.block.state.pattern.FactoryBlockPattern;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BlockPumpkin.class)
+public abstract class UTGolemFormationMixin
+{
+    @WrapWithCondition(method = "trySpawnGolem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Z", ordinal = 1))
+    private boolean utOverrideRemovalLogic(World world, BlockPos pos, IBlockState newState, int flags, @Local(ordinal = 0) int j, @Local(ordinal = 1) int k)
+    {
+        if (!UTConfigTweaks.ENTITIES.utGolemPlacement) return true;
+        return k != 2 || (j != 0 && j != 2);
+    }
+
+    @ModifyReceiver(method = {"getGolemPattern", "getGolemBasePattern"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/pattern/FactoryBlockPattern;build()Lnet/minecraft/block/state/pattern/BlockPattern;"))
+    private FactoryBlockPattern utReplaceAirRequirementWithAny(FactoryBlockPattern receiver)
+    {
+        if (!UTConfigTweaks.ENTITIES.utGolemPlacement) return receiver;
+        return receiver.where('~', unused -> true);
+    }
+}

--- a/src/main/resources/mixins.tweaks.blocks.golemstructure.json
+++ b/src/main/resources/mixins.tweaks.blocks.golemstructure.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.golemstructure.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTGolemFormationMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- made is so the iron golem pattern applies `'~', unused -> true` instead of `BlockWorldState.hasState(BlockMaterialMatcher.forMaterial(Material.AIR))`, meaning any blocks will match it, not just AIR.
- made is so forming the iron golem will not replace the side bottom blocks [edit: whoops] or top side blocks.
- tied to a single config option. (default: `false`)

basically the same change as #464, but for Iron Golems.