### PR TITLE
Improve Barrier Particle Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ All changes are toggleable via config files.
 * **Hide Personal Effect Particles:** Disables potion effect particles emitting from yourself
 * **Horizontal Collision Damage:** Applies horizontal collision damage to the player akin to elytra collision
 * **Husk & Stray Spawning:** Lets husks and strays spawn underground like regular zombies and skeletons
+* **Improve Barrier Particle Display:** Causes Barrier Particles to always be displayed to players in Creative mode
 * **Improve Language Switching Speed:** Improves the speed of switching languages in the Language GUI
 * **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings
 * **Incurable Potions:** Excludes potion effects from being curable with curative items like buckets of milk

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -159,6 +159,11 @@ public class UTConfigTweaks
         public int utFallingBlockLifespan = 600;
 
         @Config.RequiresMcRestart
+        @Config.Name("Improve Barrier Particle Display")
+        @Config.Comment("Causes Barrier Particles to always be displayed to players in Creative mode")
+        public boolean utBarrierParticleDisplay = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Prevent Observer Activating on Placement")
         @Config.Comment("Controls if the observer activates itself on the first tick when it is placed")
         public boolean utPreventObserverActivatesOnPlacement = false;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -161,7 +161,7 @@ public class UTConfigTweaks
         @Config.RequiresMcRestart
         @Config.Name("Improve Barrier Particle Display")
         @Config.Comment("Causes Barrier Particles to always be displayed to players in Creative mode")
-        public boolean utBarrierParticleDisplay = true;
+        public boolean utBarrierParticleDisplay = false;
 
         @Config.RequiresMcRestart
         @Config.Name("Prevent Observer Activating on Placement")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -72,6 +72,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.bugfixes.world.chunksaving.json", () -> UTConfigBugfixes.WORLD.utChunkSavingToggle && !spongeForgeLoaded);
             put("mixins.bugfixes.world.tileentities.json", () -> UTConfigBugfixes.WORLD.utTileEntityMap != UTConfigBugfixes.WorldCategory.EnumMaps.HASHMAP);
             put("mixins.bugfixes.world.witchhuts.json", () -> UTConfigBugfixes.WORLD.utWitchStructuresToggle);
+            put("mixins.tweaks.blocks.barrier.json", () -> UTConfigTweaks.BLOCKS.utBarrierParticleDisplay);
             put("mixins.tweaks.blocks.bedobstruction.json", () -> UTConfigTweaks.BLOCKS.utBedObstructionToggle);
             put("mixins.tweaks.blocks.breakablebedrock.json", () -> UTConfigTweaks.BLOCKS.BREAKABLE_BEDROCK.utBreakableBedrockToggle);
             put("mixins.tweaks.blocks.endcrystal.json", () -> UTConfigTweaks.BLOCKS.utEndCrystalAnywherePlacing);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/barrier/mixin/UTBarrierParticle.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/barrier/mixin/UTBarrierParticle.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.barrier.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.world.GameType;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(WorldClient.class)
+public class UTBarrierParticle
+{
+    @Shadow
+    @Final
+    private Minecraft mc;
+
+    @ModifyVariable(method = "doVoidFogParticles", at = @At(value = "STORE", ordinal = 0))
+    private boolean utAlwaysDisplayBarrier(boolean original)
+    {
+        if (!UTConfigTweaks.BLOCKS.utBarrierParticleDisplay) return original;
+        return this.mc.playerController.getCurrentGameType() == GameType.CREATIVE;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/barrier/mixin/UTBarrierParticleMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/barrier/mixin/UTBarrierParticleMixin.java
@@ -14,7 +14,7 @@ import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 
 // Courtesy of WaitingIdly
 @Mixin(WorldClient.class)
-public class UTBarrierParticle
+public class UTBarrierParticleMixin
 {
     @Shadow
     @Final

--- a/src/main/resources/mixins.tweaks.blocks.barrier.json
+++ b/src/main/resources/mixins.tweaks.blocks.barrier.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.barrier.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTBarrierParticle"]
+}

--- a/src/main/resources/mixins.tweaks.blocks.barrier.json
+++ b/src/main/resources/mixins.tweaks.blocks.barrier.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["UTBarrierParticle"]
+  "client": ["UTBarrierParticleMixin"]
 }


### PR DESCRIPTION
changes in this PR:
- makes barrier particles always display to players in Creative Mode, regardless of if they are holding a Barrier in their hand (default: `false`)

