### PR TITLE
Third Person Ignores Non-solid Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ All changes are toggleable via config files.
 * **Super Hot Torch:** Enables one-time ignition of entities by hitting them with a torch
 * **Stronghold Enforcement:** Enforces stronghold generation to generate all blocks, regardless of air
 * **Swing Through Grass:** Allows hitting entities through grass instead of breaking it
+* **Third Person Ignores Non-solid Blocks:** When viewing in third person, don't stop the camera on non-solid blocks
 * **Tidy Chunk:** Tidies newly generated chunks by removing scattered item entities
 * **Toast Control:** Enables the control of toasts (pop-up text boxes)
 * **Toggle Cheats Button:** Adds a button to the pause menu to toggle cheats

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -529,6 +529,11 @@ public class UTConfigTweaks
         public double utFirstPersonBurningOverlay = -0.3D;
 
         @Config.RequiresMcRestart
+        @Config.Name("Third Person Ignores Non-solid Blocks")
+        @Config.Comment("When viewing in third person, don't stop the camera on non-solid blocks")
+        public boolean utThirdPersonIgnoresNonSolidBlocks = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Husk & Stray Spawning")
         @Config.Comment("Lets husks and strays spawn underground like regular zombies and skeletons")
         public boolean utHuskStraySpawningToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -176,6 +176,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.blocks.betterplacement.json", () -> UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementToggle);
             put("mixins.tweaks.entities.autojump.json", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
             put("mixins.tweaks.entities.burning.player.json", () -> UTConfigTweaks.ENTITIES.utFirstPersonBurningOverlay != -0.3D);
+            put("mixins.tweaks.entities.playerf5.json", () -> UTConfigTweaks.ENTITIES.utThirdPersonIgnoresNonSolidBlocks);
             put("mixins.tweaks.items.attackcooldown.client.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
             put("mixins.tweaks.items.itementities.client.json", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
             put("mixins.tweaks.misc.advancements.guisize.json", () -> UTConfigTweaks.MISC.ADVANCEMENTS.utAdvancementsToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerf5/mixin/UTEntityRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/playerf5/mixin/UTEntityRendererMixin.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.tweaks.entities.playerf5.mixin;
+
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+// Courtesy of WaitingIdly
+@Mixin(EntityRenderer.class)
+public abstract class UTEntityRendererMixin
+{
+    @WrapOperation(method = "orientCamera", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/WorldClient;rayTraceBlocks(Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/RayTraceResult;"))
+    private RayTraceResult utCamaraBypassesNonSolidBlocks(WorldClient instance, Vec3d start, Vec3d end, Operation<RayTraceResult> original)
+    {
+        if (!UTConfigTweaks.ENTITIES.utThirdPersonIgnoresNonSolidBlocks) return original.call(instance, start, end);
+        return instance.rayTraceBlocks(start, end, false, true, true);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -63,6 +63,7 @@ public class UTObsoleteModsHandler
             put("erebusfix", () -> UTConfigMods.EREBUS.utEBPreservedBlocksToggle);
             put("experiencebugfix", () -> UTConfigBugfixes.ENTITIES.utDimensionChangeToggle);
             put("eyltrafix", () -> UTConfigBugfixes.ENTITIES.utElytraDeploymentLandingToggle);
+            put("f5fix", () -> UTConfigTweaks.ENTITIES.utThirdPersonIgnoresNonSolidBlocks);
             put("fastbench", () -> UTConfigTweaks.PERFORMANCE.utCraftingCacheToggle);
             put("fastleafdecay", () -> UTConfigTweaks.BLOCKS.utLeafDecayToggle);
             put("fencejumper", () -> UTConfigTweaks.BLOCKS.utFenceWallJumpToggle);

--- a/src/main/resources/mixins.tweaks.entities.playerf5.json
+++ b/src/main/resources/mixins.tweaks.entities.playerf5.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.playerf5.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTEntityRendererMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- makes the third person camera ignore non-solid blocks, such as grass (default: `false`).
- marks the mod `f5fix` as obsolete.