### PR TITLE
Some RandomPatches Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All changes are toggleable via config files.
 * **Exhaustion:** Fixes saturation depleting in peaceful mode
 * **Falling Block Entity Damage:** Only damage living entities hit by falling blocks, prevents killing items and XP
 * **Faster Background Startup:** Fixes slow background startup edge case caused by checking tooltips during the loading process
+* **Fixes Invisible Player when Flying with Elytra:** Fixes the player model occasionally disappearing when flying with elytra in a straight line in third-person mode
 * **Frustum Culling:** Fixes invisible chunks in edge cases (small enclosed rooms at chunk borders)
 * **Help:** Replaces the help command, sorts and reports broken commands
 * **Hopper Bounding Box:** Slims down the hopper bounding box for easier access of nearby blocks

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ All changes are toggleable via config files.
 * **Undead Horses**
     * **Burning:** Lets untamed undead horses burn in daylight
     * **Taming:** Allows taming of undead horses
+* **Use Separate Dismount Key:** Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently
 * **Use Separate Narrator Key:** Allows using a custom Narrator key, instead of being stuck with CTRL+B
 * **Village Distance:** Sets the village generation distance in chunks
 * **Void Fog:** Re-implements pre-1.8 void fog and void particles

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ All changes are toggleable via config files.
 * **Disable Fancy Missing Model:** Improves rendering performance by removing the resource location text on missing models
 * **Disable Mob Spawner Entity Render:** Disables rendering an entity inside of Mob Spawners
 * **Disable Narrator:** Disables the narrator functionality entirely
+* **Disable Glint Overlay on Enchantment Books:** Disables the glint overlay on enchantment books
+* **Disable Glint Overlay on Potions:** Disables the glint overlay on potions
 * **Disable Sleeping:** Disables skipping night by using a bed while making it still able to set spawn
 * **Disable Text Shadowing:** Disables all text shadowing, where text has a darker version of itself rendered behind the normal text, changing the appearance and can improve fps on some screens
 * **Disable Villager Trade Leveling:** Disables leveling of villager careers, only allowing base level trades

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ All changes are toggleable via config files.
 * **Overlay Message Height:** Sets the Y value of the overlay message (action bar), displayed for playing records etc.
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
+* **Prevent Observer Activating on Placement:** Controls if the observer activates itself on the first tick when it is placed
 * **Prevent Placing Buckets in Portals:** Prevents placing of liquid source blocks overriding portal blocks
 * **Pumpkin Placing:** Allows placing Pumpkins and Jack'O'Lanterns without a supporting block
 * **Rabbit Killer Spawning:** Configurable chance for rabbits to spawn as the killer bunny variant

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ All changes are toggleable via config files.
 * **Overlay Message Height:** Sets the Y value of the overlay message (action bar), displayed for playing records etc.
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
+* **Prevent Placing Buckets in Portals:** Prevents placing of liquid source blocks overriding portal blocks
 * **Pumpkin Placing:** Allows placing Pumpkins and Jack'O'Lanterns without a supporting block
 * **Rabbit Killer Spawning:** Configurable chance for rabbits to spawn as the killer bunny variant
 * **Rabbit Toast Spawning:** Configurable chance for rabbits to spawn as the Toast variant

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ All changes are toggleable via config files.
 * **Undead Horses**
     * **Burning:** Lets untamed undead horses burn in daylight
     * **Taming:** Allows taming of undead horses
+* **Use Separate Narrator Key:** Allows using a custom Narrator key, instead of being stuck with CTRL+B
 * **Village Distance:** Sets the village generation distance in chunks
 * **Void Fog:** Re-implements pre-1.8 void fog and void particles
 * **Water Fall Damage:** Re-implements an improved version of pre-1.4 fall damage in water

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All changes are toggleable via config files.
 * **Adaptive XP Drops:** Scales dropped experience from entities based on their health
 * **AI Improvements:** Replaces/removes entity AI for improved server performance
 * **Always Eat:** Allows the consumption of food at any time, regardless of the hunger bar
+* **Always Return to Main Menu:** Always returns the player to the main menu when quitting the game
 * **Armed Armor Stands:** Enables arms for armor stands by default
 * **Armor Curve:** Adjusts the armor scaling and degradation formulae for mobs and players
 * **Attributes:** Sets custom ranges for entity attributes

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ All changes are toggleable via config files.
 * **Remove Realms Button:** Removes the redundant Minecraft Realms button from the main menu
 * **Remove Recipe Book:** Removes the recipe book button from GUIs
 * **Remove Snooper:** Forcefully turns off the snooper and hides the snooper settings button from the options menu
