### PR TITLE
Improve confetti creepers tweak, fix some client-side things being loaded on server

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -147,7 +147,6 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.performance.pathfinding.json", () -> UTConfigTweaks.PERFORMANCE.utPathfindingChunkCacheFixToggle);
             put("mixins.tweaks.performance.prefixcheck.json", () -> UTConfigTweaks.PERFORMANCE.utPrefixCheckToggle);
             put("mixins.tweaks.performance.redstone.json", () -> UTConfigTweaks.PERFORMANCE.utRedstoneLightingToggle);
-            put("mixins.tweaks.performance.texturemapcheck.json", () -> UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle);
             put("mixins.tweaks.world.chunks.gen.json", () -> UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle);
             put("mixins.tweaks.world.loading.server.json", () -> UTConfigTweaks.PERFORMANCE.utWorldLoadingToggle);
             put("mixins.tweaks.world.sealevel.json", () -> UTConfigTweaks.WORLD.utSeaLevel != 63);
@@ -214,6 +213,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.performance.missingmodel.json", () -> UTConfigTweaks.PERFORMANCE.utDisableFancyMissingModelToggle);
             put("mixins.tweaks.performance.mobspawnerrender.json", () -> UTConfigTweaks.PERFORMANCE.utDisableMobSpawnerRendering);
             put("mixins.tweaks.performance.resourcemanager.json", () -> UTConfigTweaks.PERFORMANCE.utCheckAnimatedModelsToggle);
+            put("mixins.tweaks.performance.texturemapcheck.json", () -> UTConfigTweaks.PERFORMANCE.utTextureMapCheckToggle);
             put("mixins.tweaks.world.loading.client.json", () -> UTConfigTweaks.PERFORMANCE.utWorldLoadingToggle);
             put("mixins.tweaks.world.voidfog.json", () -> UTConfigTweaks.WORLD.VOID_FOG.utVoidFogToggle);
         }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/creeper/confetti/mixin/UTCreeperConfettiMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/creeper/confetti/mixin/UTCreeperConfettiMixin.java
@@ -47,7 +47,12 @@ public abstract class UTCreeperConfettiMixin extends EntityMob
         double chargedChance = UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiChance;
         if (chargedChance <= 0.0D || !UTRandomUtil.chance(chargedChance, new Random(this.getUniqueID().getMostSignificantBits() & Long.MAX_VALUE))) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTCreeperConfetti ::: Explode");
-        if (this.world.isRemote) spawnParticles(this.getEntityWorld(), this.getPosition(), this.getPowered());
+        if (this.world.isRemote)
+        {
+            BlockPos pos = this.getPosition();
+            boolean powered = this.getPowered();
+            this.world.makeFireworks(pos.getX(), pos.getY() + (powered ? 2.5F : 0.5F), pos.getZ(), 0, 0, 0, generateTag(powered));
+        }
         else
         {
             this.dead = true;
@@ -56,14 +61,6 @@ public abstract class UTCreeperConfettiMixin extends EntityMob
             this.damagePlayers(((EntityCreeper) (Object) this));
         }
         ci.cancel();
-    }
-
-    @Unique
-    @SideOnly(Side.CLIENT)
-    public void spawnParticles(World world, BlockPos pos, boolean powered)
-    {
-        ParticleManager particleManager = Minecraft.getMinecraft().effectRenderer;
-        particleManager.addEffect(new ParticleFirework.Starter(world, pos.getX(), pos.getY() + (powered ? 2.5F : 0.5F), pos.getZ(), 0, 0, 0, particleManager, generateTag(powered)));
     }
 
     @Unique

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/creeper/confetti/mixin/UTCreeperConfettiMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/spawning/creeper/confetti/mixin/UTCreeperConfettiMixin.java
@@ -1,27 +1,22 @@
 package mod.acgaming.universaltweaks.tweaks.entities.spawning.creeper.confetti.mixin;
 
 import java.util.List;
-import java.util.Random;
-
 import com.google.common.collect.Lists;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.particle.ParticleFirework;
