### PR TITLE
Advancement GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All changes are toggleable via config files.
     * Moves the page buttons to in-line with the rest of the GUI instead of hovering significantly
     * Hides page switching buttons when at the maximum/minimum page count
     * Disables the background fading when hovering over an advancement
+    * Adds Advancement Page Title text to the Advancement GUI header
 * **Adaptive XP Drops:** Scales dropped experience from entities based on their health
 * **AI Improvements:** Replaces/removes entity AI for improved server performance
 * **Always Eat:** Allows the consumption of food at any time, regardless of the hunger bar

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All changes are toggleable via config files.
 * **Advancement GUI**
     * Allows increasing the Advancement GUI to scale with the screen size
     * Moves the page buttons to in-line with the rest of the GUI instead of hovering significantly
+    * Hides page switching buttons when at the maximum/minimum page count
 * **Adaptive XP Drops:** Scales dropped experience from entities based on their health
 * **AI Improvements:** Replaces/removes entity AI for improved server performance
 * **Always Eat:** Allows the consumption of food at any time, regardless of the hunger bar

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ All changes are toggleable via config files.
 ### **🔧 TWEAKS**
 
 * **Accurate Potion Duration:** Always displays the actual potion duration instead of `**:**`
+* **Advancement GUI**
+    * Allows increasing the Advancement GUI to scale with the screen size
+    * Moves the page buttons to in-line with the rest of the GUI instead of hovering significantly
 * **Adaptive XP Drops:** Scales dropped experience from entities based on their health
 * **AI Improvements:** Replaces/removes entity AI for improved server performance
 * **Always Eat:** Allows the consumption of food at any time, regardless of the hunger bar

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ All changes are toggleable via config files.
     * Allows increasing the Advancement GUI to scale with the screen size
     * Moves the page buttons to in-line with the rest of the GUI instead of hovering significantly
     * Hides page switching buttons when at the maximum/minimum page count
