### PR TITLE
Add memory leak fix for Collective + minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ All changes are toggleable via config files.
 * **Blood Magic**
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Optimized Hellfire Forge:** Optimizes the Hellfire/Soul Forge to reduce tick time
-    * **World Unload Memory Leak Fix:** Fixes memory leak when unloading worlds/switching dimensions
+    * **Memory Leak Fix:** Fixes memory leak when unloading worlds/switching dimensions
 * **Botania**
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Fancy Skybox:** Enables the Botania Garden of Glass skybox for custom dimensions
@@ -308,6 +308,8 @@ All changes are toggleable via config files.
     * **Packet Leak Fix:** Fixes network ByteBuf leaks from PacketCustom
 * **CoFH Core**
     * **Vorpal Enchantment Damage:** Sets the damage multiplier of the Vorpal enchantment
+* **Collective**
+    * **Memory Leak Fix:** Fixes memory leak when unloading worlds/switching dimensions
 * **Compact Machines**
     * **Invisible Wall Render Fix:** Fixes some compact machine walls being invisible if [Nothirium](https://www.curseforge.com/minecraft/mc-mods/nothirium) 0.2.x (and up) or [Vintagium](https://github.com/Asek3/sodium-1.12) is installed
 * **Effortless Building**
@@ -371,6 +373,8 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Railcraft**
   * **No Beta Warning:** Disables the beta message warning on world join
+* **Requious Frakto**
+  * **Particle Fixes:** Fixes server world being leaked to various particles
 * **RFTools Dimension**
     * **Properly Unregister Dimensions:** Fixes a bug where joining a world or server with any RFTools Dimension registered would disallow entering another world without that dimension until restarting.
 * **Roost**
@@ -402,7 +406,6 @@ All changes are toggleable via config files.
     * **Wisp Particles:** Increases particle size of wisps similar to legacy versions
 * **Thaumic Wonders**
     * **Duplication Fixes:** Fixes various duplication exploits
-    * **Memory Leak Fix:** Fixes a client-side memory leak when wearing Void Fortress armor
 * **The Erebus**
     * **Fix Cabbage Drop:** Fixes Cabbage not dropping the correct items in some situations
     * **Preserved Blocks Fix:** Prevents HWYLA/TOP crashes with preserved blocks
@@ -419,6 +422,7 @@ All changes are toggleable via config files.
     * **Material Blacklist:** Hides tool/bow materials in the 'Materials and You' book
     * **Offhand Shuriken:** Suppresses special abilities of long swords and rapiers when shurikens are wielded in the offhand
     * **Ore Dictionary Cache:** Caches all ore dictionary smelting recipes to speed up game loading
+    * **Particle Fixes:** Fixes server world being leaked to various particles
     * **Projectile Despawning:** Despawns unbreakable projectiles faster to improve framerates
     * **Tool Customization:** Sets the attack damage cutoff at which diminishing returns start for any Tinkers' tool and sets the rate at which a tool's attack damage incrementally decays depending on its damage cutoff
 * **Tiny Progressions**

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,8 @@ additionalJavaArguments =
 # Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
 # Using this requires that you use a Java 17 JDK for development.
-enableModernJavaSyntax = true
+# For some reason if this is enabled, it breaks IntelliJ's auto-complete for Forge annotations.
+enableModernJavaSyntax = false
 
 # Enables runClient/runServer tasks for Java 17 and Java 21 using LWJGL3ify.
 # This is primarily used to test if your mod is compatible with platforms running

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -14,6 +14,7 @@ import mod.acgaming.universaltweaks.mods.arcanearchives.UTArcaneArchivesEvents;
 import mod.acgaming.universaltweaks.mods.astralsorcery.UTClearOnChange;
 import mod.acgaming.universaltweaks.mods.bloodmagic.UTBloodMagicEvents;
 import mod.acgaming.universaltweaks.mods.botania.UTBotaniaFancySkybox;
+import mod.acgaming.universaltweaks.mods.collective.UTCollectiveEvents;
 import mod.acgaming.universaltweaks.mods.cqrepoured.UTGoldenFeatherEvent;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Burning;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Sprinting;
@@ -155,6 +156,8 @@ public class UniversalTweaks
         if (Loader.isModLoaded("abyssalcraft") && UTConfigMods.ABYSSALCRAFT.utOptimizedItemTransferToggle) MinecraftForge.EVENT_BUS.register(new UTAbyssalCraftEvents());
         if (Loader.isModLoaded("arcanearchives") && UTConfigMods.ARCANE_ARCHIVES.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTArcaneArchivesEvents());
         if (Loader.isModLoaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTBloodMagicEvents());
+        // TODO: Add config
+        if (Loader.isModLoaded("collective")) MinecraftForge.EVENT_BUS.register(new UTCollectiveEvents());
         if (Loader.isModLoaded("cqrepoured") && UTConfigMods.CHOCOLATE_QUEST.utCQRGoldenFeatherToggle) MinecraftForge.EVENT_BUS.register(new UTGoldenFeatherEvent());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2ExtinguishingDodgeChance > 0) MinecraftForge.EVENT_BUS.register(new UTED2Burning());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -156,8 +156,7 @@ public class UniversalTweaks
         if (Loader.isModLoaded("abyssalcraft") && UTConfigMods.ABYSSALCRAFT.utOptimizedItemTransferToggle) MinecraftForge.EVENT_BUS.register(new UTAbyssalCraftEvents());
         if (Loader.isModLoaded("arcanearchives") && UTConfigMods.ARCANE_ARCHIVES.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTArcaneArchivesEvents());
         if (Loader.isModLoaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTBloodMagicEvents());