+* **Render End Portal Bottom:** Controls if the End Portal renders its texture on the bottom face
 * **Riding Exhaustion:** Enables depleting saturation when riding mounts
 * **Sapling Behavior:** Allows customization of sapling behavior while utilizing an optimized method
 * **Sea Level:** Sets the default height of the overworld's sea level

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ All changes are toggleable via config files.
 * **Hide Personal Effect Particles:** Disables potion effect particles emitting from yourself
 * **Horizontal Collision Damage:** Applies horizontal collision damage to the player akin to elytra collision
 * **Husk & Stray Spawning:** Lets husks and strays spawn underground like regular zombies and skeletons
+* **Improve Language Switching Speed:** Improves the speed of switching languages in the Language GUI
 * **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings
 * **Incurable Potions:** Excludes potion effects from being curable with curative items like buckets of milk
 * **Infinite Music:** Lets background music play continuously without delays

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/elytra/render/mixin/UTRenderPlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/elytra/render/mixin/UTRenderPlayerMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.bugfixes.entities.elytra.render.mixin;
+
+import net.minecraft.client.renderer.entity.RenderPlayer;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = RenderPlayer.class)
+public abstract class UTRenderPlayerMixin
+{
+    @WrapOperation(method = "applyRotations", at = @At(value = "INVOKE", target = "Ljava/lang/Math;acos(D)D"))
+    private double utClampToPreventInvisiblePlayerOnElytra(double instance, Operation<Double> original)
+    {
+        if (!UTConfigBugfixes.ENTITIES.utFixInvisiblePlayerModelWithElytra) return original.call(instance);
+        return original.call(Math.min(1, instance));
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -207,6 +207,11 @@ public class UTConfigBugfixes
         public boolean utElytraDeploymentLandingToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fixes Invisible Player when Flying with Elytra")
+        @Config.Comment("Fixes the player model occasionally disappearing when flying with elytra in a straight line in third-person mode")
+        public boolean utFixInvisiblePlayerModelWithElytra = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Entity Bounding Box")
         @Config.Comment("Saves entity bounding boxes to tags to prevent breakouts and suffocation")
         public boolean utEntityAABBToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -209,7 +209,7 @@ public class UTConfigBugfixes
         @Config.RequiresMcRestart
         @Config.Name("Fixes Invisible Player when Flying with Elytra")
         @Config.Comment("Fixes the player model occasionally disappearing when flying with elytra in a straight line in third-person mode")
-        public boolean utFixInvisiblePlayerModelWithElytra = false;
+        public boolean utFixInvisiblePlayerModelWithElytra = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Entity Bounding Box")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1959,6 +1959,11 @@ public class UTConfigTweaks
         public boolean utWorldLoadingToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Improve Language Switching Speed")
+        @Config.Comment("Improves the speed of switching languages in the Language GUI")
+        public boolean utImproveLanguageSwitchingSpeed = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Mute Advancement Errors")
         @Config.Comment("Silences advancement errors")
         public boolean utAdvancementCheckToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1038,6 +1038,11 @@ public class UTConfigTweaks
         public boolean utHardcoreBucketsToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Prevent Placing Buckets in Portals")
+        @Config.Comment("Prevents placing of liquid source blocks overriding portal blocks")
+        public boolean utPreventBucketPlacingInPortal = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("No Leftover Breath Bottles")
         @Config.Comment("Disables dragon's breath from being a container item and leaving off empty bottles when a stack is brewed with")
         public boolean utLeftoverBreathBottleToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1428,6 +1428,16 @@ public class UTConfigTweaks
         public boolean utBetterPing = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Disable Glint Overlay on Potions")
+        @Config.Comment("Disables the glint overlay on potions")
+        public boolean utDisablePotionGlint = false;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Disable Glint Overlay on Enchantment Books")
+        @Config.Comment("Disables the glint overlay on enchantment books")
+        public boolean utDisableEnchantmentBookGlint = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Prevent Keybinds from Overflowing Screen")
         @Config.Comment("Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present")
         public boolean utPreventKeybindingEntryOverflow = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -159,6 +159,11 @@ public class UTConfigTweaks
         public int utFallingBlockLifespan = 600;
 
         @Config.RequiresMcRestart
+        @Config.Name("Render End Portal Bottom")
+        @Config.Comment("Controls if the End Portal renders its texture on the bottom face")
+        public boolean utRenderEndPortalBottom = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fast Leaf Decay")
         @Config.Comment("Makes leaves decay faster when trees are chopped")
         public boolean utLeafDecayToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -159,6 +159,11 @@ public class UTConfigTweaks
         public int utFallingBlockLifespan = 600;
 
         @Config.RequiresMcRestart
+        @Config.Name("Prevent Observer Activating on Placement")
+        @Config.Comment("Controls if the observer activates itself on the first tick when it is placed")
+        public boolean utPreventObserverActivatesOnPlacement = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Render End Portal Bottom")
         @Config.Comment("Controls if the End Portal renders its texture on the bottom face")
         public boolean utRenderEndPortalBottom = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1375,6 +1375,11 @@ public class UTConfigTweaks
         public boolean utPotionDurationToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Always Return to Main Menu")
+        @Config.Comment("Always returns the player to the main menu when quitting the game")
+        public boolean utReturnToMainMenu = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Copy World Seed")
         @Config.Comment("Enables clicking of `/seed` world seed in chat to copy to clipboard")
         public boolean utCopyWorldSeedToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1976,7 +1976,7 @@ public class UTConfigTweaks
         @Config.RequiresMcRestart
         @Config.Name("Improve Language Switching Speed")
         @Config.Comment("Improves the speed of switching languages in the Language GUI")
-        public boolean utImproveLanguageSwitchingSpeed = false;
+        public boolean utImproveLanguageSwitchingSpeed = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Mute Advancement Errors")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1544,6 +1544,11 @@ public class UTConfigTweaks
             })
         public boolean utSkipRegistryScreenToggle = false;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Use Separate Narrator Key")