+    * Disables the background fading when hovering over an advancement
 * **Adaptive XP Drops:** Scales dropped experience from entities based on their health
 * **AI Improvements:** Replaces/removes entity AI for improved server performance
 * **Always Eat:** Allows the consumption of food at any time, regardless of the hunger bar

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1616,12 +1616,12 @@ public class UTConfigTweaks
             @Config.RequiresMcRestart
             @Config.Name("[03] Vertical Margin")
             @Config.Comment("Sets the minimum Vertical Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
-            public int utVerticalMargin = 30;
+            public int utVerticalMargin = 50;
 
             @Config.RequiresMcRestart
             @Config.Name("[04] Horizontal Margin")
             @Config.Comment("Sets the minimum Horizontal Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
-            public int utHorizontalMargin = 30;
+            public int utHorizontalMargin = 50;
 
             @Config.RequiresMcRestart
             @Config.Name("[05] Move Arrow Buttons")
@@ -1631,7 +1631,7 @@ public class UTConfigTweaks
             @Config.RequiresMcRestart
             @Config.Name("[06] Hide Page Header")
             @Config.Comment("Hides the page number header, as it will go offscreen and be unusable on most vertical margin settings, and is rarely needed due to the increased page size")
-            public boolean utHidePageHeader = true;
+            public boolean utHidePageHeader = false;
 
             @Config.RequiresMcRestart
             @Config.Name("[07] Hide Invalid Arrow Buttons")

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1635,6 +1635,10 @@ public class UTConfigTweaks
             @Config.Name("[08] Disable Background Fade on Hover")
             @Config.Comment("Disables the background fading when hovering over an advancement")
             public boolean utDisableFadeOnHover = true;
+
+            @Config.Name("[09] Add Advancement Tab Title to Header")
+            @Config.Comment("Makes the focused Advancement Tab Title be added to the header, which otherwise is just 'Advancements' for every tab")
+            public boolean utAddFocusedTabTitleToHeader = true;
         }
 
         public static class ArmorCurveCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -3,14 +3,7 @@ package mod.acgaming.universaltweaks.config;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.minecraftforge.common.config.Config;
-import net.minecraftforge.common.config.ConfigManager;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-
 import com.cleanroommc.configanytime.ConfigAnytime;
-
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
 import mod.acgaming.universaltweaks.tweaks.blocks.breakablebedrock.UTBreakableBedrock;
@@ -23,6 +16,11 @@ import mod.acgaming.universaltweaks.tweaks.misc.loadsound.UTLoadSound;
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
 import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Config(modid = UniversalTweaks.MODID, name = UniversalTweaks.NAME + " - Tweaks")
 public class UTConfigTweaks

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1608,37 +1608,30 @@ public class UTConfigTweaks
             @Config.Comment("Enables Advancement GUI Tweaks")
             public boolean utAdvancementsToggle = false;
 
-            @Config.RequiresMcRestart
             @Config.Name("[02] Size Toggle")
             @Config.Comment("Enables the Vertical and Horizontal Margin settings")
             public boolean utSizeToggle = true;
 
-            @Config.RequiresMcRestart
             @Config.Name("[03] Vertical Margin")
             @Config.Comment("Sets the minimum Vertical Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
             public int utVerticalMargin = 50;
 
-            @Config.RequiresMcRestart
             @Config.Name("[04] Horizontal Margin")
             @Config.Comment("Sets the minimum Horizontal Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
             public int utHorizontalMargin = 50;
 
-            @Config.RequiresMcRestart
             @Config.Name("[05] Move Arrow Buttons")
             @Config.Comment("Move the Arrow Buttons visible to change focused advancement page from above the advancement box to in the empty top corners, preventing them from going offscreen and being unusable on most vertical margin settings")
             public boolean utMoveArrowButtons = true;
 
-            @Config.RequiresMcRestart
             @Config.Name("[06] Hide Page Header")
             @Config.Comment("Hides the page number header, as it will go offscreen and be unusable on most vertical margin settings, and is rarely needed due to the increased page size")
             public boolean utHidePageHeader = false;
 
-            @Config.RequiresMcRestart
             @Config.Name("[07] Hide Invalid Arrow Buttons")
             @Config.Comment("Hides page switching buttons when at the maximum/minimum page count")
             public boolean utHideInvalidArrowButtons = true;
 
-            @Config.RequiresMcRestart
             @Config.Name("[08] Disable Background Fade on Hover")
             @Config.Comment("Disables the background fading when hovering over an advancement")
             public boolean utDisableFadeOnHover = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1632,6 +1632,11 @@ public class UTConfigTweaks
             @Config.Name("[06] Hide Page Header")
             @Config.Comment("Hides the page number header, as it will go offscreen and be unusable on most vertical margin settings, and is rarely needed due to the increased page size")
             public boolean utHidePageHeader = true;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[07] Hide Invalid Arrow Buttons")
+            @Config.Comment("Hides page switching buttons when at the maximum/minimum page count")
+            public boolean utHideInvalidArrowButtons = true;
         }
 
         public static class ArmorCurveCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1637,6 +1637,11 @@ public class UTConfigTweaks
             @Config.Name("[07] Hide Invalid Arrow Buttons")
             @Config.Comment("Hides page switching buttons when at the maximum/minimum page count")
             public boolean utHideInvalidArrowButtons = true;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[08] Disable Background Fade on Hover")
+            @Config.Comment("Disables the background fading when hovering over an advancement")
+            public boolean utDisableFadeOnHover = true;
         }
 
         public static class ArmorCurveCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -2,7 +2,15 @@ package mod.acgaming.universaltweaks.config;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
 import com.cleanroommc.configanytime.ConfigAnytime;
+
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
 import mod.acgaming.universaltweaks.tweaks.blocks.breakablebedrock.UTBreakableBedrock;
@@ -15,11 +23,6 @@ import mod.acgaming.universaltweaks.tweaks.misc.loadsound.UTLoadSound;
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
 import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
-import net.minecraftforge.common.config.Config;
-import net.minecraftforge.common.config.ConfigManager;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Config(modid = UniversalTweaks.MODID, name = UniversalTweaks.NAME + " - Tweaks")
 public class UTConfigTweaks
@@ -1349,6 +1352,10 @@ public class UTConfigTweaks
 
     public static class MiscCategory
     {
+        @Config.LangKey("cfg.universaltweaks.tweaks.misc.advancements")
+        @Config.Name("Advancements")
+        public final AdvancementsCategory ADVANCEMENTS = new AdvancementsCategory();
+
         @Config.LangKey("cfg.universaltweaks.tweaks.misc.armorcurve")
         @Config.Name("Armor Curve")
         public final ArmorCurveCategory ARMOR_CURVE = new ArmorCurveCategory();
@@ -1592,6 +1599,40 @@ public class UTConfigTweaks
                 "-1 for vanilla default"
             })
         public int utXPLevelCap = -1;
