### PR TITLE
Improve Emojicord's emoji context calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ All changes are toggleable via config files.
     * **Extinguishing Dodges:** Chance per dodge to extinguish the player when burning
     * **Feathers Helper API Fix:** Fixes server-sided crashes when the Feathers Helper API is utilized
     * **Sprinting Integration:** Configurable consumption of feathers when the player is sprinting
+* **Emojicord**
+    * **Emoji Context:** Improves emoji context calculation to improve fps when rendering a lot of text
 * **Ender Storage**
     * **Fix Frequency Tracking:** Fixes storage frequencies being tracked multiple times
 * **Epic Siege Mod**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -80,6 +80,7 @@ final def mod_dependencies = [
     'curse.maven:effortlessbuilding-302113:2847346'                   : [debug_effortless_building],
     'curse.maven:elementary-staffs-346007:2995593'                    : [debug_elementary_staffs],
     'curse.maven:elenaidodge2-442962:3343308'                         : [debug_elenai_dodge_2],
+    'curse.maven:emojicord-349107:4000684'                            : [debug_emojicord],
     'curse.maven:enderstorage-245174:2755787'                         : [debug_enderstorage],
     'curse.maven:epic-siege-mod-229449:3356157'                       : [debug_epic_siege_mod],
     'curse.maven:extrautilities-225561:2678374'                       : [debug_extra_utilities_2],

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ debug_crafttweaker = false
 debug_effortless_building = false
 debug_elementary_staffs = false
 debug_elenai_dodge_2 = false
+debug_emojicord = false
 debug_enderio = false
 debug_enderstorage = false
 debug_epic_siege_mod = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -87,6 +87,10 @@ public class UTConfigMods
     @Config.Name("Elenai Dodge 2")
     public static final ElenaiDodge2Category ELENAI_DODGE_2 = new ElenaiDodge2Category();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.emojicord")
+    @Config.Name("Emojicord")
+    public static final EmojicordCategory EMOJICORD = new EmojicordCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.enderstorage")
     @Config.Name("Ender Storage")
     public static final EnderStorageCategory ENDER_STORAGE = new EnderStorageCategory();
@@ -441,6 +445,14 @@ public class UTConfigMods
         @Config.Name("Sprinting Feather Requirement")
         @Config.Comment("Sets the amount of half-feathers required to start sprinting")
         public int utED2SprintingFeatherRequirement = 6;
+    }
+
+    public static class EmojicordCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Emoji Context")
+        @Config.Comment("Improves emoji context calculation to improve fps when rendering a lot of text")
+        public boolean utEmojiContextToggle = true;
     }
 
     public static class EnderStorageCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 import zone.rong.mixinbooter.IEarlyMixinLoader;
@@ -152,6 +153,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.world.village.json", () -> UTConfigTweaks.WORLD.utVillageDistance != 32);
         }
     });
+    public static boolean emojicordLoaded;
     public static boolean openModsLoaded;
     public static boolean surgeLoaded;
     private static final Map<String, Supplier<Boolean>> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
@@ -171,6 +173,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.bugfixes.misc.spectatormenu.json", () -> UTConfigBugfixes.MISC.utSpectatorMenuToggle);
             put("mixins.bugfixes.misc.startup.json", () -> UTConfigTweaks.PERFORMANCE.utFasterBackgroundStartupToggle);
             put("mixins.bugfixes.world.frustumculling.json", () -> UTConfigBugfixes.WORLD.utFrustumCullingToggle);
+            put("mixins.mods.emojicord.emojicontext.json", () -> UTConfigMods.EMOJICORD.utEmojiContextToggle && emojicordLoaded);
             put("mixins.tweaks.blocks.betterplacement.json", () -> UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementToggle);
             put("mixins.tweaks.blocks.hitdelay.json", () -> UTConfigTweaks.BLOCKS.utBlockHitDelay != 5);
             put("mixins.tweaks.entities.autojump.json", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
@@ -232,6 +235,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             Locale.setDefault(Locale.ENGLISH);
         }
 
+        emojicordLoaded = UTReflectionUtil.isClassLoaded("net.teamfruit.emojicord.asm.EmojicordCorePlugin");
         openModsLoaded = UTReflectionUtil.isClassLoaded("openmods.core.OpenModsClassTransformer");
         randomPatchesLoaded = UTReflectionUtil.isClassLoaded("com.therandomlabs.randompatches.core.RPCore");
         renderLibLoaded = UTReflectionUtil.isClassLoaded("meldexun.renderlib.RenderLib");

