### PR TITLE
Fix OpenBlocks Last Stand trigger condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ All changes are toggleable via config files.
     * **Right Click Harvesting Fix:** Prevents crashing with mods implementing right click crop harvesting
 * **NuclearCraft**
     * **Radiation Environment Map:** Changes the data table of the radiation environment handler to improve tick time
+* **OpenBlocks**
+    * **Last Stand Trigger Fix:** Fixes the Last Stand enchantment triggering too early on pre-mitigation damage (before enchants, potions, etc), instead of on post-mitigation damage.
 * **ProjectRed**
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Quark**

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:forestry-59751:2918418')
     compileOnly rfg.deobf('curse.maven:modtweaker-220954:3840577')
     compileOnly rfg.deobf('curse.maven:nuclearcraft-226254:3784145')
+    compileOnly rfg.deobf('curse.maven:openblocks-228816:2699056')
     compileOnly rfg.deobf('curse.maven:reborn-core-237903:3330308')
     compileOnly rfg.deobf('curse.maven:reskillable-286382:2815686')
     compileOnly rfg.deobf('curse.maven:roost-277711:2702080')
@@ -208,6 +209,7 @@ dependencies {
     compileOnly 'curse.maven:tinyprogressions-250850:2721018'
     compileOnly 'maven.modrinth:industrial-foregoing:1.12.13-237'
     // runtimeOnly 'TechReborn:TechReborn-ModCompatibility-1.12.2:1.4.0.76:universal'
+    // runtimeOnly 'curse.maven:openmodslib-228815:2699055'
 
     if (project.use_mixins.toBoolean()) {
         String mixin = modUtils.enableMixins("zone.rong:mixinbooter:9.1", "universaltweaks.refmap.json")

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -19,6 +19,7 @@ import mod.acgaming.universaltweaks.mods.cqrepoured.UTGoldenFeatherEvent;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Burning;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Sprinting;
 import mod.acgaming.universaltweaks.mods.mekanism.UTMekanismFixes;
+import mod.acgaming.universaltweaks.mods.openblocks.UTOpenBlocksEvents;
 import mod.acgaming.universaltweaks.mods.projectred.UTProjectRedWorldEvents;
 import mod.acgaming.universaltweaks.mods.simplyjetpacks.UTSimplyJetpacksEvents;
 import mod.acgaming.universaltweaks.mods.simplyjetpacks.network.message.MessageClientStatesReset;
@@ -73,7 +74,7 @@ public class UniversalTweaks
     public static final String MODID = Tags.MOD_ID;
     public static final String NAME = Tags.MOD_NAME;
     public static final String VERSION = Tags.VERSION;
-    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.0,);required-after:configanytime;"
+    public static final String DEPENDENCIES = "required-after:mixinbooter@[8.9,);required-after:configanytime;"
         + "after:abyssalcraft;"
         + "after:actuallyadditions;"
         + "after:aoa3;"
@@ -113,6 +114,7 @@ public class UniversalTweaks
         + "after:netherchest;"
         + "after:netherrocks;"
         + "after:nuclearcraft;"
+        + "after:openblocks;"
         + "after:plustic;"
         + "after:projectred-exploration;"
         + "after:quark;"
@@ -159,6 +161,7 @@ public class UniversalTweaks
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2ExtinguishingDodgeChance > 0) MinecraftForge.EVENT_BUS.register(new UTED2Burning());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());
         if (Loader.isModLoaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle) UTMekanismFixes.fixBinRecipes();
+        if (Loader.isModLoaded("openblocks")) MinecraftForge.EVENT_BUS.register(new UTOpenBlocksEvents());
         if (Loader.isModLoaded("projectred-exploration") && UTConfigMods.PROJECTRED.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTProjectRedWorldEvents());
         // Unregister reason: disable beta warning.
         if (Loader.isModLoaded("railcraft") && UTConfigMods.RAILCRAFT.utNoBetaWarningToggle && UTReflectionUtil.isClassLoaded("mods.railcraft.common.core.BetaMessageTickHandler"))

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -161,7 +161,7 @@ public class UniversalTweaks
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2ExtinguishingDodgeChance > 0) MinecraftForge.EVENT_BUS.register(new UTED2Burning());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());
         if (Loader.isModLoaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle) UTMekanismFixes.fixBinRecipes();
