### PR TITLE
Catch Radar Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ All changes are toggleable via config files.
 * **Epic Siege Mod**
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**
+  * **Catch Radar Exception:** Fixes the Radar feature (find in nearby inventories) entirely breaking when near some inventories
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Fix Deep Dark Stats:** Fixes Mob Attack and Health Statistics being repeatedly doubled
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ All changes are toggleable via config files.
 * **Epic Siege Mod**
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**
-  * **Catch Radar Exception:** Fixes the Radar feature (find in nearby inventories) entirely breaking when near some inventories
+    * **Catch Radar Exception:** Fixes the Radar feature (find in nearby inventories) entirely breaking when near some inventories
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Fix Deep Dark Stats:** Fixes Mob Attack and Health Statistics being repeatedly doubled
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -436,6 +436,15 @@ public class UTConfigMods
     public static class ExtraUtilitiesCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Catch Radar Exception")
+        @Config.Comment
+            ({
+                "When near some inventories, the Radar feature (find in nearby inventories) will entirely break",
+                "this catches the AbstractMethodException thrown, allowing other nearby inventories to be searched"
+            })
+        public boolean utCatchRadarException = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Deep Dark Stats")
         @Config.Comment("Fixes Mob Attack and Health Statistics being repeatedly doubled")
         public boolean utDeepDarkStats = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -59,6 +59,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
             put("mixins.mods.extrautilities.mutabledrops.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
+            put("mixins.mods.extrautilities.radar.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utCatchRadarException);
             put("mixins.mods.forestry.cocoa.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utFOCocoaBeansToggle);
             put("mixins.mods.forestry.dupes.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utDuplicationFixesToggle);
             put("mixins.mods.forestry.extratrees.json", () -> loaded("extratrees"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/radar/mixin/UTRadarPingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/radar/mixin/UTRadarPingMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.radar.mixin;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.rwtema.extrautils2.crafting.Radar;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+@Mixin(value = Radar.PacketPing.class, remap = false)
+public abstract class UTRadarPingMixin
+{
+    @WrapOperation(method = "lambda$doStuffServer$1", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/items/IItemHandler;getStackInSlot(I)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utCatchItemHandlerException(IItemHandler instance, int slot, Operation<ItemStack> original)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utCatchRadarException) return original.call(instance, slot);
+        try
+        {
+            return original.call(instance, slot);
+        }
+        catch (AbstractMethodError e)
+        {
+            e.printStackTrace();
+            return ItemStack.EMPTY;
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/radar/mixin/UTRadarPingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/radar/mixin/UTRadarPingMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 
+// Courtesy of WaitingIdly
 @Mixin(value = Radar.PacketPing.class, remap = false)
 public abstract class UTRadarPingMixin
 {

--- a/src/main/resources/mixins.mods.extrautilities.radar.json
+++ b/src/main/resources/mixins.mods.extrautilities.radar.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.radar.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTRadarPingMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- catches `AbstractMethodError`s in the Extra Utilities Radar feature (find in nearby inventories) to allow Radar to still find items in nearby inventories when one of the nearby inventories breaks. (default: `true`)


this frequently happens when near BiblioCraft blocks, such as in this log:

```
Error executing task
java.util.concurrent.ExecutionException: java.lang.AbstractMethodError: Method jds/bibliocraft/tileentities/TileEntityArmorStand.getStackInSlot(I)Lnet/minecraft/item/ItemStack; is abstract
        at java.util.concurrent.FutureTask.report(Unknown Source) ~[?:1.8.0_411]
        at java.util.concurrent.FutureTask.get(Unknown Source) ~[?:1.8.0_411]
        at net.minecraft.util.Util.runTask(SourceFile:531) [h.class:?]
        at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:723) [MinecraftServer.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:397) [nz.class:?]
        at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526) [MinecraftServer.class:?]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_411]
Caused by: java.lang.AbstractMethodError: Method jds/bibliocraft/tileentities/TileEntityArmorStand.getStackInSlot(I)Lnet/minecraft/item/ItemStack; is abstract
        at jds.bibliocraft.tileentities.TileEntityArmorStand.getStackInSlot(TileEntityArmorStand.java) ~[TileEntityArmorStand.class:2.4.6]
        at com.rwtema.extrautils2.crafting.Radar$PacketPing.lambda$doStuffServer$1(Radar.java:185) ~[Radar$PacketPing.class:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_411]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_411]
        at net.minecraft.util.Util.runTask(SourceFile:529) ~[h.class:?]
        ... 5 more

```