-        // TODO: Add config
-        if (Loader.isModLoaded("collective")) MinecraftForge.EVENT_BUS.register(new UTCollectiveEvents());
+        if (Loader.isModLoaded("collective") && UTConfigMods.COLLECTIVE.utMemoryLeakFixToggle) MinecraftForge.EVENT_BUS.register(new UTCollectiveEvents());
         if (Loader.isModLoaded("cqrepoured") && UTConfigMods.CHOCOLATE_QUEST.utCQRGoldenFeatherToggle) MinecraftForge.EVENT_BUS.register(new UTGoldenFeatherEvent());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2ExtinguishingDodgeChance > 0) MinecraftForge.EVENT_BUS.register(new UTED2Burning());
         if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -67,6 +67,10 @@ public class UTConfigMods
     @Config.Name("CoFH Core")
     public static final CoFHCoreCategory COFH_CORE = new CoFHCoreCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.collective")
+    @Config.Name("Collective")
+    public static final CollectiveCategory COLLECTIVE = new CollectiveCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.compactmachines")
     @Config.Name("Compact Machines")
     public static final CompactMachinesCoreCategory COMPACT_MACHINES = new CompactMachinesCoreCategory();
@@ -314,7 +318,7 @@ public class UTConfigMods
         public boolean utBMOptimizeSoulForgeToggle = true;
 
         @Config.RequiresMcRestart
-        @Config.Name("World Unload Memory Leak Fix")
+        @Config.Name("Memory Leak Fix")
         @Config.Comment("Fixes memory leak when unloading worlds/switching dimensions")
         public boolean utBMWorldUnloadToggle = true;
 
@@ -379,6 +383,14 @@ public class UTConfigMods
         @Config.Name("Vorpal Enchantment Damage")
         @Config.Comment("Sets the damage multiplier of the Vorpal enchantment")
         public double utCoFHVorpalDamage = 10.0D;
