### PR TITLE
Fix Requious Frakto and Tinkers Construct leaking server world to particles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:openblocks-228816:2699056')
     compileOnly rfg.deobf('curse.maven:reborn-core-237903:3330308')
     compileOnly rfg.deobf('curse.maven:reskillable-286382:2815686')
+    compileOnly rfg.deobf('curse.maven:requious-frakto-336748:3218640')
     compileOnly rfg.deobf('curse.maven:roost-277711:2702080')
     compileOnly rfg.deobf('curse.maven:simpledifficulty-360779:3613814')
     compileOnly rfg.deobf('curse.maven:storage-drawers-223852:2952606')

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -159,6 +159,10 @@ public class UTConfigMods
     @Config.Name("Railcraft")
     public static final RailcraftCategory RAILCRAFT = new RailcraftCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.requiousfrakto")
+    @Config.Name("Requious Frakto")
+    public static final RequiousFraktoCategory REQUIOUS_FRAKTO = new RequiousFraktoCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.rftoolsdimensions")
     @Config.Name("RFTools Dimensions")
     public static final RFToolsDimensionsCategory RFTOOLS_DIMENSIONS = new RFToolsDimensionsCategory();
@@ -654,6 +658,14 @@ public class UTConfigMods
         public boolean utNoBetaWarningToggle = true;
     }
 
+    public static class RequiousFraktoCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Particle Fixes")
+        @Config.Comment("Fixes server world being leaked to various particles")
+        public boolean utParticleFixesToggle = true;
+    }
+
     public static class RoostCategory
     {
         @Config.RequiresMcRestart
@@ -941,6 +953,11 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Particle Fixes")
+        @Config.Comment("Fixes server world being leaked to various particles")
+        public boolean utParticleFixesToggle = true;
 
         @Config.RequiresMcRestart
         @Config.Name("Tool Customization")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -24,6 +24,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.modularrouters.json", () -> loaded("modularrouters") && UTConfigMods.MODULAR_ROUTERS.utParticleThreadToggle);
             put("mixins.mods.roost.json", () -> loaded("roost") && loaded("contenttweaker"));
             put("mixins.mods.storagedrawers.client.json", () -> loaded("storagedrawers"));
+            put("mixins.mods.tconstruct.client.json", () -> loaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utParticleFixesToggle);
             put("mixins.mods.thaumcraft.entities.client.json", () -> loaded("thaumcraft"));
         }
     });
@@ -77,6 +78,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.nuclearcraft.json", () -> loaded("nuclearcraft"));
             put("mixins.mods.openblocks.json", () -> loaded("openblocks") && UTConfigMods.OPEN_BLOCKS.utLastStandFixToggle);
             put("mixins.mods.quark.dupes.json", () -> loaded("quark") && UTConfigMods.QUARK.utDuplicationFixesToggle);
+            put("mixins.mods.requiousfrakto.json", () -> loaded("requious") && UTConfigMods.REQUIOUS_FRAKTO.utParticleFixesToggle);
             put("mixins.mods.reskillable.json", () -> loaded("reskillable"));
             put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));
             put("mixins.mods.roost.contenttweaker.json", () -> loaded("contenttweaker"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/requiousfrakto/mixin/UTTileEntityAssemblyMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/requiousfrakto/mixin/UTTileEntityAssemblyMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.requiousfrakto.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import requious.tile.TileEntityAssembly;
+
+// Courtesy of jchung01
+@Mixin(value = TileEntityAssembly.class)
+public abstract class UTTileEntityAssemblyMixin extends TileEntity
+{
+    /**
+     * @reason Updating MachineVisuals should only be needed client-side.
+     * This is the earliest we can check the side before calls to IProxy
+     * methods for spawning particles.
+     */
+    @ModifyExpressionValue(method = "update", at = @At(value = "INVOKE", target = "Ljava/util/Iterator;hasNext()Z", remap = false))
+    private boolean utCheckSide(boolean original)
+    {
+        if (!this.world.isRemote) return false;
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/UTClientProxyMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/UTClientProxyMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import slimeknights.tconstruct.common.ClientProxy;
+
+// Courtesy of jchung01
+@Mixin(value = ClientProxy.class, remap = false)
+public class UTClientProxyMixin
+{
+    /**
+     * @reason It is never correct to use passed worlds for particles, only use the client's.
+     * Ideally we would check sides in the relevant methods before even calling this,
+     * but this is simpler.
+     */
+    @Inject(method = "spawnParticle", at = @At(value = "HEAD"))
+    private void utSetWorld(CallbackInfo ci, @Local(argsOnly = true) LocalRef<World> worldRef)
+    {
+        worldRef.set(Minecraft.getMinecraft().world);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -83,6 +83,7 @@ cfg.universaltweaks.modintegration.projectred=ProjectRed
 cfg.universaltweaks.modintegration.quark=Quark
 cfg.universaltweaks.modintegration.rftoolsdimensions=RFTools Dimensions
 cfg.universaltweaks.modintegration.railcraft=Railcraft
+cfg.universaltweaks.modintegration.requiousfrakto=Requious Frakto
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.sd=Storage Drawers
 cfg.universaltweaks.modintegration.simpledifficulty=Simple Difficulty

--- a/src/main/resources/mixins.mods.requiousfrakto.json
+++ b/src/main/resources/mixins.mods.requiousfrakto.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.requiousfrakto.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTTileEntityAssemblyMixin"]
+}

--- a/src/main/resources/mixins.mods.tconstruct.client.json
+++ b/src/main/resources/mixins.mods.tconstruct.client.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.tconstruct.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTClientProxyMixin"]
+}


### PR DESCRIPTION
Particles are client-side; in SP/integrated server cases these mods could leak the server's world to the client when creating particles.
Fixes Red-Studio-Ragnarok/Alfheim#48
Fixes Red-Studio-Ragnarok/Alfheim#50