+
+
+        public static class AdvancementsCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[01] Advancements Toggle")
+            @Config.Comment("Enables Advancement GUI Tweaks")
+            public boolean utAdvancementsToggle = false;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[02] Size Toggle")
+            @Config.Comment("Enables the Vertical and Horizontal Margin settings")
+            public boolean utSizeToggle = true;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[03] Vertical Margin")
+            @Config.Comment("Sets the minimum Vertical Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
+            public int utVerticalMargin = 30;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[04] Horizontal Margin")
+            @Config.Comment("Sets the minimum Horizontal Margin of the Advancement GUI. Too high a number may cause the advancement box to render incorrectly, depending on screen size and GUI scale")
+            public int utHorizontalMargin = 30;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[05] Move Arrow Buttons")
+            @Config.Comment("Move the Arrow Buttons visible to change focused advancement page from above the advancement box to in the empty top corners, preventing them from going offscreen and being unusable on most vertical margin settings")
+            public boolean utMoveArrowButtons = true;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[06] Hide Page Header")
+            @Config.Comment("Hides the page number header, as it will go offscreen and be unusable on most vertical margin settings, and is rarely needed due to the increased page size")
+            public boolean utHidePageHeader = true;
+        }
 
         public static class ArmorCurveCategory
         {

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -177,6 +177,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.entities.burning.player.json", () -> UTConfigTweaks.ENTITIES.utFirstPersonBurningOverlay != -0.3D);
             put("mixins.tweaks.items.attackcooldown.client.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
             put("mixins.tweaks.items.itementities.client.json", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
+            put("mixins.tweaks.misc.advancements.guisize.json", () -> UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle);
             put("mixins.tweaks.misc.buttons.anaglyph.json", () -> UTConfigTweaks.MISC.ut3DAnaglyphButtonToggle);
             put("mixins.tweaks.misc.buttons.realms.json", () -> UTConfigTweaks.MISC.utRealmsButtonToggle && !randomPatchesLoaded);
             put("mixins.tweaks.misc.buttons.snooper.client.json", () -> UTConfigTweaks.MISC.utSnooperToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
@@ -5,6 +5,8 @@ import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 // Courtesy of WaitingIdly
 public class UTAdvancementInfo
 {
+    public static final int DEFAULT_WIDTH = 252;
+    public static final int DEFAULT_HEIGHT = 140;
     private static final int PADDING = 9;
     private static final int HEIGHT_MULT = 28;
     private static final int WIDTH_MULT = 32;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
@@ -21,9 +21,19 @@ public class UTAdvancementInfo
         return height / HEIGHT_MULT * HEIGHT_MULT;
     }
 
+    private static int utClampWidth(int width)
+    {
+        return Math.max(width, DEFAULT_WIDTH);
+    }
+
+    private static int utClampHeight(int height)
+    {
+        return Math.max(height, DEFAULT_HEIGHT);
+    }
+
     public static int utPageWidth(int externalWidth)
     {
-        return utStepwiseWidth(externalWidth - UTConfigTweaks.MISC.ADVANCEMENTS.utHorizontalMargin * 2);
+        return utStepwiseWidth(utClampWidth(externalWidth - UTConfigTweaks.MISC.ADVANCEMENTS.utHorizontalMargin * 2));
     }
 
     public static int utPageWidth(int externalWidth, int padding)
@@ -33,7 +43,7 @@ public class UTAdvancementInfo
 
     public static int utPageHeight(int externalHeight)
     {
-        return utStepwiseHeight(externalHeight - UTConfigTweaks.MISC.ADVANCEMENTS.utVerticalMargin * 2);
+        return utStepwiseHeight(utClampHeight(externalHeight - UTConfigTweaks.MISC.ADVANCEMENTS.utVerticalMargin * 2));
     }
 
     public static int utPageHeight(int externalHeight, int padding)

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/UTAdvancementInfo.java
@@ -1,0 +1,61 @@
+package mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+public class UTAdvancementInfo
+{
+    private static final int PADDING = 9;
+    private static final int HEIGHT_MULT = 28;
+    private static final int WIDTH_MULT = 32;
+
+    private static int utStepwiseWidth(int width)
+    {
+        return width / WIDTH_MULT * WIDTH_MULT;
+    }
+
+    private static int utStepwiseHeight(int height)
+    {
+        return height / HEIGHT_MULT * HEIGHT_MULT;
+    }
+
+    public static int utPageWidth(int externalWidth)
+    {
+        return utStepwiseWidth(externalWidth - UTConfigTweaks.MISC.ADVANCEMENTS.utHorizontalMargin * 2);
+    }
+
+    public static int utPageWidth(int externalWidth, int padding)
+    {
+        return utPageWidth(externalWidth) - padding * PADDING;
+    }
+
+    public static int utPageHeight(int externalHeight)
+    {
+        return utStepwiseHeight(externalHeight - UTConfigTweaks.MISC.ADVANCEMENTS.utVerticalMargin * 2);
+    }
+
+    public static int utPageHeight(int externalHeight, int padding)
+    {
+        return utPageHeight(externalHeight) - padding * PADDING;
+    }
+
+    private static int utTabCountForWidth(int width)
+    {
+        return utPageWidth(width) / WIDTH_MULT;
+    }
+
+    private static int utTabCountForHeight(int height)
+    {
+        return utPageHeight(height) / HEIGHT_MULT;
+    }
+
+    public static int utTabCountForSide(int width, int height, boolean isVertical)
+    {
+        return isVertical ? utTabCountForHeight(height) : utTabCountForWidth(width);
+    }
+
+    public static int utMaximumTabCountPerPage(int width, int height)
+    {
+        return (utTabCountForWidth(width) + utTabCountForHeight(height)) * 2;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTAdvancementTabTypeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTAdvancementTabTypeMixin.java
@@ -1,0 +1,50 @@
+package mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.advancements.AdvancementTabType;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.UTAdvancementInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = AdvancementTabType.class)
+public abstract class UTAdvancementTabTypeMixin
+{
+    @WrapOperation(method = "draw", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;max:I"))
+    private int utIndex(AdvancementTabType instance, Operation<Integer> original, @Local(argsOnly = true, ordinal = 2) int index)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || Minecraft.getMinecraft().currentScreen == null)
+        {
+            return original.call(instance);
+        }
+        return UTAdvancementInfo.utTabCountForSide(Minecraft.getMinecraft().currentScreen.width, Minecraft.getMinecraft().currentScreen.height, instance == AdvancementTabType.LEFT || instance == AdvancementTabType.RIGHT);
+    }
+
+    @ModifyConstant(method = "getX", constant = @Constant(intValue = 248))
+    private int utOverrideX(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || Minecraft.getMinecraft().currentScreen == null)
+        {
+            return original;
+        }
+        return UTAdvancementInfo.utPageWidth(Minecraft.getMinecraft().currentScreen.width) - 8;
+    }
+
+    @ModifyConstant(method = "getY", constant = @Constant(intValue = 136))
+    private int utOverrideY(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || Minecraft.getMinecraft().currentScreen == null)
+        {
+            return original;
+        }
+        return UTAdvancementInfo.utPageHeight(Minecraft.getMinecraft().currentScreen.height) - 4;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTAdvancementTabTypeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTAdvancementTabTypeMixin.java
@@ -28,7 +28,7 @@ public abstract class UTAdvancementTabTypeMixin
         return UTAdvancementInfo.utTabCountForSide(Minecraft.getMinecraft().currentScreen.width, Minecraft.getMinecraft().currentScreen.height, instance == AdvancementTabType.LEFT || instance == AdvancementTabType.RIGHT);
     }
 
-    @ModifyConstant(method = "getX", constant = @Constant(intValue = 248))
+    @ModifyConstant(method = "getX", constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_WIDTH - 4))
     private int utOverrideX(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || Minecraft.getMinecraft().currentScreen == null)
@@ -38,7 +38,7 @@ public abstract class UTAdvancementTabTypeMixin
         return UTAdvancementInfo.utPageWidth(Minecraft.getMinecraft().currentScreen.width) - 8;
     }
 
-    @ModifyConstant(method = "getY", constant = @Constant(intValue = 136))
+    @ModifyConstant(method = "getY", constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_HEIGHT - 4))
     private int utOverrideY(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || Minecraft.getMinecraft().currentScreen == null)

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
@@ -4,6 +4,7 @@ import net.minecraft.client.gui.advancements.AdvancementTabType;
 import net.minecraft.client.gui.advancements.GuiAdvancementTab;
 import net.minecraft.client.gui.advancements.GuiScreenAdvancements;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -84,4 +85,11 @@ public abstract class UTGuiAdvancementTabMixin
         return UTAdvancementInfo.utPageHeight(screen.height) / 16 + 1;
     }
 