+    }
+
+    public static class CollectiveCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Memory Leak Fix")
+        @Config.Comment("Fixes memory leak when unloading worlds/switching dimensions")
+        public boolean utMemoryLeakFixToggle = true;
     }
 
     public static class CompactMachinesCoreCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -41,10 +41,10 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.astralsorcery.json", () -> loaded("astralsorcery"));
             put("mixins.mods.biomesoplenty.json", () -> loaded("biomesoplenty"));
             put("mixins.mods.biomesoplenty.sealevel.json", () -> loaded("biomesoplenty") && UTConfigTweaks.WORLD.utSeaLevel != 63);
-            put("mixins.mods.bloodmagic.dupes.json", () -> loaded("bloodmagic"));
-            put("mixins.mods.bloodmagic.json", () -> loaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle);
-            put("mixins.mods.botania.dupes.json", () -> loaded("botania"));
-            put("mixins.mods.botania.json", () -> loaded("botania") && UTConfigMods.BOTANIA.utDuplicationFixesToggle);
+            put("mixins.mods.bloodmagic.dupes.json", () -> loaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle);
+            put("mixins.mods.bloodmagic.json", () -> loaded("bloodmagic"));
+            put("mixins.mods.botania.dupes.json", () -> loaded("botania") && UTConfigMods.BOTANIA.utDuplicationFixesToggle);
+            put("mixins.mods.botania.json", () -> loaded("botania"));
             put("mixins.mods.cbmultipart.json", () -> loaded("forgemultipartcbe") && UTConfigMods.CB_MULTIPART.utMemoryLeakFixToggle);
             put("mixins.mods.ceramics.json", () -> loaded("ceramics"));
             put("mixins.mods.chisel.tcomplement.dupes.json", () -> loaded("chisel") && loaded("tcomplement") && UTConfigMods.CHISEL.utDuplicationFixesToggle);
@@ -104,8 +104,8 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.thaumcraft.json", () -> loaded("thaumcraft"));
             put("mixins.mods.thaumicwonders.dupes.json", () -> loaded("thaumicwonders") && UTConfigMods.THAUMIC_WONDERS.utDuplicationFixesToggle);
             put("mixins.mods.thefarlanders.dupes.json", () -> loaded("farlanders") && UTConfigMods.THE_FARLANDERS.utDuplicationFixesToggle);
-            put("mixins.mods.thermalexpansion.dupes.json", () -> loaded("thermalexpansion"));
-            put("mixins.mods.thermalexpansion.json", () -> loaded("thermalexpansion") && UTConfigMods.THERMAL_EXPANSION.utDuplicationFixesToggle);
+            put("mixins.mods.thermalexpansion.dupes.json", () -> loaded("thermalexpansion") && UTConfigMods.THERMAL_EXPANSION.utDuplicationFixesToggle);
+            put("mixins.mods.thermalexpansion.json", () -> loaded("thermalexpansion"));
             put("mixins.mods.tinyprogressions.dupes.json", () -> loaded("tp") && UTConfigMods.TINY_PROGRESSIONS.utDuplicationFixesToggle);
         }
     });

