### PR TITLE
Customize Particle Limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ All changes are toggleable via config files.
 * **Offhand Improvement:** Prevents placing offhand blocks when blocks or food are held in the mainhand
 * **Overhaul Beacon:** Change how beacon construct and range apply per level
 * **Overlay Message Height:** Sets the Y value of the overlay message (action bar), displayed for playing records etc.
+* **Particle Limit:** Limits particles to a set amount. Should not be set too low, as it will cause particles to appear for a single tick before vanishing
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
 * **Prevent Observer Activating on Placement:** Controls if the observer activates itself on the first tick when it is placed

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1487,7 +1487,7 @@ public class UTConfigTweaks
                 "Vanilla default is 16384",
                 "Less than or equal to 0 is set to the default"
             })
-        public int utParticleLimit = 50;
+        public int utParticleLimit = -1;
 
         @Config.RequiresMcRestart
         @Config.Name("No Smelting XP")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1480,6 +1480,16 @@ public class UTConfigTweaks
         public boolean utPoVEffectParticles = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Particle Limit")
+        @Config.Comment
+            ({
+                "Limits particles to a set amount. Should not be set too low, as it will cause particles to appear for a single tick before vanishing",
+                "Vanilla default is 16384",
+                "Less than or equal to 0 is set to the default"
+            })
+        public int utParticleLimit = 50;
+
+        @Config.RequiresMcRestart
         @Config.Name("No Smelting XP")
         @Config.Comment("Disables the experience reward when smelting items in furnaces")
         public boolean utSmeltingXPToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -192,6 +192,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.gui.potionduration.json", () -> UTConfigTweaks.MISC.utPotionDurationToggle);
             put("mixins.tweaks.misc.gui.selecteditemtooltip.json", () -> UTConfigTweaks.MISC.utSelectedItemTooltipHeight != 59);
             put("mixins.tweaks.misc.gui.textshadow.json", () -> UTConfigTweaks.MISC.utDisableTextShadow);
+            put("mixins.tweaks.misc.particlelimit.json", () -> UTConfigTweaks.MISC.utParticleLimit > 0);
             put("mixins.tweaks.misc.lightning.flash.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFlashToggle);
             put("mixins.tweaks.misc.mainmenu.json", () -> UTConfigTweaks.MISC.utReturnToMainMenu);
             put("mixins.tweaks.misc.music.json", () -> UTConfigTweaks.MISC.utInfiniteMusicToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/particlelimit/mixin/UTParticleManagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/particlelimit/mixin/UTParticleManagerMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 
+// Courtesy of WaitingIdly
 @Mixin(ParticleManager.class)
 public class UTParticleManagerMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/particlelimit/mixin/UTParticleManagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/particlelimit/mixin/UTParticleManagerMixin.java
@@ -1,0 +1,20 @@
+package mod.acgaming.universaltweaks.tweaks.misc.particlelimit.mixin;
+
+import net.minecraft.client.particle.ParticleManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+@Mixin(ParticleManager.class)
+public class UTParticleManagerMixin
+{
+    @ModifyConstant(method = "updateEffects", constant = @Constant(intValue = 16384))
+    public int utRenderParticles(int original)
+    {
+        if (UTConfigTweaks.MISC.utParticleLimit <= 0) return original;
+        return UTConfigTweaks.MISC.utParticleLimit;
+    }
+}

--- a/src/main/resources/mixins.tweaks.misc.particlelimit.json
+++ b/src/main/resources/mixins.tweaks.misc.particlelimit.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.particlelimit.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTParticleManagerMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- allows customizing the maximum number of displayed particles, changing from the default maximum of 16384. (default: `-1`)
- includes a warning about setting it too low, as setting it to eg 1 will cause the rendered particle to appear for a moment, before being replaced with another.

