### PR TITLE
Add modelManager to AT

### DIFF
--- a/src/main/resources/universaltweaks_at.cfg
+++ b/src/main/resources/universaltweaks_at.cfg
@@ -29,3 +29,6 @@ public net.minecraft.client.gui.advancements.AdvancementTabType BELOW # BELOW
 public net.minecraft.client.gui.advancements.AdvancementTabType LEFT # LEFT
 public net.minecraft.client.gui.advancements.AdvancementTabType RIGHT # RIGHT
 
+# Particle Util
+public net.minecraft.client.Minecraft field_175617_aL # modelManager
+


### PR DESCRIPTION
Thaumcraft's AT also upgrades the visibility, so you couldn't tell in dev it was private in vanilla. Fixes #511.