-        if (Loader.isModLoaded("openblocks")) MinecraftForge.EVENT_BUS.register(new UTOpenBlocksEvents());
+        if (Loader.isModLoaded("openblocks") && UTConfigMods.OPEN_BLOCKS.utLastStandFixToggle) MinecraftForge.EVENT_BUS.register(new UTOpenBlocksEvents());
         if (Loader.isModLoaded("projectred-exploration") && UTConfigMods.PROJECTRED.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTProjectRedWorldEvents());
         // Unregister reason: disable beta warning.
         if (Loader.isModLoaded("railcraft") && UTConfigMods.RAILCRAFT.utNoBetaWarningToggle && UTReflectionUtil.isClassLoaded("mods.railcraft.common.core.BetaMessageTickHandler"))

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -143,6 +143,10 @@ public class UTConfigMods
     @Config.Name("NuclearCraft")
     public static final NuclearCraftCategory NUCLEARCRAFT = new NuclearCraftCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.openblocks")
+    @Config.Name("OpenBlocks")
+    public static final OpenBlocksCategory OPEN_BLOCKS = new OpenBlocksCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.projectred")
     @Config.Name("ProjectRed")
     public static final ProjectRedCategory PROJECTRED = new ProjectRedCategory();
@@ -612,6 +616,18 @@ public class UTConfigMods
             CONCURRENT_LINKED_HASHMAP,
             CONCURRENT_LINKED_QUEUE
         }
+    }
+
+    public static class OpenBlocksCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Last Stand Trigger Fix")
+        @Config.Comment
+            ({
+                "Fixes the Last Stand enchantment triggering too early on pre-mitigation damage (before enchants, potions, etc)",
+                "instead of on post-mitigation damage."
+            })
+        public boolean utLastStandFixToggle = true;
     }
 
     public static class ProjectRedCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -75,7 +75,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.netherchest.dupes.json", () -> loaded("netherchest") && UTConfigMods.NETHER_CHEST.utDuplicationFixesToggle);
             put("mixins.mods.netherrocks.json", () -> loaded("netherrocks"));
             put("mixins.mods.nuclearcraft.json", () -> loaded("nuclearcraft"));
-            put("mixins.mods.openblocks.json", () -> loaded("openblocks"));
+            put("mixins.mods.openblocks.json", () -> loaded("openblocks") && UTConfigMods.OPEN_BLOCKS.utLastStandFixToggle);
             put("mixins.mods.quark.dupes.json", () -> loaded("quark") && UTConfigMods.QUARK.utDuplicationFixesToggle);
             put("mixins.mods.reskillable.json", () -> loaded("reskillable"));
             put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -75,6 +75,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.netherchest.dupes.json", () -> loaded("netherchest") && UTConfigMods.NETHER_CHEST.utDuplicationFixesToggle);
             put("mixins.mods.netherrocks.json", () -> loaded("netherrocks"));
             put("mixins.mods.nuclearcraft.json", () -> loaded("nuclearcraft"));
+            put("mixins.mods.openblocks.json", () -> loaded("openblocks"));
             put("mixins.mods.quark.dupes.json", () -> loaded("quark") && UTConfigMods.QUARK.utDuplicationFixesToggle);
             put("mixins.mods.reskillable.json", () -> loaded("reskillable"));
             put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/UTOpenBlocksEvents.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/UTOpenBlocksEvents.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.mods.openblocks;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import openblocks.enchantments.LastStandEnchantmentsHandler;