-import net.minecraft.client.particle.ParticleManager;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.util.UTRandomUtil;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.item.ItemDye;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.DataSerializers;
+import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import mod.acgaming.universaltweaks.UniversalTweaks;
-import mod.acgaming.universaltweaks.config.UTConfigGeneral;
-import mod.acgaming.universaltweaks.config.UTConfigTweaks;
-import mod.acgaming.universaltweaks.util.UTRandomUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -29,10 +24,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-// Courtesy of SR2610
+// Courtesy of SR2610, jchung01
 @Mixin(EntityCreeper.class)
 public abstract class UTCreeperConfettiMixin extends EntityMob
 {
+    @SuppressWarnings("WrongEntityDataParameterClass")
+    @Unique
+    private static final DataParameter<Boolean> ut$CONFETTI = EntityDataManager.createKey(EntityCreeper.class, DataSerializers.BOOLEAN);
+
     protected UTCreeperConfettiMixin(World worldIn)
     {
         super(worldIn);
@@ -41,30 +40,57 @@ public abstract class UTCreeperConfettiMixin extends EntityMob
     @Shadow
     public abstract boolean getPowered();
 
-    @Inject(method = "explode", at = @At("HEAD"), cancellable = true)
-    public void utCreeperConfetti(CallbackInfo ci)
+    @Shadow
+    protected abstract void spawnLingeringCloud();
+
+    /**
+     * Register confetti DataParameter.
+     * @author jchung01
+     */
+    @Inject(method = "entityInit", at = @At(value = "TAIL"))
+    private void utRegisterConfetti(CallbackInfo ci)
     {
+        this.dataManager.register(ut$CONFETTI, Boolean.FALSE);
+    }
+
+    /**
+     * Determine on spawn if this creeper should explode into confetti.
+     * @author jchung01
+     */
+    @Inject(method = "<init>", at = @At(value = "TAIL"))
+    private void utInitConfetti(World worldIn, CallbackInfo ci)
+    {
+        if (this.world.isRemote) return;
         double chargedChance = UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiChance;
-        if (chargedChance <= 0.0D || !UTRandomUtil.chance(chargedChance, new Random(this.getUniqueID().getMostSignificantBits() & Long.MAX_VALUE))) return;
+        if (chargedChance > 0.0D && UTRandomUtil.chance(chargedChance, this.rand))
+        {
+            this.dataManager.set(ut$CONFETTI, Boolean.TRUE);
+        }
+    }
+
+    @Inject(method = "explode", at = @At("HEAD"), cancellable = true)
+    private void utDoConfetti(CallbackInfo ci)
+    {
+        if (!this.dataManager.get(ut$CONFETTI)) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTCreeperConfetti ::: Explode");
         if (this.world.isRemote)
         {
             BlockPos pos = this.getPosition();
             boolean powered = this.getPowered();
-            this.world.makeFireworks(pos.getX(), pos.getY() + (powered ? 2.5F : 0.5F), pos.getZ(), 0, 0, 0, generateTag(powered));
+            this.world.makeFireworks(pos.getX(), pos.getY() + (powered ? 2.5F : 0.5F), pos.getZ(), 0, 0, 0, ut$generateTag(powered));
         }
         else
         {
             this.dead = true;
             this.setDead();
             this.spawnLingeringCloud();
-            this.damagePlayers(((EntityCreeper) (Object) this));
+            this.ut$damagePlayers(((EntityCreeper) (Object) this));
         }
         ci.cancel();
     }
 
     @Unique
-    public NBTTagCompound generateTag(boolean powered)
+    private NBTTagCompound ut$generateTag(boolean powered)
     {
         NBTTagCompound fireworkTag = new NBTTagCompound();
         NBTTagCompound fireworkItemTag = new NBTTagCompound();
@@ -85,13 +111,10 @@ public abstract class UTCreeperConfettiMixin extends EntityMob
     }
 
     @Unique
-    public void damagePlayers(EntityCreeper creeper)
+    private void ut$damagePlayers(EntityCreeper creeper)
     {
         float explosionStrength = (float) (creeper.getPowered() ? UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiDamage * 2 : UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiDamage);
         Explosion explosion = new Explosion(creeper.getEntityWorld(), creeper, creeper.posX, creeper.posY, creeper.posZ, 3.0F * explosionStrength, false, false);
         explosion.doExplosionA();
     }
-
-    @Shadow
-    protected abstract void spawnLingeringCloud();
 }

--- a/src/main/resources/mixins.tweaks.performance.texturemapcheck.json
+++ b/src/main/resources/mixins.tweaks.performance.texturemapcheck.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTTextureMapCheckMixin"]
+  "client": ["UTTextureMapCheckMixin"]
 }


### PR DESCRIPTION
A couple client-side tweaks were trying to be loaded on the physical server, which errored in logs. 
Namely, (1) moved TextureMapCheck tweak to client, and (2) adjusted Confetti Creeper tweak to use the built-in client-side `World#makeFireworks`.

While I was at it, I noticed confetti creeper tweak was using independent chances on server vs client. Changed it to check the chance on server-side creeper spawn, so it should be synced better now. This means the chance depends on the server's config only now.