### PR TITLE
disable realms notification if the button is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ All changes are toggleable via config files.
 * **Rabbit Toast Spawning:** Configurable chance for rabbits to spawn as the Toast variant
 * **Rally Health:** Adds Bloodborne's Rally system to Minecraft, regain lost health when attacking back within the risk time
 * **Remove 3D Anaglyph Button:** Removes the 3D Anaglyph button from the video settings menu
-* **Remove Realms Button:** Removes the redundant Minecraft Realms button from the main menu
+* **Remove Realms Button:** Removes the redundant Minecraft Realms button from the main menu and silences notifications
 * **Remove Recipe Book:** Removes the recipe book button from GUIs
 * **Remove Snooper:** Forcefully turns off the snooper and hides the snooper settings button from the options menu
 * **Render End Portal Bottom:** Controls if the End Portal renders its texture on the bottom face

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1511,7 +1511,7 @@ public class UTConfigTweaks
         @Config.Name("Remove Realms Button")
         @Config.Comment
             ({
-                "Removes the redundant Minecraft Realms button from the main menu",
+                "Removes the redundant Minecraft Realms button from the main menu and silences notifications",
                 "Incompatible with RandomPatches"
             })
         public boolean utRealmsButtonToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/buttons/realms/mixin/UTRealmsButtonMainMenuMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/buttons/realms/mixin/UTRealmsButtonMainMenuMixin.java
@@ -5,16 +5,18 @@ import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 
-import mod.acgaming.universaltweaks.UniversalTweaks;
-import mod.acgaming.universaltweaks.config.UTConfigGeneral;
-import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-// Courtesy of Robitobi01
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of Robitobi01, WaitingIdly
 @Mixin(GuiMainMenu.class)
 public class UTRealmsButtonMainMenuMixin extends GuiScreen
 {
@@ -25,8 +27,18 @@ public class UTRealmsButtonMainMenuMixin extends GuiScreen
     public void utRemoveRealmsButtonMainMenu(int p_73969_1_, int p_73969_2_, CallbackInfo ci)
     {
         if (!UTConfigTweaks.MISC.utRealmsButtonToggle) return;
-        if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTRealmsButtonMainMenu ::: Initialize buttons");
+        if (UTConfigGeneral.DEBUG.utDebugToggle)
+        {
+            UniversalTweaks.LOGGER.debug("UTRealmsButtonMainMenu ::: Initialize buttons");
+        }
         buttonList.add(modButton = new GuiButton(6, this.width / 2 - 100, p_73969_1_ + p_73969_2_ * 2, I18n.format("fml.menu.mods")));
         ci.cancel();
+    }
+
+    @ModifyReturnValue(method = "areRealmsNotificationsEnabled", at = @At("RETURN"))
+    private boolean utDisableRealmNotification(boolean original)
+    {
+        if (!UTConfigTweaks.MISC.utRealmsButtonToggle) return original;
+        return false;
     }
 }


### PR DESCRIPTION
changes in this PR:
- made it so disabling the realms button also disables the notification. no new configs were introduced.