### PR TITLE
Glass Bottle Consumes Water Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ All changes are toggleable via config files.
 * **Fence/Wall Jump:** Allows the player to jump over fences and walls
 * **Finite Water:** Prevents creation of infinite water sources outside of ocean and river biomes
 * **First Person Burning Overlay:** Sets the offset for the fire overlay in first person when the player is burning
+* **Glass Bottle Consumes Water Source:** Causes Glass Bottles to consume the source block of water
 * **Growth Size:** Configurable growth height/length for sugar cane, cacti and vines
 * **Hardcore Buckets:** Prevents placing of liquid source blocks in the world
 * **Hide Personal Effect Particles:** Disables potion effect particles emitting from yourself

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1063,6 +1063,11 @@ public class UTConfigTweaks
         @Config.Comment("Disables dragon's breath from being a container item and leaving off empty bottles when a stack is brewed with")
         public boolean utLeftoverBreathBottleToggle = true;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Glass Bottle Consumes Water Source")
+        @Config.Comment("Causes Glass Bottles to consume the source block of water")
+        public boolean utGlassBottlesConsumeWaterSource = false;
+
         @Config.Name("Custom Rarity")
         @Config.Comment
             ({

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -117,6 +117,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.entities.trading.json", () -> UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle);
             put("mixins.tweaks.entities.voidteleport.json", () -> UTConfigTweaks.ENTITIES.VOID_TELEPORT.utVoidTeleportToggle);
             put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
+            put("mixins.tweaks.items.bottle.json", () -> UTConfigTweaks.ITEMS.utGlassBottlesConsumeWaterSource);
             put("mixins.tweaks.items.bucket.json", () -> UTConfigTweaks.ITEMS.utPreventBucketPlacingInPortal);
             put("mixins.tweaks.items.eating.json", () -> UTConfigTweaks.ITEMS.utAlwaysEatToggle);
             put("mixins.tweaks.items.hardcorebuckets.json", () -> UTConfigTweaks.ITEMS.utHardcoreBucketsToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bottle/mixin/UTItemGlassBottleMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/bottle/mixin/UTItemGlassBottleMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.tweaks.items.bottle.mixin;
+
+import net.minecraft.item.ItemGlassBottle;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(ItemGlassBottle.class)
+public abstract class UTItemGlassBottleMixin
+{
+    @Inject(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;playSound(Lnet/minecraft/entity/player/EntityPlayer;DDDLnet/minecraft/util/SoundEvent;Lnet/minecraft/util/SoundCategory;FF)V", ordinal = 1, shift = At.Shift.AFTER))
+    private void utConsumeWaterSourceBlock(CallbackInfoReturnable<ActionResult<ItemStack>> cir, @Local(argsOnly = true) World world, @Local BlockPos blockpos)
+    {
+        if (!UTConfigTweaks.ITEMS.utGlassBottlesConsumeWaterSource) return;
+        world.setBlockToAir(blockpos);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -36,6 +36,7 @@ public class UTObsoleteModsHandler
             put("blockdispenser", () -> UTConfigTweaks.BLOCKS.BLOCK_DISPENSER.utBlockDispenserToggle);
             put("blockfire", () -> UTConfigBugfixes.ENTITIES.utBlockFireToggle);
             put("blockoverlayfix", () -> UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle);
+            put("bottlefix", () -> UTConfigTweaks.ITEMS.utGlassBottlesConsumeWaterSource);
             put("bottomsugarcanharvest", () -> UTConfigTweaks.BLOCKS.utSugarCaneSize != 3);
             put("bowinfinityfix", () -> UTConfigTweaks.ITEMS.INFINITY.utBowInfinityToggle);
             put("breedablekillerrabbit", () -> UTConfigTweaks.ENTITIES.utRabbitKillerChance > 0.0D);
@@ -117,12 +118,14 @@ public class UTObsoleteModsHandler
             put("savemystronghold", () -> UTConfigTweaks.WORLD.utStrongholdToggle);
             put("sleepsooner", () -> UTConfigTweaks.ENTITIES.SLEEPING.utSleepingTime != -1);
             put("smooth-scrolling-everywhere", () -> UTConfigTweaks.MISC.SMOOTH_SCROLLING.utSmoothScrollingToggle);
+            put("sourcebottles", () -> UTConfigTweaks.ITEMS.utGlassBottlesConsumeWaterSource);
             put("steamworldpatcher", () -> UTConfigMods.STEAMWORLD.utSkyOfOldFixToggle);
             put("stepupfix", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
             put("stg", () -> UTConfigTweaks.MISC.SWING_THROUGH_GRASS.utSwingThroughGrassToggle);
             put("superhot", () -> UTConfigTweaks.ITEMS.utSuperHotTorchToggle);
             put("surge", () -> true);
             put("tconfixes", () -> true);
+            put("thirstybottles", () -> UTConfigTweaks.ITEMS.utGlassBottlesConsumeWaterSource);
             put("tidychunk", () -> UTConfigTweaks.WORLD.utTidyChunkToggle);
             put("tinkersoredictcache", () -> UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle);
             put("toastcontrol", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);

--- a/src/main/resources/mixins.tweaks.items.bottle.json
+++ b/src/main/resources/mixins.tweaks.items.bottle.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.bottle.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemGlassBottleMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- when converting empty glass bottles into water bottles, replace the water block with an air block (default: `false`).
- mark three mods as obsolete if enabled.

theres also this mod which is also obsolete and does the same thing - but its modid is `examplemod`. whoops.
https://www.curseforge.com/minecraft/mc-mods/pwiat-pour-water-into-a-bottle