### PR TITLE
Prevent Mob Eggs from Changing Spawners

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ All changes are toggleable via config files.
 * **Particle Limit:** Limits particles to a set amount. Should not be set too low, as it will cause particles to appear for a single tick before vanishing
 * **Pickup Notification:** Displays highly configurable notifications when the player obtains or loses items
 * **Player Speed:** Enables the modification of base and maximum player speeds along with fixing 'Player moved too quickly' messages
+* **Prevent Mob Eggs from Changing Spawners:** Prevents using Mob Spawner Eggs to change what a Spawner is spawning
 * **Prevent Observer Activating on Placement:** Controls if the observer activates itself on the first tick when it is placed
 * **Prevent Placing Buckets in Portals:** Prevents placing of liquid source blocks overriding portal blocks
 * **Pumpkin Placing:** Allows placing Pumpkins and Jack'O'Lanterns without a supporting block

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1134,6 +1134,11 @@ public class UTConfigTweaks
             })
         public int utXPBottleAmount = -1;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Prevent Mob Eggs from Changing Spawners")
+        @Config.Comment("Prevents using Mob Spawner Eggs to change what a Spawner is spawning")
+        public boolean utPreventMobEggsFromChangingSpawner = false;
+
         public static class AttackCooldownCategory
         {
             @Config.RequiresMcRestart

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -123,6 +123,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.items.infinityallarrows.json", () -> UTConfigTweaks.ITEMS.INFINITY.utAllArrowsAreInfinite);
             put("mixins.tweaks.items.infinitymending.json", () -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
             put("mixins.tweaks.items.itementities.server.json", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
+            put("mixins.tweaks.items.mobegg.json", () -> UTConfigTweaks.ITEMS.utPreventMobEggsFromChangingSpawner);
             put("mixins.tweaks.items.repairing.json", () -> UTConfigTweaks.ITEMS.utCraftingRepairToggle);
             put("mixins.tweaks.items.xpbottle.json", () -> UTConfigTweaks.ITEMS.utXPBottleAmount != -1);
             put("mixins.tweaks.misc.advancements.json", () -> UTConfigTweaks.MISC.utDisableAdvancementsToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/mobegg/mixin/UTItemMonsterPlacerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/mobegg/mixin/UTItemMonsterPlacerMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.items.mobegg.mixin;
+
+import net.minecraft.item.ItemMonsterPlacer;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(ItemMonsterPlacer.class)
+public abstract class UTItemMonsterPlacerMixin
+{
+//    @Inject(method = "onPlaceItemIntoWorld", target = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;onItemUse(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/EnumHand;Lnet/minecraft/util/EnumFacing;FFF)Lnet/minecraft/util/EnumActionResult;"))
+//    private boolean utPreventReplacingMobSpawnerEntity(Object instance, Operation<Boolean> original)
+//    {
+//        if (!UTConfigTweaks.ITEMS.utPreventMobEggsFromChangingSpawner) return original.call(instance);
+//        return false;
+//    }
+    @WrapOperation(method = "onItemUse", constant = @Constant(classValue = TileEntityMobSpawner.class, ordinal = 0))
+    private boolean utPreventReplacingMobSpawnerEntity(Object instance, Operation<Boolean> original)
+    {
+        if (!UTConfigTweaks.ITEMS.utPreventMobEggsFromChangingSpawner) return original.call(instance);
+        return false;
+    }
+}

--- a/src/main/resources/mixins.tweaks.items.mobegg.json
+++ b/src/main/resources/mixins.tweaks.items.mobegg.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.mobegg.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemMonsterPlacerMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- prevents using a monster item placer (mob egg) to change what mob a mob spawner will spawn (default: `false`).