### PR TITLE
Fix Deep Dark Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ All changes are toggleable via config files.
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Fix Deep Dark Stats:** Fixes Mob Attack and Health Statistics being repeatedly doubled
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.
     * **Creative Mill Harvestability:** Fixes the Creative Mill Generator not respecting the Creative Block Breaking config
 * **Forestry**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -428,6 +428,11 @@ public class UTConfigMods
     public static class ExtraUtilitiesCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Fix Deep Dark Stats")
+        @Config.Comment("Fixes Mob Attack and Health Statistics being repeatedly doubled")
+        public boolean utDeepDarkStats = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -56,6 +56,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
             put("mixins.mods.erebus.quakehammer.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utFixQuakeHammerTexture);
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
+            put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
             put("mixins.mods.extrautilities.mutabledrops.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
             put("mixins.mods.forestry.cocoa.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utFOCocoaBeansToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -56,7 +56,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
             put("mixins.mods.erebus.quakehammer.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utFixQuakeHammerTexture);
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
-            put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
+            put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
             put("mixins.mods.extrautilities.mutabledrops.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
             put("mixins.mods.forestry.cocoa.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utFOCocoaBeansToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.deepdarkstats.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.rwtema.extrautils2.dimensions.deep_dark.WorldProviderDeepDark;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.entity.SharedMonsterAttributes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = WorldProviderDeepDark.class, remap = false)
+public abstract class UTDeepDarkStatRunawayFix
+{
+    @ModifyExpressionValue(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;getBaseValue()D", ordinal = 0))
+    private static double utFixMaxHealth(double original)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats) return original;
+        return SharedMonsterAttributes.MAX_HEALTH.getDefaultValue();
+    }
+
+    @ModifyExpressionValue(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;getBaseValue()D", ordinal = 1))
+    private static double utFixAttackDamage(double original)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats) return original;
+        return SharedMonsterAttributes.ATTACK_DAMAGE.getDefaultValue();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
@@ -24,7 +24,7 @@ public abstract class UTDeepDarkStatRunawayFix
     @Unique
     private static final AttributeModifier ATTACK_MODIFIER = new AttributeModifier(ATTACK_MODIFIER_ID, "Deep Dark Attack Doubling", 1, 2);
 
-    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 0))
+    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 0, remap = true))
     private static void utFixMaxHealth(IAttributeInstance attributeInstance, double original)
     {
         if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats)
@@ -36,7 +36,7 @@ public abstract class UTDeepDarkStatRunawayFix
         attributeInstance.applyModifier(HEALTH_MODIFIER);
     }
 
-    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 1))
+    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 1, remap = true))
     private static void utFixAttackDamage(IAttributeInstance attributeInstance, double original)
     {
         if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats)

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/deepdarkstats/mixin/UTDeepDarkStatRunawayFix.java
@@ -1,27 +1,50 @@
 package mod.acgaming.universaltweaks.mods.extrautilities.deepdarkstats.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.rwtema.extrautils2.dimensions.deep_dark.WorldProviderDeepDark;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
-import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.UUID;
 
 // Courtesy of WaitingIdly
 @Mixin(value = WorldProviderDeepDark.class, remap = false)
 public abstract class UTDeepDarkStatRunawayFix
 {
-    @ModifyExpressionValue(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;getBaseValue()D", ordinal = 0))
-    private static double utFixMaxHealth(double original)
+    @Unique
+    private static final UUID HEALTH_MODIFIER_ID = UUID.fromString("e12a4c74-5fe0-4b33-8461-d0320345eb61");
+    @Unique
+    private static final AttributeModifier HEALTH_MODIFIER = new AttributeModifier(HEALTH_MODIFIER_ID, "Deep Dark Health Doubling", 1, 2);
+    @Unique
+    private static final UUID ATTACK_MODIFIER_ID = UUID.fromString("468afd07-b07b-4031-ba34-6fa29e154569");
+    @Unique
+    private static final AttributeModifier ATTACK_MODIFIER = new AttributeModifier(ATTACK_MODIFIER_ID, "Deep Dark Attack Doubling", 1, 2);
+
+    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 0))
+    private static void utFixMaxHealth(IAttributeInstance attributeInstance, double original)
     {
-        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats) return original;
-        return SharedMonsterAttributes.MAX_HEALTH.getDefaultValue();
+        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats)
+        {
+            attributeInstance.setBaseValue(original);
+            return;
+        }
+        attributeInstance.removeModifier(HEALTH_MODIFIER);
+        attributeInstance.applyModifier(HEALTH_MODIFIER);
     }
 
-    @ModifyExpressionValue(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;getBaseValue()D", ordinal = 1))
-    private static double utFixAttackDamage(double original)
+    @Redirect(method = "noMobs", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/attributes/IAttributeInstance;setBaseValue(D)V", ordinal = 1))
+    private static void utFixAttackDamage(IAttributeInstance attributeInstance, double original)
     {
-        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats) return original;
-        return SharedMonsterAttributes.ATTACK_DAMAGE.getDefaultValue();
+        if (!UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats)
+        {
+            attributeInstance.setBaseValue(original);
+            return;
+        }
+        attributeInstance.removeModifier(ATTACK_MODIFIER);
+        attributeInstance.applyModifier(ATTACK_MODIFIER);
     }
 }

--- a/src/main/resources/mixins.mods.extrautilities.deepdarkstats.json
+++ b/src/main/resources/mixins.mods.extrautilities.deepdarkstats.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.deepdarkstats.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTDeepDarkStatRunawayFix"]
+}


### PR DESCRIPTION
changes in this PR:
- adds a config option to change how the doubling effect of the deep dark applies. normally, it applies via
    ```java
    IAttributeInstance t = entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
    t.setBaseValue(t.getBaseValue() * 2.0);
    entity.heal((float)t.getAttributeValue());
    t = entity.getEntityAttribute(SharedMonsterAttributes.ATTACK_DAMAGE);
    t.setBaseValue(t.getBaseValue() * 2.0);
    ```
    but this has reportedly caused repeated doubling effects due to other mods (unknown) repeatedly triggering this effect, leading to eg being one-shot by a random mob. with this enabled, it will instead use custom `AttributeModifier`s to double the health and damage of mobs spawned to a maximum of once. (default: `true`)
- UUIDs are were generated beforehand via `UUID.randomUUID()`.

to test this issue in development:
- put a breakpoint in the `noMobs` method XU2 adds.
- run `ForgeEventFactory.canEntitySpawn(event.getEntityLiving(), event.getWorld(), event.x, event.y, event.z, event.getSpawner())` repeatedly.
- check `event.getEntityLiving().getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getAttributeValue()` to confirm it has repeatedly doubled.

this is responsible for a few issues involving "max health mob" and "mob one-shot me", here is an example of this issue: https://github.com/rwtema/Extra-Utilities-2-Source/issues/435