+    // prevents changing the fade value from 0
+    @ModifyExpressionValue(method = "drawToolTips", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(FFF)F"))
+    private float utRemoveFade(float original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utDisableFadeOnHover) return original;
+        return 0;
+    }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
@@ -41,14 +41,14 @@ public abstract class UTGuiAdvancementTabMixin
     }
 
     // update the size
-    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = 234))
+    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_WIDTH - 18))
     private int utDrawWidth(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
         return UTAdvancementInfo.utPageWidth(screen.width, 2) - 4;
     }
 
-    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = 113))
+    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_HEIGHT - 27))
     private int utDrawHeight(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
@@ -56,14 +56,14 @@ public abstract class UTGuiAdvancementTabMixin
     }
 
     // origin of the shown tree within the scrollable space
-    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 117))
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = (UTAdvancementInfo.DEFAULT_WIDTH - 18) / 2))
     private int utDrawContentsWidth(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
         return (UTAdvancementInfo.utPageWidth(screen.width, 2) - 4) / 2;
     }
 
-    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 56))
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = (UTAdvancementInfo.DEFAULT_HEIGHT - 27) / 2))
     private int utDrawContentsHeight(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiAdvancementTabMixin.java
@@ -1,0 +1,87 @@
+package mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.mixin;
+
+import net.minecraft.client.gui.advancements.AdvancementTabType;
+import net.minecraft.client.gui.advancements.GuiAdvancementTab;
+import net.minecraft.client.gui.advancements.GuiScreenAdvancements;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.UTAdvancementInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(GuiAdvancementTab.class)
+public abstract class UTGuiAdvancementTabMixin
+{
+    @Shadow
+    @Final
+    private GuiScreenAdvancements screen;
+
+    @WrapOperation(method = "create", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;MAX_TABS:I"))
+    private static int utAdjustMaxTabs(Operation<Integer> original, @Local(argsOnly = true) GuiScreenAdvancements screen)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original.call();
+        return UTAdvancementInfo.utMaximumTabCountPerPage(screen.width, screen.height);
+    }
+
+    @WrapOperation(method = "create", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;getMax()I"))
+    private static int utAdjustIndividualMaxTabs(AdvancementTabType instance, Operation<Integer> original, @Local(argsOnly = true) GuiScreenAdvancements screen)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original.call(instance);
+        return UTAdvancementInfo.utTabCountForSide(screen.width, screen.height, instance == AdvancementTabType.LEFT || instance == AdvancementTabType.RIGHT);
+    }
+
+    // update the size
+    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = 234))
+    private int utDrawWidth(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageWidth(screen.width, 2) - 4;
+    }
+
+    @ModifyConstant(method = {"drawContents", "scroll", "drawToolTips"}, constant = @Constant(intValue = 113))
+    private int utDrawHeight(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(screen.height, 3);
+    }
+
+    // origin of the shown tree within the scrollable space
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 117))
+    private int utDrawContentsWidth(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return (UTAdvancementInfo.utPageWidth(screen.width, 2) - 4) / 2;
+    }
+
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 56))
+    private int utDrawContentsHeight(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(screen.height, 3) / 2;
+    }
+
+    // repeat the texture to fill up the drawn space
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 15))
+    private int utRepeatingTextureWidth(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return (UTAdvancementInfo.utPageWidth(screen.width) - 4) / 16 + 1;
+    }
+
+    @ModifyConstant(method = "drawContents", constant = @Constant(intValue = 8))
+    private int utRepeatingTextureHeight(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(screen.height) / 16 + 1;
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -1,7 +1,9 @@
 package mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.mixin;
 
 import java.util.List;
+import java.util.Map;
 
+import net.minecraft.advancements.Advancement;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.advancements.GuiAdvancementTab;
@@ -10,6 +12,7 @@ import net.minecraft.client.gui.advancements.GuiScreenAdvancements;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -31,13 +34,17 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @Shadow(remap = false)
     private static int maxPages;
 
+    @Shadow
+    @Final
+    private Map<Advancement, GuiAdvancementTab> tabs;
+    @Shadow
+    private GuiAdvancementTab selectedTab;
+
     @Unique
     private GuiButton buttonLeft;
     @Unique
     private GuiButton buttonRight;
 
-    @Shadow
-    private GuiAdvancementTab selectedTab;
 
     /**
      * @reason ensure the maxPages field is set to 0 on gui size update, otherwise it is only updated if >0, meaning it will always linger at 1+
@@ -62,7 +69,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     }
 
     /**
-     * @reason puts the left arrow button to a variable to control visibility state in {@link #utHideInvalidButtons}
+     * @reason saves the left arrow button to a variable to control visibility state in {@link #utHideInvalidButtons}
      */
     @WrapOperation(method = "initGui", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0))
     private boolean utStoreLeftButton(List<GuiButton> list, Object button, Operation<Boolean> original)
