### PR TITLE
Fix some mixins not applying outside of dev-env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,8 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:mcjtylib-233105:2745846')
     compileOnly rfg.deobf('curse.maven:rftools-224641:2861573')
     compileOnly rfg.deobf('curse.maven:rftools-dimensions-240950:2707390')
-    compileOnly 'curse.maven:actuallyaditions-228404:2844115'
+    compileOnly rfg.deobf('curse.maven:actuallyaditions-228404:2844115')
+    compileOnly rfg.deobf('curse.maven:extrautilities-225561:2678374')
     compileOnly 'curse.maven:applecore-224472:2969118'
     compileOnly 'curse.maven:arcanearchives-311357:3057332'
     compileOnly 'curse.maven:bewitchment-285439:3044569'

--- a/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/mixin/UTBlockLaserRelayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/mixin/UTBlockLaserRelayMixin.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // Courtesy of WaitingIdly
-@Mixin(value = BlockLaserRelay.class, remap = false)
+@Mixin(value = BlockLaserRelay.class)
 public abstract class UTBlockLaserRelayMixin
 {
     @Inject(method = "onBlockActivated", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isCreative()Z"))

--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // Courtesy of WaitingIdly
-@Mixin(value = BlockCabbage.class, remap = false)
+@Mixin(value = BlockCabbage.class)
 public abstract class UTCabbageMixin extends BlockCrops
 {
     @Override
@@ -31,7 +31,7 @@ public abstract class UTCabbageMixin extends BlockCrops
         return ItemErebusFood.EnumFoodType.CABBAGE.ordinal();
     }
 
-    @Inject(method = "getDrops", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "getDrops", at = @At("HEAD"), remap = false, cancellable = true)
     private void utOverrideDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune, CallbackInfoReturnable<List<ItemStack>> cir)
     {
         if (!UTConfigMods.EREBUS.utCabbageDrop) return;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/breakcreativemill/mixin/UTBreakableCreativeMill.java
@@ -9,10 +9,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 // Courtesy of WaitingIdly
-@Mixin(value = BlockPassiveGenerator.class, remap = false)
+@Mixin(value = BlockPassiveGenerator.class)
 public abstract class UTBreakableCreativeMill extends XUBlockStatic
 {
-    @ModifyExpressionValue(method = "getBlockHardness", at = @At(value = "FIELD", target = "Lcom/rwtema/extrautils2/ExtraUtils2;allowCreativeBlocksToBeBroken:Z"))
+    @ModifyExpressionValue(method = "getBlockHardness", at = @At(value = "FIELD", target = "Lcom/rwtema/extrautils2/ExtraUtils2;allowCreativeBlocksToBeBroken:Z", remap = false))
     private boolean utBreakCreativeMill(boolean original)
     {
         if (!UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability) return original;


### PR DESCRIPTION
changes in this PR:
- adds Actually Additions and Extra Utilities 2 as `rfg.deobf` mods.
- fixes the `UTBlockLaserRelayMixin`, `UTCabbageMixin`, and `UTBreakableCreativeMill` mixins not applying outside of the dev environment.

thanks jchung01 for pointing out my mistake(s) in this comment: https://github.com/ACGaming/UniversalTweaks/pull/467#pullrequestreview-2054111195