--- a/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/EmojiFontRendererContext.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/EmojiFontRendererContext.java
@@ -1,0 +1,9 @@
+package mod.acgaming.universaltweaks.mods.emojicord.emojicontext;
+
+public class EmojiFontRendererContext
+{
+
+    public static boolean isChatInput;
+    public static boolean isChatMessage;
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTEmojiFontRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTEmojiFontRendererMixin.java
@@ -1,0 +1,39 @@
+package mod.acgaming.universaltweaks.mods.emojicord.emojicontext.mixin;
+
+import java.util.EnumSet;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import mod.acgaming.universaltweaks.mods.emojicord.emojicontext.EmojiFontRendererContext;
+import net.teamfruit.emojicord.EmojicordConfig;
+import net.teamfruit.emojicord.emoji.EmojiContext;
+import net.teamfruit.emojicord.emoji.EmojiContext.EmojiContextAttribute;
+import net.teamfruit.emojicord.emoji.EmojiFontRenderer;
+
+@Mixin(value = EmojiFontRenderer.class, remap = false)
+public class UTEmojiFontRendererMixin
+{
+
+    @Shadow(remap = false)
+    private static EmojiContext CurrentContext;
+
+    @Overwrite(remap = false)
+    public static String updateEmojiContext(final String text)
+    {
+        if (EmojicordConfig.spec.isAvailable() && EmojicordConfig.RENDER.renderEnabled.get())
+        {
+            final EnumSet<EmojiContextAttribute> attributes = EnumSet.noneOf(EmojiContextAttribute.class);
+            if (EmojiFontRendererContext.isChatInput)
+                attributes.add(EmojiContextAttribute.CHAT_INPUT);
+            if (EmojiFontRendererContext.isChatMessage)
+                attributes.add(EmojiContextAttribute.CHAT_MESSAGE);
+            CurrentContext = EmojiContext.EmojiContextCache.instance.getContext(text, attributes);
+            return CurrentContext.text;
+        }
+        CurrentContext = null;
+        return text;
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTGuiChatMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTGuiChatMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.mods.emojicord.emojicontext.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import mod.acgaming.universaltweaks.mods.emojicord.emojicontext.EmojiFontRendererContext;
+import net.minecraft.client.gui.GuiChat;
+
+@Mixin(GuiChat.class)
+public class UTGuiChatMixin
+{
+
+    @ModifyVariable(method = "drawScreen", at = @At("HEAD"), index = 3, ordinal = 0, name = "partialTicks")
+    private float pre_drawScreen(float partialTicks)
+    {
+        EmojiFontRendererContext.isChatInput = true;
+        return partialTicks;
+    }
+
+    @ModifyVariable(method = "drawScreen", at = @At("RETURN"), index = 3, ordinal = 0, name = "partialTicks")
+    private float post_drawScreen(float partialTicks)
+    {
+        EmojiFontRendererContext.isChatInput = false;
+        return partialTicks;
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTGuiNewChatMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/emojicord/emojicontext/mixin/UTGuiNewChatMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.mods.emojicord.emojicontext.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import mod.acgaming.universaltweaks.mods.emojicord.emojicontext.EmojiFontRendererContext;
+import net.minecraft.client.gui.GuiNewChat;
+
+@Mixin(GuiNewChat.class)
+public class UTGuiNewChatMixin
+{
+
+    @ModifyVariable(method = "drawChat", at = @At("HEAD"), index = 1, ordinal = 0, name = "updateCounter")
+    private int pre_drawChat(int updateCounter)
+    {
+        EmojiFontRendererContext.isChatMessage = true;
+        return updateCounter;
+    }
+
+    @ModifyVariable(method = "drawChat", at = @At("RETURN"), index = 1, ordinal = 0, name = "updateCounter")
+    private int post_drawChat(int updateCounter)
+    {
+        EmojiFontRendererContext.isChatMessage = false;
+        return updateCounter;
+    }
+
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -66,6 +66,7 @@ cfg.universaltweaks.modintegration.cqrepoured=Chocolate Quest Repoured
 cfg.universaltweaks.modintegration.effortlessbuilding=Effortless Building
 cfg.universaltweaks.modintegration.elementarystaffs=Elementary Staffs
 cfg.universaltweaks.modintegration.elenaidodge2=Elenai Dodge 2
+cfg.universaltweaks.modintegration.emojicord=Emojicord
 cfg.universaltweaks.modintegration.enderstorage=Ender Storage
 cfg.universaltweaks.modintegration.erebus=The Erebus
 cfg.universaltweaks.modintegration.esm=Epic Siege Mod

--- a/src/main/resources/mixins.mods.emojicord.emojicontext.json
+++ b/src/main/resources/mixins.mods.emojicord.emojicontext.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.emojicord.emojicontext.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEmojiFontRendererMixin", "UTGuiChatMixin", "UTGuiNewChatMixin"]
+}


### PR DESCRIPTION
Emojicord calls `Thread.currentThread().getStackTrace()` to calculate the emoji context whenever text gets rendered. For example, in the hotkey menu, there is a huge FPS drop. Also, see https://github.com/Team-Fruit/Emojicord/issues/23.

This PR fixes this issue by setting a flag at the start of `GuiChat#drawScreen` and `GuiNewChat#drawChat` which eliminates the need to check the stack trace.