### PR TITLE
Disable End Portal Parallax by default

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1446,7 +1446,7 @@ public class UTConfigTweaks
         @Config.RequiresMcRestart
         @Config.Name("End Portal Parallax")
         @Config.Comment("Re-implements parallax rendering of the end portal from 1.10 and older")
-        public boolean utEndPortalParallaxToggle = true;
+        public boolean utEndPortalParallaxToggle = false;
 
         @Config.RequiresMcRestart
         @Config.Name("Infinite Music")


### PR DESCRIPTION
This was done because this tweak breaks certain shaders by default and it is quite reactive to fog as talked about on this issue [here](https://github.com/ACGaming/UniversalTweaks/issues/64). Disabling this tweak by default will negate complaints.