### PR TITLE
Fix crashes with CCL, TE tweaks

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/codechickenlib/mixin/UTPacketCustomRetainMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/codechickenlib/mixin/UTPacketCustomRetainMixin.java
@@ -87,15 +87,8 @@ public abstract class UTPacketCustomRetainMixin
         }
     }
 
-    @Shadow
-    public abstract boolean release();
-
-    /**
-     * Release this buf after copying it, just to be safe.
-     */
-    @Inject(method = "toPacket", at = @At(value = "RETURN"))
-    private void utReleaseOriginal(CallbackInfoReturnable<FMLProxyPacket> cir)
-    {
-        this.release();
-    }
+    // Releasing the PacketCustom on copy to packet would be ideal, but some mods still use the PacketCustom after calling this...
+    // But there isn't any other good way (AFAIK) to release without knowing a mod's specific usage.
+    // Excluding this prevents crashes from deallocating too early, but could there be leaks? If so, needs more investigation.
+    // @Inject(method = "toPacket", at = @At(value = "RETURN"))
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/codechickenlib/mixin/UTPacketCustomRetainMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/codechickenlib/mixin/UTPacketCustomRetainMixin.java
@@ -15,12 +15,10 @@ import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 
 import codechicken.lib.packet.PacketCustom;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * This mixin retains PacketCustom payloads, increasing the ref count by the number of players

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/modtweaker/UTInsolatorExpansion.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/modtweaker/UTInsolatorExpansion.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import net.minecraft.item.ItemStack;
 
+import net.minecraftforge.fml.common.Loader;
+
 import com.blamejared.compat.thermalexpansion.Insolator;
 import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
@@ -56,7 +58,7 @@ public class UTInsolatorExpansion
     public static List<ItemStack> getFertilizers()
     {
         List<ItemStack> fertilizers = Collections.emptyList();
-        if (additionalFertilizers != null)
+        if (additionalFertilizers != null && Loader.isModLoaded("crafttweaker"))
         {
             fertilizers = additionalFertilizers.stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList());
             additionalFertilizers = null;


### PR DESCRIPTION
Fixed crash in CCL packet fix by removing extra `release` call. I think in theory having it is necessary, but it deallocates the packet too early if any mod calls any of the `sendToXXX` methods on the `PacketCustom` object multiple times. I couldn't really come up with a different way to ensure the packet is released before gc'ed in this particular case (without case-by-case modifications). I tested with `-Dio.netty.leakDetection.level=paranoid` and didn't seem to find any packet leaks from CCL related networking, so hopefully leaks are still prevented.

Also fixed crash with TE monoculture tweak change - forgot a mod check. 