### PR TITLE
Improve Server Connection Speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ All changes are toggleable via config files.
 * **Horizontal Collision Damage:** Applies horizontal collision damage to the player akin to elytra collision
 * **Husk & Stray Spawning:** Lets husks and strays spawn underground like regular zombies and skeletons
 * **Improve Language Switching Speed:** Improves the speed of switching languages in the Language GUI
+* **Improve Server Connection Speed:** Improves the speed of connecting to servers by setting the InetAddress host name to the IP in situations where it can be represented as the IP address, preventing getHostFromNameService from being to be run
 * **Improved Entity Tracker Warning:** Provides more information to addPacket removed entity warnings
 * **Incurable Potions:** Excludes potion effects from being curable with curative items like buckets of milk
 * **Infinite Music:** Lets background music play continuously without delays

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1979,6 +1979,15 @@ public class UTConfigTweaks
         public boolean utImproveLanguageSwitchingSpeed = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Improve Server Connection Speed")
+        @Config.Comment
+            ({
+                "Improves the speed of connecting to servers by setting the InetAddress host name to the IP in situations",
+                "where it can be represented as the IP address, preventing getHostFromNameService from being to be run"
+            })
+        public boolean utImproveServerConnectionSpeed = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Mute Advancement Errors")
         @Config.Comment("Silences advancement errors")
         public boolean utAdvancementCheckToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -203,6 +203,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.smoothscrolling.json", () -> UTConfigTweaks.MISC.SMOOTH_SCROLLING.utSmoothScrollingToggle);
             put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
             put("mixins.tweaks.performance.audioreload.json", () -> UTConfigTweaks.PERFORMANCE.utDisableAudioDebugToggle && !surgeLoaded);
+            put("mixins.tweaks.performance.connectionspeed.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);
             put("mixins.tweaks.performance.fps.json", () -> UTConfigTweaks.PERFORMANCE.utUncapFPSToggle);
             put("mixins.tweaks.performance.languageswitching.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);
             put("mixins.tweaks.performance.missingmodel.json", () -> UTConfigTweaks.PERFORMANCE.utDisableFancyMissingModelToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/UTConnectionPatch.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/UTConnectionPatch.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.tweaks.performance.connectionspeed;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import com.google.common.net.InetAddresses;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+
+public class UTConnectionPatch
+{
+    public static InetAddress patch(String hostName) throws UnknownHostException
+    {
+        return patch(InetAddress.getByName(hostName), hostName);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public static InetAddress patch(InetAddress original, String hostName) throws UnknownHostException
+    {
+        if (InetAddresses.isInetAddress(hostName))
+        {
+            InetAddress patched = InetAddress.getByAddress(original.getHostAddress(), original.getAddress());
+            UniversalTweaks.LOGGER.debug("Patching ip-only InetAddress from {} to {}", original, patched);
+            return patched;
+        }
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTGuiConnectingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTGuiConnectingMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.mixin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.UTConnectionPatch;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "net.minecraft.client.multiplayer.GuiConnecting$1")
+public class UTGuiConnectingMixin
+{
+    @WrapOperation(method = "run", at = @At(value = "INVOKE", target = "Ljava/net/InetAddress;getByName(Ljava/lang/String;)Ljava/net/InetAddress;"))
+    private InetAddress utPatchInetAddress(String ip, Operation<InetAddress> original) throws UnknownHostException
+    {
+        if (!UTConfigTweaks.PERFORMANCE.utImproveServerConnectionSpeed) return original.call(ip);
+        return UTConnectionPatch.patch(ip);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTRealmsConnectMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTRealmsConnectMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.mixin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.UTConnectionPatch;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "net.minecraft.realms.RealmsConnect$1")
+public class UTRealmsConnectMixin
+{
+    @WrapOperation(method = "run", at = @At(value = "INVOKE", target = "Ljava/net/InetAddress;getByName(Ljava/lang/String;)Ljava/net/InetAddress;"))
+    private InetAddress utPatchInetAddress(String ip, Operation<InetAddress> original) throws UnknownHostException
+    {
+        if (!UTConfigTweaks.PERFORMANCE.utImproveServerConnectionSpeed) return original.call(ip);
+        return UTConnectionPatch.patch(ip);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTServerPingerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/connectionspeed/mixin/UTServerPingerMixin.java
@@ -1,0 +1,26 @@
+package mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.mixin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import net.minecraft.client.network.ServerPinger;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.UTConnectionPatch;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ServerPinger.class)
+public class UTServerPingerMixin
+{
+    @WrapOperation(method = "ping", at = @At(value = "INVOKE", target = "Ljava/net/InetAddress;getByName(Ljava/lang/String;)Ljava/net/InetAddress;"))
+    private InetAddress utPatchInetAddress(String ip, Operation<InetAddress> original) throws UnknownHostException
+    {
+        if (!UTConfigTweaks.PERFORMANCE.utImproveServerConnectionSpeed) return original.call(ip);
+        return UTConnectionPatch.patch(ip);
+    }
+}

--- a/src/main/resources/mixins.tweaks.performance.connectionspeed.json
+++ b/src/main/resources/mixins.tweaks.performance.connectionspeed.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.performance.connectionspeed.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiConnectingMixin", "UTRealmsConnectMixin", "UTServerPingerMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- speeds up pinging servers without a hostname by a second or so (default: `true`)
- logic based on a mod for 1.14.4-1.20.* to 1.12.2.

backports code based on the logic introduced in `fast-ip-ping`, licensed LGPL v3.0:
https://github.com/Fallen-Breath/fast-ip-ping/tree/master