### PR TITLE
Disable hotbar scroll wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ All changes are toggleable via config files.
 * **Disable Audio Debug:** Improves loading times by removing debug code for missing sounds and subtitles
 * **Disable Creeper Music Discs:** Disables creepers dropping music discs when slain by skeletons
 * **Disable Fancy Missing Model:** Improves rendering performance by removing the resource location text on missing models
+* **Disable Hotbar Scroll Wrapping:** Disables using the scroll wheel to change hotbar slots wrapping
 * **Disable Mob Spawner Entity Render:** Disables rendering an entity inside of Mob Spawners
 * **Disable Narrator:** Disables the narrator functionality entirely
 * **Disable Glint Overlay on Enchantment Books:** Disables the glint overlay on enchantment books

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1443,6 +1443,11 @@ public class UTConfigTweaks
         public boolean utDisableEnchantmentBookGlint = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Disable Hotbar Scroll Wrapping")
+        @Config.Comment("Disables using the scroll wheel to change hotbar slots wrapping")
+        public boolean utDisableHotbarScrollWrapping = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Prevent Keybinds from Overflowing Screen")
         @Config.Comment("Always indent keybind entries from the screen edge, preventing them from overflowing off the left side when particularly long keybind names are present")
         public boolean utPreventKeybindingEntryOverflow = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -192,6 +192,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.gui.potionduration.json", () -> UTConfigTweaks.MISC.utPotionDurationToggle);
             put("mixins.tweaks.misc.gui.selecteditemtooltip.json", () -> UTConfigTweaks.MISC.utSelectedItemTooltipHeight != 59);
             put("mixins.tweaks.misc.gui.textshadow.json", () -> UTConfigTweaks.MISC.utDisableTextShadow);
+            put("mixins.tweaks.misc.hotbarscroll.json", () -> UTConfigTweaks.MISC.utDisableHotbarScrollWrapping);
             put("mixins.tweaks.misc.lightning.flash.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFlashToggle);
             put("mixins.tweaks.misc.mainmenu.json", () -> UTConfigTweaks.MISC.utReturnToMainMenu);
             put("mixins.tweaks.misc.music.json", () -> UTConfigTweaks.MISC.utInfiniteMusicToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/hotbarscroll/mixin/UTInventoryPlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/hotbarscroll/mixin/UTInventoryPlayerMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.misc.hotbarscroll.mixin;
+
+import net.minecraft.entity.player.InventoryPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(InventoryPlayer.class)
+public abstract class UTInventoryPlayerMixin
+{
+    @Shadow
+    public int currentItem;
+
+    @Inject(method = "changeCurrentItem", at = @At("HEAD"), cancellable = true)
+    private void utDefaultDifficultyMP(int direction, CallbackInfo ci)
+    {
+        if (!UTConfigTweaks.MISC.utDisableHotbarScrollWrapping) return;
+        int target = currentItem - (int) Math.signum(direction);
+        if (target < 0 || target >= InventoryPlayer.getHotbarSize())
+        {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/hotbarscroll/mixin/UTInventoryPlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/hotbarscroll/mixin/UTInventoryPlayerMixin.java
@@ -18,7 +18,7 @@ public abstract class UTInventoryPlayerMixin
     public int currentItem;
 
     @Inject(method = "changeCurrentItem", at = @At("HEAD"), cancellable = true)
-    private void utDefaultDifficultyMP(int direction, CallbackInfo ci)
+    private void utCancelOnRollover(int direction, CallbackInfo ci)
     {
         if (!UTConfigTweaks.MISC.utDisableHotbarScrollWrapping) return;
         int target = currentItem - (int) Math.signum(direction);

--- a/src/main/resources/mixins.tweaks.misc.hotbarscroll.json
+++ b/src/main/resources/mixins.tweaks.misc.hotbarscroll.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.hotbarscroll.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTInventoryPlayerMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- allows disabling using the scroll wheel to change hotbar slots wrapping (default: `false`)