+        @Config.Comment("Allows using a custom Narrator key, instead of being stuck with CTRL+B")
+        public boolean utUseCustomNarratorKeybind = false;
+
         @Config.Name("Toggle Cheats Button")
         @Config.Comment("Adds a button to the pause menu to toggle cheats")
         public boolean utToggleCheatsToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1545,6 +1545,11 @@ public class UTConfigTweaks
         public boolean utSkipRegistryScreenToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Use Separate Dismount Key")
+        @Config.Comment("Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently")
+        public boolean utUseSeparateDismountKey = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Use Separate Narrator Key")
         @Config.Comment("Allows using a custom Narrator key, instead of being stuck with CTRL+B")
         public boolean utUseCustomNarratorKeybind = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -113,6 +113,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.entities.trading.json", () -> UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle);
             put("mixins.tweaks.entities.voidteleport.json", () -> UTConfigTweaks.ENTITIES.VOID_TELEPORT.utVoidTeleportToggle);
             put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
+            put("mixins.tweaks.items.bucket.json", () -> UTConfigTweaks.ITEMS.utPreventBucketPlacingInPortal);
             put("mixins.tweaks.items.eating.json", () -> UTConfigTweaks.ITEMS.utAlwaysEatToggle);
             put("mixins.tweaks.items.hardcorebuckets.json", () -> UTConfigTweaks.ITEMS.utHardcoreBucketsToggle);
             put("mixins.tweaks.items.infinityallarrows.json", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -75,6 +75,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.blocks.bedobstruction.json", () -> UTConfigTweaks.BLOCKS.utBedObstructionToggle);
             put("mixins.tweaks.blocks.breakablebedrock.json", () -> UTConfigTweaks.BLOCKS.BREAKABLE_BEDROCK.utBreakableBedrockToggle);
             put("mixins.tweaks.blocks.endcrystal.json", () -> UTConfigTweaks.BLOCKS.utEndCrystalAnywherePlacing);
+            put("mixins.tweaks.blocks.endportal.json", () -> UTConfigTweaks.BLOCKS.utRenderEndPortalBottom);
             put("mixins.tweaks.blocks.explosion.json", () -> UTConfigTweaks.BLOCKS.utExplosionDropChance != 1.0D);
             put("mixins.tweaks.blocks.falling.json", () -> UTConfigTweaks.BLOCKS.utFallingBlockLifespan != 600);
             put("mixins.tweaks.blocks.golemstructure.json", () -> UTConfigTweaks.ENTITIES.utGolemPlacement);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -194,6 +194,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.mainmenu.json", () -> UTConfigTweaks.MISC.utReturnToMainMenu);
             put("mixins.tweaks.misc.music.json", () -> UTConfigTweaks.MISC.utInfiniteMusicToggle);
             put("mixins.tweaks.misc.narrator.json", () -> UTConfigTweaks.MISC.utDisableNarratorToggle);
+            put("mixins.tweaks.misc.narratorkeybind.json", () -> UTConfigTweaks.MISC.utUseCustomNarratorKeybind);
             put("mixins.tweaks.misc.nightvisionflash.json", () -> UTConfigTweaks.MISC.utNightVisionFlashToggle);
             put("mixins.tweaks.misc.personalpotionparticles.json", () -> UTConfigTweaks.MISC.utPoVEffectParticles);
             put("mixins.tweaks.misc.recipebook.client.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -189,6 +189,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.gui.selecteditemtooltip.json", () -> UTConfigTweaks.MISC.utSelectedItemTooltipHeight != 59);
             put("mixins.tweaks.misc.gui.textshadow.json", () -> UTConfigTweaks.MISC.utDisableTextShadow);
             put("mixins.tweaks.misc.lightning.flash.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFlashToggle);
+            put("mixins.tweaks.misc.mainmenu.json", () -> UTConfigTweaks.MISC.utReturnToMainMenu);
             put("mixins.tweaks.misc.music.json", () -> UTConfigTweaks.MISC.utInfiniteMusicToggle);
             put("mixins.tweaks.misc.narrator.json", () -> UTConfigTweaks.MISC.utDisableNarratorToggle);
             put("mixins.tweaks.misc.nightvisionflash.json", () -> UTConfigTweaks.MISC.utNightVisionFlashToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -99,6 +99,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.entities.damage.velocity.json", () -> UTConfigTweaks.ENTITIES.DAMAGE_VELOCITY.utDamageVelocityToggle);
             put("mixins.tweaks.entities.despawning.json", () -> UTConfigTweaks.ENTITIES.utMobDespawnToggle);
             put("mixins.tweaks.entities.loot.json", () -> UTConfigTweaks.ENTITIES.utCreeperMusicDiscsToggle);
+            put("mixins.tweaks.entities.playerdismount.json", () -> UTConfigTweaks.MISC.utUseSeparateDismountKey);
             put("mixins.tweaks.entities.saturation.json", () -> UTConfigTweaks.ENTITIES.utRidingExhaustion != 0.0D);
             put("mixins.tweaks.entities.spawning.caps.json", () -> UTConfigTweaks.ENTITIES.SPAWN_CAPS.utSpawnCapsToggle);
             put("mixins.tweaks.entities.spawning.creeper.confetti.json", () -> UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiChance != 0.0D);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -83,6 +83,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.blocks.hitdelay.json", () -> UTConfigTweaks.BLOCKS.utBlockHitDelay != 5);
             put("mixins.tweaks.blocks.leafdecay.json", () -> UTConfigTweaks.BLOCKS.utLeafDecayToggle);
             put("mixins.tweaks.blocks.lenientpaths.json", () -> UTConfigTweaks.BLOCKS.utLenientPathsToggle);
+            put("mixins.tweaks.blocks.observer.json", () -> UTConfigTweaks.BLOCKS.utPreventObserverActivatesOnPlacement);
             put("mixins.tweaks.blocks.overhaulbeacon.json", () -> UTConfigTweaks.BLOCKS.OVERHAUL_BEACON.utOverhaulBeaconToggle);
             put("mixins.tweaks.blocks.pumpkinplacing.json", () -> UTConfigTweaks.BLOCKS.utUnsupportedPumpkinPlacing);
             put("mixins.tweaks.blocks.sapling.json", () -> UTConfigTweaks.BLOCKS.SAPLING_BEHAVIOR.utSaplingBehaviorToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -156,6 +156,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.bugfixes.blocks.blockoverlay.json", () -> UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle);
             put("mixins.bugfixes.blocks.miningglitch.client.json", () -> UTConfigBugfixes.BLOCKS.MINING_GLITCH.utMiningGlitchToggle);
             put("mixins.bugfixes.entities.elytra.json", () -> UTConfigBugfixes.ENTITIES.utElytraDeploymentLandingToggle);
+            put("mixins.bugfixes.entities.elytrarender.json", () -> UTConfigBugfixes.ENTITIES.utFixInvisiblePlayerModelWithElytra);
             put("mixins.bugfixes.entities.entitylists.client.json", () -> UTConfigBugfixes.ENTITIES.ENTITY_LISTS.utWorldAdditionsToggle);
             put("mixins.bugfixes.entities.villagermantle.json", () -> UTConfigBugfixes.ENTITIES.utVillagerMantleToggle);
             put("mixins.bugfixes.misc.depthmask.json", () -> UTConfigBugfixes.MISC.utDepthMaskToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -181,6 +181,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.chat.maximumlines.json", () -> UTConfigTweaks.MISC.CHAT.utChatLines != 100);
             put("mixins.tweaks.misc.commands.seed.json", () -> UTConfigTweaks.MISC.utCopyWorldSeedToggle);
             put("mixins.tweaks.misc.credits.json", () -> UTConfigTweaks.MISC.utSkipCreditsToggle);
+            put("mixins.tweaks.misc.glint.enchantedbook.json", () -> UTConfigTweaks.MISC.utDisableEnchantmentBookGlint);
+            put("mixins.tweaks.misc.glint.potion.json", () -> UTConfigTweaks.MISC.utDisablePotionGlint);
             put("mixins.tweaks.misc.gui.keybindlistentry.json", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);
             put("mixins.tweaks.misc.gui.lanserverproperties.json", () -> UTConfigTweaks.MISC.utLANServerProperties);
             put("mixins.tweaks.misc.gui.overlaymessage.json", () -> UTConfigTweaks.MISC.utOverlayMessageHeight != -4);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -201,6 +201,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
             put("mixins.tweaks.performance.audioreload.json", () -> UTConfigTweaks.PERFORMANCE.utDisableAudioDebugToggle && !surgeLoaded);
             put("mixins.tweaks.performance.fps.json", () -> UTConfigTweaks.PERFORMANCE.utUncapFPSToggle);
+            put("mixins.tweaks.performance.languageswitching.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);
             put("mixins.tweaks.performance.missingmodel.json", () -> UTConfigTweaks.PERFORMANCE.utDisableFancyMissingModelToggle);
             put("mixins.tweaks.performance.mobspawnerrender.json", () -> UTConfigTweaks.PERFORMANCE.utDisableMobSpawnerRendering);
             put("mixins.tweaks.performance.resourcemanager.json", () -> UTConfigTweaks.PERFORMANCE.utCheckAnimatedModelsToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endportal/mixin/UTEndPortalMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endportal/mixin/UTEndPortalMixin.java
@@ -1,0 +1,26 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.endportal.mixin;
+
+import net.minecraft.block.BlockEndPortal;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = BlockEndPortal.class)
+public abstract class UTEndPortalMixin
+{
+    @Inject(method = "shouldSideBeRendered", at = @At("HEAD"), cancellable = true)
+    private void utEnsureDownIsRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigTweaks.BLOCKS.utRenderEndPortalBottom) return;
+        cir.setReturnValue(side == EnumFacing.UP || side == EnumFacing.DOWN);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endportal/mixin/UTTileEntityEndPortalMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/endportal/mixin/UTTileEntityEndPortalMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.endportal.mixin;
+
+import net.minecraft.tileentity.TileEntityEndPortal;
+import net.minecraft.util.EnumFacing;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = TileEntityEndPortal.class)
+public abstract class UTTileEntityEndPortalMixin
+{
+    @ModifyReturnValue(method = "shouldRenderFace", at = @At("RETURN"))
+    private boolean utEnsureDownIsRendered(boolean original, EnumFacing side)
+    {
+        if (!UTConfigTweaks.BLOCKS.utRenderEndPortalBottom) return original;
+        return side == EnumFacing.UP || side == EnumFacing.DOWN;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/observer/mixin/UTBlockObserverMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/observer/mixin/UTBlockObserverMixin.java
@@ -1,0 +1,39 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.observer.mixin;
+
+import net.minecraft.block.BlockObserver;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = BlockObserver.class)
+public abstract class UTBlockObserverMixin
+{
+    @Shadow
+    protected abstract void updateNeighborsInFront(World worldIn, BlockPos pos, IBlockState state);
+
+    @Inject(method = "onBlockAdded", at = @At("HEAD"), cancellable = true)
+    private void utPreventPlacementFromCausingPulse(World worldIn, BlockPos pos, IBlockState state, CallbackInfo ci)
+    {
+        if (!UTConfigTweaks.BLOCKS.utPreventObserverActivatesOnPlacement) return;
+        if (!worldIn.isRemote)
+        {
+            if (state.getValue(BlockObserver.POWERED) && !worldIn.isUpdateScheduled(pos, ((BlockObserver) (Object) this)))
+            {
+                IBlockState unpowered = state.withProperty(BlockObserver.POWERED, false);
+                worldIn.setBlockState(pos, unpowered, 18);
+                this.updateNeighborsInFront(worldIn, pos, state);
+            }
+        }
+        ci.cancel();
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/UTDismountKeybind.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/UTDismountKeybind.java
@@ -1,0 +1,42 @@
+package mod.acgaming.universaltweaks.tweaks.entities.playerdismount;
+
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.lwjgl.input.Keyboard;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTKeybindings;
+
+@SideOnly(Side.CLIENT)
+public class UTDismountKeybind extends UTKeybindings.Key
+{
+    public static UTKeybindings.Key key;
+
+    public UTDismountKeybind()
+    {
+        super("dismount", KeyConflictContext.IN_GAME, KeyModifier.NONE, Keyboard.KEY_LSHIFT);
+    }
+
+    public static void createKeybind()
+    {
+        if (UTConfigTweaks.MISC.utUseSeparateDismountKey)
+        {
+            key = new UTDismountKeybind();
+            UTKeybindings.addKey(key);
+        }
+    }
+
+    /**
+     * Logic handled in {@link mod.acgaming.universaltweaks.tweaks.entities.playerdismount.mixin.UTEntityPlayerSPMixin}
+     * due to checking if the key is held, not having a specific thing be run on the key being pressed.
+     */
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void handleKeybind()
+    {
+        // Handled in UTEntityPlayerSPMixin, see javadoc
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTEntityPlayerSPMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTEntityPlayerSPMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.entities.playerdismount.mixin;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.util.MovementInput;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.entities.playerdismount.UTDismountKeybind;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = EntityPlayerSP.class)
+public abstract class UTEntityPlayerSPMixin
+{
+    @WrapOperation(method = "onUpdate", at = @At(value = "FIELD", target = "Lnet/minecraft/util/MovementInput;sneak:Z"))
+    public boolean utOnUpdate(MovementInput instance, Operation<Boolean> original)
+    {
+        if (!UTConfigTweaks.MISC.utUseSeparateDismountKey) return original.call(instance);
+        return UTDismountKeybind.key.getKey().isKeyDown();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTKeyBindingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTKeyBindingMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.entities.playerdismount.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.entities.playerdismount.UTDismountKeybind;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = KeyBinding.class)
+public abstract class UTKeyBindingMixin
+{
+    @Inject(method = "conflicts", at = @At("HEAD"), cancellable = true, remap = false)
+    public void utConflicts(KeyBinding other, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigTweaks.MISC.utUseSeparateDismountKey) return;
+        //noinspection ConstantValue
+        if (UTDismountKeybind.key.getKey() == ((Object) this) && Minecraft.getMinecraft().gameSettings.keyBindSneak == other ||
+                UTDismountKeybind.key.getKey() == other && Minecraft.getMinecraft().gameSettings.keyBindSneak == ((Object) this))
+        {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTNetHandlerPlayClientMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerdismount/mixin/UTNetHandlerPlayClientMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.entities.playerdismount.mixin;
+
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.client.settings.KeyBinding;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.entities.playerdismount.UTDismountKeybind;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = NetHandlerPlayClient.class)
+public abstract class UTNetHandlerPlayClientMixin
+{
+    @WrapOperation(method = "handleSetPassengers", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;getDisplayName()Ljava/lang/String;", remap = false))
+    public String utHandleSetPassengers(KeyBinding instance, Operation<String> original)
+    {
+        if (!UTConfigTweaks.MISC.utUseSeparateDismountKey) return original.call(instance);
+        return UTDismountKeybind.key.getKey().getDisplayName();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bucket/mixin/UTPreventBucketReplacingPortalMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bucket/mixin/UTPreventBucketReplacingPortalMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.items.bucket.mixin;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemBucket;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = ItemBucket.class)
+public abstract class UTPreventBucketReplacingPortalMixin
+{
+    @WrapOperation(method = "tryPlaceContainedLiquid", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/material/Material;isSolid()Z"))
+    private boolean utPreventPlacementIfPortalBlock(Material instance, Operation<Boolean> original, @Nullable EntityPlayer player, World worldIn, BlockPos posIn)
+    {
+        if (original.call(instance)) return true;
+        if (!UTConfigTweaks.ITEMS.utPreventBucketPlacingInPortal) return true;
+        return worldIn.getBlockState(posIn).getBlock() == Blocks.PORTAL || instance == Material.PORTAL;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/glint/enchantedbook/mixin/UTItemEnchantedBookMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/glint/enchantedbook/mixin/UTItemEnchantedBookMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.tweaks.misc.glint.enchantedbook.mixin;
+
+import net.minecraft.item.ItemEnchantedBook;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemEnchantedBook.class)
+public abstract class UTItemEnchantedBookMixin
+{
+    @ModifyReturnValue(method = "hasEffect", at = @At("RETURN"))
+    private boolean utHasEffect(boolean original)
+    {
+        if (!UTConfigTweaks.MISC.utDisableEnchantmentBookGlint) return original;
+        return false;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/glint/potion/mixin/UTItemPotionMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/glint/potion/mixin/UTItemPotionMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.misc.glint.potion.mixin;
+
+import java.util.List;
+
+import net.minecraft.item.ItemPotion;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = ItemPotion.class)
+public abstract class UTItemPotionMixin
+{
+    @WrapOperation(method = "hasEffect", at = @At(value = "INVOKE", target = "Ljava/util/List;isEmpty()Z"))
+    private boolean utHasEffect(List<?> instance, Operation<Boolean> original)
+    {
+        if (!UTConfigTweaks.MISC.utDisablePotionGlint) return original.call(instance);
+        return true;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/mainmenu/mixin/UTGuiIngameMenuMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/mainmenu/mixin/UTGuiIngameMenuMixin.java
@@ -1,0 +1,23 @@
+package mod.acgaming.universaltweaks.tweaks.misc.mainmenu.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiIngameMenu;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(value = GuiIngameMenu.class)
+public abstract class UTGuiIngameMenuMixin
+{
+    @WrapOperation(method = "actionPerformed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isIntegratedServerRunning()Z"))
+    private boolean utAlwaysReturnToMainMenu(Minecraft instance, Operation<Boolean> original)
+    {
+        if (!UTConfigTweaks.MISC.utReturnToMainMenu) return original.call(instance);
+        return true;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/UTNarratorKeybind.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/UTNarratorKeybind.java
@@ -1,0 +1,57 @@
+package mod.acgaming.universaltweaks.tweaks.misc.narrator;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiControls;
+import net.minecraft.client.gui.ScreenChatOptions;
+import net.minecraft.client.settings.GameSettings;
+import net.minecraftforge.client.settings.IKeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.lwjgl.input.Keyboard;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTKeybindings;
+
+@SideOnly(Side.CLIENT)
+public class UTNarratorKeybind extends UTKeybindings.Key
+{
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private static final IKeyConflictContext CONTEXT = new IKeyConflictContext()
+    {
+        public boolean isActive()
+        {
+            return !(mc.currentScreen instanceof GuiControls);
+        }
+
+        public boolean conflicts(IKeyConflictContext other)
+        {
+            return false;
+        }
+    };
+
+    public UTNarratorKeybind()
+    {
+        super("narrator", CONTEXT, KeyModifier.CONTROL, Keyboard.KEY_B);
+    }
+
+    public static void createKeybind()
+    {
+        if (!UTConfigTweaks.MISC.utDisableNarratorToggle && UTConfigTweaks.MISC.utUseCustomNarratorKeybind)
+        {
+            UTKeybindings.addKey(new UTNarratorKeybind());
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void handleKeybind()
+    {
+        mc.gameSettings.setOptionValue(GameSettings.Options.NARRATOR, 1);
+        if (mc.currentScreen instanceof ScreenChatOptions)
+        {
+            ((ScreenChatOptions) mc.currentScreen).updateNarratorButton();
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorKeybindMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorKeybindMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.tweaks.misc.narrator.mixin;
+
+import net.minecraft.client.Minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(value = Minecraft.class)
+public class UTNarratorKeybindMixin
+{
+    @ModifyConstant(method = "dispatchKeypresses", constant = @Constant(intValue = 48))
+    public int utNarratorSay(int original)
+    {
+        if (!UTConfigTweaks.MISC.utUseCustomNarratorKeybind) return original;
+        return 0;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/languageswitching/mixin/UTLanguageListMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/languageswitching/mixin/UTLanguageListMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.languageswitching.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.resource.IResourceType;
+import net.minecraftforge.fml.client.FMLClientHandler;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly, TheRandomLabs (RandomPatches)
+@Mixin(targets = "net.minecraft.client.gui.GuiLanguage$List")
+public abstract class UTLanguageListMixin
+{
+    @Redirect(method = "elementClicked", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/client/FMLClientHandler;refreshResources([Lnet/minecraftforge/client/resource/IResourceType;)V", remap = false))
+    public void utImproveLanguageSwitchingPerformance(FMLClientHandler handler, IResourceType[] resources)
+    {
+        if (!UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed) return;
+        Minecraft mc = Minecraft.getMinecraft();
+        mc.getLanguageManager().onResourceManagerReload(mc.getResourceManager());
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.narrator.UTNarratorKeybind;
 import mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.UTClearToastKeybind;
 
 @Mod.EventBusSubscriber(modid = UniversalTweaks.MODID, value = Side.CLIENT)
@@ -32,6 +33,7 @@ public class UTKeybindings extends KeyBinding
     public static void initialize()
     {
         UTClearToastKeybind.createKeybind();
+        UTNarratorKeybind.createKeybind();
 
         for (Key key : keys)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/UTKeybindings.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.tweaks.entities.playerdismount.UTDismountKeybind;
 import mod.acgaming.universaltweaks.tweaks.misc.narrator.UTNarratorKeybind;
 import mod.acgaming.universaltweaks.tweaks.misc.toastcontrol.UTClearToastKeybind;
 
@@ -33,6 +34,7 @@ public class UTKeybindings extends KeyBinding
     public static void initialize()
     {
         UTClearToastKeybind.createKeybind();
+        UTDismountKeybind.createKeybind();
         UTNarratorKeybind.createKeybind();
 
         for (Key key : keys)

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -127,6 +127,7 @@ public class UTObsoleteModsHandler
             put("toastcontrol", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
             put("tramplestopper", () -> UTConfigTweaks.BLOCKS.utFarmlandTrample != UTConfigTweaks.TrampleOptions.DEFAULT);
             put("unloader", () -> UTConfigTweaks.WORLD.DIMENSION_UNLOAD.utUnloaderToggle);
+            put("unridekeybind", () -> UTConfigTweaks.MISC.utUseSeparateDismountKey);
             put("villagermantlefix", () -> UTConfigBugfixes.ENTITIES.utVillagerMantleToggle);
             put("voidfog", () -> UTConfigTweaks.WORLD.VOID_FOG.utVoidFogToggle);
             put("watercontrolextreme", () -> UTConfigTweaks.BLOCKS.FINITE_WATER.utFiniteWaterToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -112,6 +112,7 @@ public class UTObsoleteModsHandler
             put("preventghost", () -> UTConfigBugfixes.BLOCKS.MINING_GLITCH.utMiningGlitchToggle);
             put("quickleafdecay", () -> UTConfigTweaks.BLOCKS.utLeafDecayToggle);
             put("rallyhealth", () -> UTConfigTweaks.ENTITIES.RALLY_HEALTH.utRallyHealthToggle);
+            put("rebind_narrator", () -> UTConfigTweaks.MISC.utUseCustomNarratorKeybind);
             put("salwayseat", () -> UTConfigTweaks.ITEMS.utAlwaysEatToggle);
             put("savemystronghold", () -> UTConfigTweaks.WORLD.utStrongholdToggle);
             put("sleepsooner", () -> UTConfigTweaks.ENTITIES.SLEEPING.utSleepingTime != -1);

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -5,6 +5,7 @@ msg.universaltweaks.obsoletemods.warning3=Consider removing them from your game 
 
 # KEYBINDS
 keybind.universaltweaks.clear_toasts=Clear Toasts
+keybind.universaltweaks.dismount=Dismount
 keybind.universaltweaks.narrator=Toggle Narrator
 
 # TOGGLE CHEATS

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -5,6 +5,7 @@ msg.universaltweaks.obsoletemods.warning3=Consider removing them from your game 
 
 # KEYBINDS
 keybind.universaltweaks.clear_toasts=Clear Toasts
+keybind.universaltweaks.narrator=Toggle Narrator
 
 # TOGGLE CHEATS
 btn.universaltweaks.cheats.enabled=Cheats: ON

--- a/src/main/resources/mixins.bugfixes.entities.elytrarender.json
+++ b/src/main/resources/mixins.bugfixes.entities.elytrarender.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.entities.elytra.render.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTRenderPlayerMixin"]
+}

--- a/src/main/resources/mixins.tweaks.blocks.endportal.json
+++ b/src/main/resources/mixins.tweaks.blocks.endportal.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.endportal.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTEndPortalMixin", "UTTileEntityEndPortalMixin"]
+}

--- a/src/main/resources/mixins.tweaks.blocks.observer.json
+++ b/src/main/resources/mixins.tweaks.blocks.observer.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.observer.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBlockObserverMixin"]
+}

--- a/src/main/resources/mixins.tweaks.entities.playerdismount.json
+++ b/src/main/resources/mixins.tweaks.entities.playerdismount.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.playerdismount.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEntityPlayerSPMixin", "UTKeyBindingMixin", "UTNetHandlerPlayClientMixin"]
+}

--- a/src/main/resources/mixins.tweaks.items.bucket.json
+++ b/src/main/resources/mixins.tweaks.items.bucket.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.bucket.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTPreventBucketReplacingPortalMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.glint.enchantedbook.json
+++ b/src/main/resources/mixins.tweaks.misc.glint.enchantedbook.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.glint.enchantedbook.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTItemEnchantedBookMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.glint.potion.json
+++ b/src/main/resources/mixins.tweaks.misc.glint.potion.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.glint.potion.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTItemPotionMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.mainmenu.json
+++ b/src/main/resources/mixins.tweaks.misc.mainmenu.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.mainmenu.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiIngameMenuMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.narratorkeybind.json
+++ b/src/main/resources/mixins.tweaks.misc.narratorkeybind.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.narrator.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTNarratorKeybindMixin"]
+}

--- a/src/main/resources/mixins.tweaks.performance.languageswitching.json
+++ b/src/main/resources/mixins.tweaks.performance.languageswitching.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.languageswitching.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTLanguageListMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- fixes the player model turning invisible occasionally when flying around with an elytra in third-person mode. (default: `true`)
- always returning the player to the main menu instead of the multiplayer screen or realms. (default: `false`)
- disables glint effect on potions. (default: `false`)
- improves the speed of switching languages. (default: `true`)
- prevents the observer being placed from activating itself (default: `false`)
- prevents placing a bucket inside a portal block (default: `false`)
- controls if the bottom of the end portal should be rendered (default: `true`)
- allows for rebinding a dismount key, separate to the crouch key. (default: `false`)
- allows for rebinding the narrator key, provided the narrator is not disabled. (default: `false`)
- in addition to these changes based on random patches, i also added a config option to disable the glint effect on enchantment books. (default: `false`)


this includes a number of changes that RandomPatches makes, but not all changes. the things RandomPatches changes but are not included here are:
- title and icon changes: `setWindowIcon` and `defaultWindowTitle`.
- `framerateLimitSliderStepSize`, `smoothEyeLevelChanges`, `fixTickNextTickListOutOfSynch`, `miningGhostBlocksFix`, `isRecipeBookNBTFixEnabled`, `skullStackingFix`, and `patchEntityBoat`.

this relates to the following discussions: https://github.com/ACGaming/UniversalTweaks/discussions/479, https://github.com/ACGaming/UniversalTweaks/discussions/347, https://github.com/ACGaming/UniversalTweaks/discussions/332, https://github.com/ACGaming/UniversalTweaks/discussions/206, and https://github.com/ACGaming/UniversalTweaks/discussions/50