@@ -70,12 +77,13 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
         if (UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle && UTConfigTweaks.MISC.ADVANCEMENTS.utHideInvalidArrowButtons)
         {
             buttonLeft = (GuiButton) button;
+            buttonLeft.visible = tabPage != 0;
         }
         return original.call(list, button);
     }
 
     /**
-     * @reason puts the right arrow button to a variable to control visibility state in {@link #utHideInvalidButtons}
+     * @reason saves the right arrow button to a variable to control visibility state in {@link #utHideInvalidButtons}
      */
     @WrapOperation(method = "initGui", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 1))
     private boolean utStoreRightButton(List<GuiButton> list, Object button, Operation<Boolean> original)
@@ -83,6 +91,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
         if (UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle && UTConfigTweaks.MISC.ADVANCEMENTS.utHideInvalidArrowButtons)
         {
             buttonRight = (GuiButton) button;
+            buttonRight.visible = tabPage != tabs.size() / UTAdvancementInfo.utMaximumTabCountPerPage(width, height);
         }
         return original.call(list, button);
     }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.advancements.GuiAdvancementTab;
 import net.minecraft.client.gui.advancements.GuiScreenAdvancements;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.Mixin;
@@ -163,6 +164,19 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
             return original;
         }
         return ARROW_ADJUSTMENT;
+    }
+
+    /**
+     * @reason replaces the header always being 'Advancements' to also include the title of the focused advancement tab
+     */
+    @ModifyExpressionValue(method = "renderWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/I18n;format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"))
+    private String utHeaderTitle(String original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utAddFocusedTabTitleToHeader)
+        {
+            return original;
+        }
+        return original + " - " + selectedTab.getTitle();
     }
 
     /**

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -110,6 +110,16 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     }
 
     /**
+     * @reason adjust the location used to indicate half the width for drawing the header text
+     */
+    @ModifyConstant(method = "drawScreen", constant = @Constant(intValue = 126))
+    private int utAdjustHalfWidthPosition(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return (UTAdvancementInfo.utPageWidth(width) - 4) / 2;
+    }
+
+    /**
      * @reason adjust the location used for the height
      */
     @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 140))

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -39,6 +39,15 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     private GuiAdvancementTab selectedTab;
 
     /**
+     * @reason ensure the maxPages field is set to 0 on gui size update, otherwise it is only updated if >0, meaning it will always linger at 1+
+     */
+    @Inject(method = "initGui", at = @At("HEAD"))
+    private void utAdjustMaxTabs(CallbackInfo ci)
+    {
+        maxPages = 0;
+    }
+
+    /**
      * @reason adjust the maximum number of tabs from a final static field to a number based on the height and width
      */
     @WrapOperation(method = "initGui", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;MAX_TABS:I"))

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -107,7 +107,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @Inject(method = "initGui", at = @At("TAIL"))
     private void utFocusActiveTab(CallbackInfo ci)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle || selectedTab == null)
         {
             return;
         }
