### PR TITLE
Fix block interactions with Better Placement tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -165,6 +165,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.bugfixes.misc.spectatormenu.json", () -> UTConfigBugfixes.MISC.utSpectatorMenuToggle);
             put("mixins.bugfixes.misc.startup.json", () -> UTConfigTweaks.PERFORMANCE.utFasterBackgroundStartupToggle);
             put("mixins.bugfixes.world.frustumculling.json", () -> UTConfigBugfixes.WORLD.utFrustumCullingToggle);
+            put("mixins.tweaks.blocks.betterplacement.json", () -> UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementToggle);
             put("mixins.tweaks.entities.autojump.json", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
             put("mixins.tweaks.entities.burning.player.json", () -> UTConfigTweaks.ENTITIES.utFirstPersonBurningOverlay != -0.3D);
             put("mixins.tweaks.items.attackcooldown.client.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/IInteractable.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/IInteractable.java
@@ -1,0 +1,6 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.betterplacement;
+
+public interface IInteractable
+{
+    boolean isInteractable();
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/UTBetterPlacement.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/UTBetterPlacement.java
@@ -1,17 +1,15 @@
 package mod.acgaming.universaltweaks.tweaks.blocks.betterplacement;
 
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.RayTraceResult.Type;
 import net.minecraft.util.math.Vec3d;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
-
-import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 
 // Courtesy of tterrag1098, BucketOfCompasses
 public class UTBetterPlacement
@@ -47,7 +45,7 @@ public class UTBetterPlacement
                     {
                         Minecraft.getMinecraft().rightClickDelayTimer = 0;
                     }
-                    else if (UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementNewLoc && pos.equals(lastTargetPos) && side == lastTargetSide && !isDrawer(pos))
+                    else if (UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementNewLoc && pos.equals(lastTargetPos) && side == lastTargetSide && !isInteractableAt(pos))
                     {
                         Minecraft.getMinecraft().rightClickDelayTimer = 4;
                     }
@@ -59,15 +57,8 @@ public class UTBetterPlacement
         }
     }
 
-    public static boolean isDrawer(BlockPos pos)
+    private static boolean isInteractableAt(BlockPos pos)
     {
-        try
-        {
-            return Loader.isModLoaded("storagedrawers") && Minecraft.getMinecraft().world.getBlockState(pos).getBlock().getRegistryName().getNamespace().equals("storagedrawers");
-        }
-        catch (Exception e)
-        {
-            return false;
-        }
+        return ((IInteractable) Minecraft.getMinecraft().world.getBlockState(pos).getBlock()).isInteractable();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/mixin/UTInteractableBlockMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/betterplacement/mixin/UTInteractableBlockMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.betterplacement.mixin;
+
+import mod.acgaming.universaltweaks.tweaks.blocks.betterplacement.IInteractable;
+import net.minecraft.block.Block;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = Block.class)
+public class UTInteractableBlockMixin implements IInteractable
+{
+    @Unique
+    private boolean ut$interactable = true;
+
+    @Override
+    public boolean isInteractable()
+    {
+        return ut$interactable;
+    }
+
+    /**
+     * @reason Block is assumed NOT interactable if the default/super implementation is called.
+     */
+    @Inject(method = "onBlockActivated", at = @At(value = "HEAD"))
+    private void utSetInteractable(CallbackInfoReturnable<Boolean> cir)
+    {
+        ut$interactable = false;
+    }
+}

--- a/src/main/resources/mixins.tweaks.blocks.betterplacement.json
+++ b/src/main/resources/mixins.tweaks.blocks.betterplacement.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.betterplacement.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTInteractableBlockMixin"]
+}


### PR DESCRIPTION
Should fix #473 by accounting for interactable blocks, although the way it determines if it's interactable may not be perfect. Replaces the mod-specific `isDrawer()` check for a universal `isInteractableAt()`.