+
+public class UTOpenBlocksEvents
+{
+    public static LastStandEnchantmentsHandler lastStandHandler;
+
+    /**
+     * Last Stand in 1.12 uses LivingHurtEvent, which is the pre-mitigation damage (before armor, potions, etc).
+     * It should use LivingDamageEvent, which is the post-mitigation damage.
+     * This was actually explicitly fixed in older versions (1.10) but once again uses the wrong event in 1.12.
+     */
+    @SubscribeEvent
+    public void handleLastStand(LivingDamageEvent event)
+    {
+        // This is a double check, to avoid extra allocations.
+        if (event.getEntityLiving() instanceof EntityPlayer)
+        {
+            WrappedLivingHurtEvent eventIn = new WrappedLivingHurtEvent(event.getEntityLiving(), event.getSource(), event.getAmount());
+            lastStandHandler.onHurt(eventIn);
+            event.setAmount(eventIn.getAmount());
+            event.setCanceled(eventIn.isCanceled());
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/WrappedLivingHurtEvent.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/WrappedLivingHurtEvent.java
@@ -1,0 +1,17 @@
+package mod.acgaming.universaltweaks.mods.openblocks;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+
+/**
+ * Same as LivingHurtEvent, but only fired manually by the last stand handler.
+ * @author jchung01
+ */
+public class WrappedLivingHurtEvent extends LivingHurtEvent
+{
+    public WrappedLivingHurtEvent(EntityLivingBase entity, DamageSource source, float amount)
+    {
+        super(entity, source, amount);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/mixin/UTConfigMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/mixin/UTConfigMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.openblocks.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.mods.openblocks.UTOpenBlocksEvents;
+import openblocks.enchantments.LastStandEnchantmentsHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import openblocks.Config;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = Config.class, remap = false)
+public class UTConfigMixin
+{
+    // MixinBooter 8.9 (MixinExtras 0.2.1) required!
+    @WrapOperation(method = "register", at = @At(value = "NEW", target = "()Lopenblocks/enchantments/LastStandEnchantmentsHandler;"))
+    private static LastStandEnchantmentsHandler utCaptureLastStandHandler(Operation<LastStandEnchantmentsHandler> original)
+    {
+        UTOpenBlocksEvents.lastStandHandler = original.call();
+        return UTOpenBlocksEvents.lastStandHandler;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/mixin/UTLastStandEnchantmentsHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/openblocks/mixin/UTLastStandEnchantmentsHandlerMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.mods.openblocks.mixin;
+
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import mod.acgaming.universaltweaks.mods.openblocks.WrappedLivingHurtEvent;
+import openblocks.enchantments.LastStandEnchantmentsHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of jchung01
+@Mixin(value = LastStandEnchantmentsHandler.class, remap = false)
+public class UTLastStandEnchantmentsHandlerMixin
+{
+    /**
+     * Repurpose onHurt as a passthrough method for {@link mod.acgaming.universaltweaks.mods.openblocks.UTOpenBlocksEvents#handleLastStand}
+     * instead of an event subscriber.
+     * Uses a wrapper for maximum compatibilty with other mods (e.g. DimHopper Tweaks) that may mixin into this method's logic.
+     *
+     * @reason Only handle player damage from LivingDamageEvent, not LivingHurtEvent
+     */
+    @Inject(method = "onHurt", at = @At(value = "HEAD"), cancellable = true)
+    private void utCheckEvent(LivingHurtEvent event, CallbackInfo ci)
+    {
+         if (!(event instanceof WrappedLivingHurtEvent))
+        {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -78,6 +78,7 @@ cfg.universaltweaks.modintegration.mrtjpcore=MrTJPCore
 cfg.universaltweaks.modintegration.netherchest=Nether Chest
 cfg.universaltweaks.modintegration.netherrocks=Netherrocks
 cfg.universaltweaks.modintegration.nuclearcraft=NuclearCraft
+cfg.universaltweaks.modintegration.openblocks=OpenBlocks
 cfg.universaltweaks.modintegration.projectred=ProjectRed
 cfg.universaltweaks.modintegration.quark=Quark
 cfg.universaltweaks.modintegration.rftoolsdimensions=RFTools Dimensions

--- a/src/main/resources/mixins.mods.openblocks.json
+++ b/src/main/resources/mixins.mods.openblocks.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.openblocks.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTConfigMixin", "UTLastStandEnchantmentsHandlerMixin"]
+}


### PR DESCRIPTION
Fixes the Last Stand enchant triggering on pre-mitigation damage (before enchants, potions, etc). It now triggers on post-mitigation damage, as [originally intended](https://github.com/OpenMods/OpenBlocks/commit/e87f263f4cc298300f2da744d3dc21528067f5d9).

The specific way this tweak is implemented is to offer maximum compatibility with other mixins (e.g. Dimension Hopper Tweaks) into this method. As a side effect, this does cause an extra object allocation for each player damage event, but that should be okay.

Also **bumps required min version of MixinBooter to 8.9** for `@WrapOperation` on NEW object instantatiations.