@@ -172,7 +172,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyExpressionValue(method = "renderWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/I18n;format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"))
     private String utHeaderTitle(String original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utAddFocusedTabTitleToHeader)
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utAddFocusedTabTitleToHeader || selectedTab == null)
         {
             return original;
         }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -245,6 +245,26 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     }
 
     /**
+     * @reason adjust the horizontal location used for where the internal text is located
+     */
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 117))
+    private int utDrawContentsWidth(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return (UTAdvancementInfo.utPageWidth(width, 2) - 4) / 2;
+    }
+
+    /**
+     * @reason adjust the vertical location used for where the internal text is located
+     */
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 56))
+    private int utDrawContentsHeight(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(height, 3) / 2;
+    }
+
+    /**
      * @reason render the advancement display in an expandable way, cutting and repeatedly rendering some sections to
      * extend the size
      */

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -56,7 +56,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason prevent displaying the page number or total, as there is nowhere to put it and it goes offscreen
      */
-    @WrapOperation(method = "drawScreen", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/GuiScreenAdvancements;maxPages:I", remap = false))
+    @WrapOperation(method = "drawScreen", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/GuiScreenAdvancements;maxPages:I", remap = false, ordinal = 0))
     private int utDisableMaxPageText(Operation<Integer> original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utHidePageHeader)

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -33,7 +33,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @WrapOperation(method = "initGui", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;MAX_TABS:I"))
     private int utAdjustMaxTabs(Operation<Integer> original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original.call();
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original.call();
+        }
         return UTAdvancementInfo.utMaximumTabCountPerPage(width, height);
     }
 
@@ -43,7 +46,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @Inject(method = "initGui", at = @At("TAIL"))
     private void utFocusActiveTab(CallbackInfo ci)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return;
+        }
         tabPage = selectedTab.getPage();
     }
 
@@ -105,7 +111,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 252))
     private int utAdjustWidthPosition(int original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original;
+        }
         return UTAdvancementInfo.utPageWidth(width) - 4;
     }
 
@@ -115,7 +124,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyConstant(method = "drawScreen", constant = @Constant(intValue = 126))
     private int utAdjustHalfWidthPosition(int original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original;
+        }
         return (UTAdvancementInfo.utPageWidth(width) - 4) / 2;
     }
 
@@ -125,7 +137,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 140))
     private int utAdjustHeightPosition(int original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original;
+        }
         return UTAdvancementInfo.utPageHeight(height);
     }
 
@@ -135,7 +150,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 234))
     private int utRenderWidthPosition(int original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original;
+        }
         return UTAdvancementInfo.utPageWidth(width, 2) - 4;
     }
 
@@ -145,7 +163,10 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 113))
     private int utRenderHeightPosition(int original)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            return original;
+        }
         return UTAdvancementInfo.utPageHeight(height, 3);
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -191,7 +191,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the location used for the width
      */
-    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 252))
+    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_WIDTH))
     private int utAdjustWidthPosition(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
@@ -204,7 +204,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the location used to indicate half the width for drawing the header text
      */
-    @ModifyConstant(method = "drawScreen", constant = @Constant(intValue = 126))
+    @ModifyConstant(method = "drawScreen", constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_WIDTH / 2))
     private int utAdjustHalfWidthPosition(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
@@ -217,7 +217,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the location used for the height
      */
-    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 140))
+    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_HEIGHT))
     private int utAdjustHeightPosition(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
@@ -230,7 +230,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the location used for the width when padded
      */
-    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 234))
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_WIDTH - 18))
     private int utRenderWidthPosition(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
@@ -243,7 +243,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the location used for the height when padded
      */
-    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 113))
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = UTAdvancementInfo.DEFAULT_HEIGHT - 27))
     private int utRenderHeightPosition(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
@@ -256,7 +256,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the horizontal location used for where the internal text is located
      */
-    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 117))
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = (UTAdvancementInfo.DEFAULT_WIDTH - 18) / 2))
     private int utDrawContentsWidth(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
@@ -266,7 +266,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     /**
      * @reason adjust the vertical location used for where the internal text is located
      */
-    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 56))
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = (UTAdvancementInfo.DEFAULT_HEIGHT - 27) / 2))
     private int utDrawContentsHeight(int original)
     {
         if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
@@ -287,8 +287,8 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
         }
 
         // default texture location information