--- a/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/mixin/UTPlayerEquipmentMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/aoa3/mixin/UTPlayerEquipmentMixin.java
@@ -25,11 +25,7 @@ public class UTPlayerEquipmentMixin
     @WrapWithCondition(method = "tickEquipment", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V", remap = true))
     private boolean utUpdateInventoryIfAllowed(Container instance, @Share("shouldUpdate") LocalBooleanRef shouldUpdate)
     {
-        if (shouldUpdate.get())
-        {
-            shouldUpdate.set(false);
-            return true;
-        }
-        return false;
+        // Last use of the LocalRef, so no need to reset.
+        return shouldUpdate.get();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/collective/UTCollectiveEvents.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/collective/UTCollectiveEvents.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.collective;
+
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import com.natamus.collective.events.CollectiveEvents;
+
+public class UTCollectiveEvents
+{
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event)
+    {
+        World world = event.getWorld();
+        if (!world.isRemote)
+        {
+            WorldServer serverWorld = (WorldServer) world;
+            CollectiveEvents.entitiesToRide.remove(serverWorld);
+            CollectiveEvents.entitiesToSpawn.remove(serverWorld);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/quark/mixin/UTEntityPickarangMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/quark/mixin/UTEntityPickarangMixin.java
@@ -51,7 +51,7 @@ public abstract class UTEntityPickarangMixin extends EntityThrowable
     @Shadow
     public abstract int getEfficiencyModifier();
 
-    @Inject(method = "func_70071_h_", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true, remap = true)
     public void onUpdate(CallbackInfo info)
     {
         IS_PICKARANG_UPDATING.set(true);
@@ -139,6 +139,7 @@ public abstract class UTEntityPickarangMixin extends EntityThrowable
                     {
                         for (EntityItem item : items)
                         {
+                            // CHANGE START: wrap block with check
                             if (!item.isDead)
                             {
                                 ItemStack drop = item.getItem();
@@ -146,11 +147,14 @@ public abstract class UTEntityPickarangMixin extends EntityThrowable
                                     player.dropItem(drop, false);
                                 item.setDead();
                             }
+                            // CHANGE END
                         }
 
                         for (EntityXPOrb xpOrb : xp)
                         {
+                            // CHANGE START: wrap call with check
                             if (!xpOrb.isDead) xpOrb.onCollideWithPlayer(player);
+                            // CHANGE END
                         }
 
                         for (Entity riding : getPassengers())

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/enderio/mixin/UTDSUContainerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumcraft/enderio/mixin/UTDSUContainerMixin.java
@@ -10,10 +10,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import thaumcraft.api.items.ItemsTC;
 
 // Courtesy of Focamacho
-@Mixin(value = DSUContainer.class, remap = false)
+@Mixin(value = DSUContainer.class)
 public class UTDSUContainerMixin
 {
-    @Inject(method = "func_75145_c", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "canInteractWith", at = @At("HEAD"), cancellable = true)
     private void canInteractWith(EntityPlayer player, CallbackInfoReturnable<Boolean> info)
     {
         if (((DSUContainer) (Object) this).getSlot(1).getStack().getItem().equals(ItemsTC.primordialPearl)) info.setReturnValue(false);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thaumicwonders/mixin/UTEntityFlyingCarpetMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thaumicwonders/mixin/UTEntityFlyingCarpetMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // Courtesy of Focamacho
-@Mixin(value = EntityFlyingCarpet.class, remap = false)
+@Mixin(value = EntityFlyingCarpet.class)
 public abstract class UTEntityFlyingCarpetMixin extends Entity
 {
     public UTEntityFlyingCarpetMixin(World worldIn)
@@ -20,7 +20,7 @@ public abstract class UTEntityFlyingCarpetMixin extends Entity
         super(worldIn);
     }
 
-    @Inject(method = "func_184230_a", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "processInitialInteract", at = @At("HEAD"), cancellable = true)
     private void processInitialInteract(EntityPlayer player, EnumHand hand, CallbackInfoReturnable<Boolean> info)
     {
         if (this.isDead) info.setReturnValue(true);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTInsolatorManagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTInsolatorManagerMixin.java
@@ -26,7 +26,7 @@ public class UTInsolatorManagerMixin
         if (!UTConfigMods.THERMAL_EXPANSION.utTEInsolatorCustomMonoculture) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInsolatorManagerMixin ::: Add custom fertilizers");
         // EXTRA FERTILIZERS
-        for (ItemStack item : UTInsolatorExpansion.additionalFertilizers)
+        for (ItemStack item : UTInsolatorExpansion.getFertilizers())
         {
             if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInsolatorManagerMixin ::: Adding fertilizer: " + item.toString());
             // adding the fertilizer is enough for TE to recognize the recipe(s) for Monoculture Cycle

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/modtweaker/UTInsolatorExpansion.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/modtweaker/UTInsolatorExpansion.java
@@ -1,6 +1,9 @@
 package mod.acgaming.universaltweaks.mods.thermalexpansion.modtweaker;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import net.minecraft.item.ItemStack;
 
@@ -23,9 +26,8 @@ import stanhebben.zenscript.annotations.ZenMethodStatic;
 @ZenRegister
 public class UTInsolatorExpansion
 {
-    // list of fertilizers that will be added to TE's InsolatorManager
-    // This isn't really a Set because ItemStack doesn't override equals(), but performance impact shouldn't be significant.
-    public static Set<ItemStack> additionalFertilizers = UTConfigMods.THERMAL_EXPANSION.utTEInsolatorCustomMonoculture ? new ObjectOpenHashSet<>() : null;
+    // Set of fertilizers that will be added to TE's InsolatorManager
+    public static Set<IItemStack> additionalFertilizers = UTConfigMods.THERMAL_EXPANSION.utTEInsolatorCustomMonoculture ? new ObjectOpenHashSet<>() : null;
 
     @ZenMethodStatic
     public static void addRecipeMonoculture(IItemStack primaryOutput, IItemStack primaryInput, IItemStack secondaryInput, int energy, @Optional IItemStack secondaryOutput, @Optional int secondaryChance, @Optional(valueLong = -1L) int water)
@@ -35,7 +37,7 @@ public class UTInsolatorExpansion
             if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInsolatorExpansion ::: ERROR - utTEInsolatorCustomMonoculture must be enabled to use this function!");
             return;
         }
-        additionalFertilizers.add(CraftTweakerMC.getItemStack(secondaryInput));
+        additionalFertilizers.add(secondaryInput);
         Insolator.addRecipe(primaryOutput, primaryInput, secondaryInput, energy, secondaryOutput, secondaryChance, water);
     }
 
@@ -47,7 +49,18 @@ public class UTInsolatorExpansion
             if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInsolatorExpansion ::: ERROR - utTEInsolatorCustomMonoculture must be enabled to use this function!");
             return;
         }
-        additionalFertilizers.add(CraftTweakerMC.getItemStack(secondaryInput));
+        additionalFertilizers.add(secondaryInput);
         Insolator.addRecipeSaplingInfuser(primaryOutput, primaryInput, secondaryInput, energy, secondaryOutput, secondaryChance, water);
+    }
+
+    public static List<ItemStack> getFertilizers()
+    {
+        List<ItemStack> fertilizers = Collections.emptyList();
+        if (additionalFertilizers != null)
+        {
+            fertilizers = additionalFertilizers.stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList());
+            additionalFertilizers = null;
+        }
+        return fertilizers;
     }
 }

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -60,6 +60,7 @@ cfg.universaltweaks.modintegration.cbmultipart=CB Multipart/Forge Multipart CBE
 cfg.universaltweaks.modintegration.ccl=CodeChicken Lib
 cfg.universaltweaks.modintegration.chisel=Chisel
 cfg.universaltweaks.modintegration.cofhcore=CoFH Core
+cfg.universaltweaks.modintegration.collective=Collective
 cfg.universaltweaks.modintegration.compactmachines=Compact Machines
 cfg.universaltweaks.modintegration.cqrepoured=Chocolate Quest Repoured
 cfg.universaltweaks.modintegration.effortlessbuilding=Effortless Building


### PR DESCRIPTION
Main additions/adjustments for this PR:
- Adds a fix for a memory leak with the Collective mod where maps were still holding onto `WorldServer`s even after unload, similar to Blood Magic.
- Clean up Thermal Expansion monoculture tweak by using `IItemStack` for proper `Set` functionality.
- Remove some unnecessary code in Advent of Ascension mixin.

Alongside fixing some other minor mistakes in readme, configs, deobf mixin names.
Also disables Jabel from new buildscript for now, it seems to make IntelliJ forget how to auto-complete Forge annotations, but feel free to enable it if you want to use modern Java syntax.