-        final int texture_width = 252;
-        final int texture_height = 140;
+        final int texture_width = UTAdvancementInfo.DEFAULT_WIDTH;
+        final int texture_height = UTAdvancementInfo.DEFAULT_HEIGHT;
         final int texture_corner = 30;
         // location to draw to
         final int width = UTAdvancementInfo.utPageWidth(this.width) - 4;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -83,7 +83,7 @@ public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
     @Inject(method = "drawScreen", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;FFI)I", shift = At.Shift.AFTER))
     private void utHideInvalidButtons(CallbackInfo ci)
     {
-        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utHideInvalidArrowButtons)
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utHideInvalidArrowButtons || buttonLeft == null || buttonRight == null)
         {
             return;
         }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/advancements/guisize/mixin/UTGuiScreenAdvancementsMixin.java
@@ -1,0 +1,201 @@
+package mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.mixin;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.advancements.GuiAdvancementTab;
+import net.minecraft.client.gui.advancements.GuiScreenAdvancements;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.UTAdvancementInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(GuiScreenAdvancements.class)
+public abstract class UTGuiScreenAdvancementsMixin extends GuiScreen
+{
+    @Unique
+    private static final int ARROW_ADJUSTMENT = 22;
+
+    @Shadow(remap = false)
+    private static int tabPage;
+    @Shadow
+    private GuiAdvancementTab selectedTab;
+
+    /**
+     * @reason adjust the maximum number of tabs from a final static field to a number based on the height and width
+     */
+    @WrapOperation(method = "initGui", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/AdvancementTabType;MAX_TABS:I"))
+    private int utAdjustMaxTabs(Operation<Integer> original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original.call();
+        return UTAdvancementInfo.utMaximumTabCountPerPage(width, height);
+    }
+
+    /**
+     * @reason set the current page to that of the focused tab
+     */
+    @Inject(method = "initGui", at = @At("TAIL"))
+    private void utFocusActiveTab(CallbackInfo ci)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return;
+        tabPage = selectedTab.getPage();
+    }
+
+    /**
+     * @reason prevent displaying the page number or total, as there is nowhere to put it and it goes offscreen
+     */
+    @WrapOperation(method = "drawScreen", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/advancements/GuiScreenAdvancements;maxPages:I", remap = false))
+    private int utDisableMaxPageText(Operation<Integer> original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utHidePageHeader)
+        {
+            return original.call();
+        }
+        return 0;
+    }
+
+    /**
+     * @reason move the left arrow from offscreen into the corner
+     */
+    @ModifyArg(method = "initGui", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiButton;<init>(IIIIILjava/lang/String;)V", ordinal = 0), index = 1)
+    private int utAdjustArrowLeft(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utMoveArrowButtons)
+        {
+            return original;
+        }
+        return original - ARROW_ADJUSTMENT;
+    }
+
+    /**
+     * @reason move the right arrow from offscreen into the corner
+     */
+    @ModifyArg(method = "initGui", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiButton;<init>(IIIIILjava/lang/String;)V", ordinal = 1), index = 1)
+    private int utAdjustArrowRight(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utMoveArrowButtons)
+        {
+            return original;
+        }
+        return original + ARROW_ADJUSTMENT;
+    }
+
+    /**
+     * @reason move both arrows from offscreen into the corner
+     */
+    @ModifyConstant(method = "initGui", constant = @Constant(intValue = 50))
+    private int utVerticalOffset(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utMoveArrowButtons)
+        {
+            return original;
+        }
+        return ARROW_ADJUSTMENT;
+    }
+
+    /**
+     * @reason adjust the location used for the width
+     */
+    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 252))
+    private int utAdjustWidthPosition(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageWidth(width) - 4;
+    }
+
+    /**
+     * @reason adjust the location used for the height
+     */
+    @ModifyConstant(method = {"initGui", "mouseClicked", "drawScreen"}, constant = @Constant(intValue = 140))
+    private int utAdjustHeightPosition(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(height);
+    }
+
+    /**
+     * @reason adjust the location used for the width when padded
+     */
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 234))
+    private int utRenderWidthPosition(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageWidth(width, 2) - 4;
+    }
+
+    /**
+     * @reason adjust the location used for the height when padded
+     */
+    @ModifyConstant(method = "renderInside", constant = @Constant(intValue = 113))
+    private int utRenderHeightPosition(int original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle) return original;
+        return UTAdvancementInfo.utPageHeight(height, 3);
+    }
+
+    /**
+     * @reason render the advancement display in an expandable way, cutting and repeatedly rendering some sections to
+     * extend the size
+     */
+    @WrapOperation(method = "renderWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/advancements/GuiScreenAdvancements;drawTexturedModalRect(IIIIII)V"))
+    private void utRenderLargerWindow(GuiScreenAdvancements instance, int left, int top, int textureX, int textureY, int w, int h, Operation<Void> original)
+    {
+        if (!UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle || !UTConfigTweaks.MISC.ADVANCEMENTS.utSizeToggle)
+        {
+            original.call(instance, left, top, textureX, textureY, w, h);
+            return;
+        }
+
+        // default texture location information
+        final int texture_width = 252;
+        final int texture_height = 140;
+        final int texture_corner = 30;
+        // location to draw to
+        final int width = UTAdvancementInfo.utPageWidth(this.width) - 4;
+        final int height = UTAdvancementInfo.utPageHeight(this.height);
+        final int right = width + (this.width - width) / 2;
+        final int bottom = height + (this.height - height) / 2;
+
+        // draw components clockwise, from top left:
+
+        // corner: top left
+        drawTexturedModalRect(left, top, 0, 0, texture_corner, texture_corner);
+        // side: top
+        utRenderTextureRepeating(left + texture_corner, top, width - texture_corner * 2, texture_corner, texture_corner, 0, texture_width - texture_corner * 2, texture_corner);
+        // corner: top right
+        drawTexturedModalRect(right - texture_corner, top, texture_width - texture_corner, 0, texture_corner, texture_corner);
+        // side: right
+        utRenderTextureRepeating(right - texture_corner, top + texture_corner, texture_corner, bottom - top - texture_corner * 2, texture_width - texture_corner, texture_corner, texture_corner, texture_height - texture_corner * 2);
+        // corner: bottom left
+        drawTexturedModalRect(left, bottom - texture_corner, 0, texture_height - texture_corner, texture_corner, texture_corner);
+        // side: bottom
+        utRenderTextureRepeating(left + texture_corner, bottom - texture_corner, width - texture_corner * 2, texture_corner, texture_corner, texture_height - texture_corner, texture_width - texture_corner * 2, texture_corner);
+        // corner: bottom right
+        drawTexturedModalRect(right - texture_corner, bottom - texture_corner, texture_width - texture_corner, texture_height - texture_corner, texture_corner, texture_corner);
+        // side: left
+        utRenderTextureRepeating(left, top + texture_corner, texture_corner, bottom - top - texture_corner * 2, 0, texture_corner, texture_corner, texture_height - texture_corner * 2);
+    }
+
+    @Unique
+    private void utRenderTextureRepeating(int x, int y, int width, int height, int textureX, int textureY, int textureWidth, int textureHeight)
+    {
+        for (int w = 0; w < width; w += textureWidth)
+        {
+            int drawX = x + w;
+            int drawWidth = Math.min(textureWidth, width - w);
+            for (int h = 0; h < height; h += textureHeight)
+            {
+                int drawY = y + h;
+                int drawHeight = Math.min(textureHeight, height - h);
+                this.drawTexturedModalRect(drawX, drawY, textureX, textureY, drawWidth, drawHeight);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -135,6 +135,7 @@ cfg.universaltweaks.tweaks.items.infinity=Infinity
 cfg.universaltweaks.tweaks.items.itementities=Item Entities
 cfg.universaltweaks.tweaks.items.mending=Mending
 cfg.universaltweaks.tweaks.items.parry=Shield Parry
+cfg.universaltweaks.tweaks.misc.advancements=Advancements
 cfg.universaltweaks.tweaks.misc.armorcurve=Armor Curve
 cfg.universaltweaks.tweaks.misc.chat=Chat
 cfg.universaltweaks.tweaks.misc.incurablepotions=Incurable Potions

--- a/src/main/resources/mixins.tweaks.misc.advancements.guisize.json
+++ b/src/main/resources/mixins.tweaks.misc.advancements.guisize.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.advancements.guisize.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTAdvancementTabTypeMixin", "UTGuiAdvancementTabMixin", "UTGuiScreenAdvancementsMixin"]
+}

--- a/src/main/resources/universaltweaks_at.cfg
+++ b/src/main/resources/universaltweaks_at.cfg
@@ -21,3 +21,11 @@ public net.minecraft.client.Minecraft field_71467_ac # rightClickDelayTimer
 
 # Double Consumption
 public net.minecraft.entity.EntityLivingBase field_184627_bm # activeItemStack
+
+# Advancement Tab Type Enum
+public net.minecraft.client.gui.advancements.AdvancementTabType
+public net.minecraft.client.gui.advancements.AdvancementTabType ABOVE # ABOVE
+public net.minecraft.client.gui.advancements.AdvancementTabType BELOW # BELOW
+public net.minecraft.client.gui.advancements.AdvancementTabType LEFT # LEFT
+public net.minecraft.client.gui.advancements.AdvancementTabType RIGHT # RIGHT
+


### PR DESCRIPTION
changes in this PR:
- adds the ability to adjust the Advancement GUI, which controls all lower options (default: `false`).
- adds the ability to adjust the size of the Advancement GUI (default: `true`).
  - control the vertical and horizontal margins independently (default: `50`, `50`).
  - the minimum height/width cannot go lower than the vanilla default.
- moves the arrow buttons from above the Advancement GUI to in line with the top advancement row (default: `true`).
- removes the screen header indicating what page number you are on out of the maximum (default: `false`). 
- removes arrow buttons that have no effect when clicked due to already being at the minimum/maximum page number (default: `true`).
- disables the background fade effect when hovering advancements (default: `true`).
- adds the focused tab to the header, which otherwise is only "Advancements" (default: `true`).
- use the access transformer to make the `AdvancementTabType` enum public (required to properly use some mixins on it).

