### PR TITLE
Add Compact Machines tweak to properly control mob spawn checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ All changes are toggleable via config files.
     * **Memory Leak Fix:** Fixes memory leak when unloading worlds/switching dimensions
 * **Compact Machines**
     * **Invisible Wall Render Fix:** Fixes some compact machine walls being invisible if [Nothirium](https://www.curseforge.com/minecraft/mc-mods/nothirium) 0.2.x (and up) or [Vintagium](https://github.com/Asek3/sodium-1.12) is installed
+    * **Allowed Spawns Improvement:** Improves server performance by properly controlling spawn checks (effectiveness depends on CM's config)
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory
 * **Elementary Staffs**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -399,6 +399,16 @@ public class UTConfigMods
         @Config.Name("Invisible Wall Render Fix")
         @Config.Comment("Fixes some compact machine walls being invisible if Nothirium 0.2.x (and up) or Vintagium is installed")
         public boolean utCMRenderFixToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Allowed Spawns Improvement")
+        @Config.Comment
+            ({
+                "Improves server performance by properly controlling spawn checks (effectiveness depends on CM's config)",
+                "Disable both 'allowHostileSpawns' and 'allowPeacefulSpawns' in the CM config for best performance",
+                "Does nothing if both config values are true"
+            })
+        public boolean utAllowedSpawnsImprovementToggle = true;
     }
 
     public static class EffortlessBuildingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -19,7 +19,7 @@ public class UTMixinLoader implements ILateMixinLoader
     {
         {
             put("mixins.mods.cbmultipart.client.json", () -> loaded("forgemultipartcbe") && UTConfigMods.CB_MULTIPART.utMemoryLeakFixToggle);
-            put("mixins.mods.compactmachines.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle);
+            put("mixins.mods.compactmachines.render.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle);
             put("mixins.mods.crafttweaker.json", () -> loaded("crafttweaker"));
             put("mixins.mods.hwyla.json", () -> loaded("waila"));
             put("mixins.mods.modularrouters.json", () -> loaded("modularrouters") && UTConfigMods.MODULAR_ROUTERS.utParticleThreadToggle);
@@ -51,6 +51,8 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.codechickenlib.json", () -> loaded("codechickenlib") && UTConfigMods.CCL.utPacketLeakFixToggle);
             put("mixins.mods.cofhcore.json", () -> loaded("cofhcore"));
             put("mixins.mods.collective.json", () -> loaded("collective"));
+            // TODO: Add config
+            put("mixins.mods.compactmachines.spawns.json", () -> loaded("compactmachines3"));
             put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
             put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding"));
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -51,8 +51,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.codechickenlib.json", () -> loaded("codechickenlib") && UTConfigMods.CCL.utPacketLeakFixToggle);
             put("mixins.mods.cofhcore.json", () -> loaded("cofhcore"));
             put("mixins.mods.collective.json", () -> loaded("collective"));
-            // TODO: Add config
-            put("mixins.mods.compactmachines.spawns.json", () -> loaded("compactmachines3"));
+            put("mixins.mods.compactmachines.spawns.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utAllowedSpawnsImprovementToggle);
             put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
             put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding"));
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/render/mixin/UTCubeToolsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/render/mixin/UTCubeToolsMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.compactmachines.mixin;
+package mod.acgaming.universaltweaks.mods.compactmachines.render.mixin;
 
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTChunkGeneratorMachinesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTChunkGeneratorMachinesMixin.java
@@ -5,28 +5,36 @@ import java.util.List;
 
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import org.dave.compactmachines3.misc.ConfigurationHandler;
 import org.dave.compactmachines3.world.ChunkGeneratorMachines;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 
 // Courtesy of jchung01
 @Mixin(value = ChunkGeneratorMachines.class)
 public class UTChunkGeneratorMachinesMixin
 {
+    @Shadow(remap = false)
+    @Final
+    private World world;
+
     /**
      * Another spot the CM config should control spawns; here for redundancy.
+     * @reason Control mob spawn based on type
+     * @author jchung01
      */
-    @ModifyReturnValue(method = "getPossibleCreatures", at = @At(value = "RETURN"))
-    private List<Biome.SpawnListEntry> utCheckAllowedCreatures(List<Biome.SpawnListEntry> original, EnumCreatureType creatureType, BlockPos pos)
+    @Overwrite
+    public List<Biome.SpawnListEntry> getPossibleCreatures(EnumCreatureType creatureType, BlockPos pos)
     {
         if ((creatureType.getPeacefulCreature() && ConfigurationHandler.MachineSettings.allowPeacefulSpawns) ||
             (!creatureType.getPeacefulCreature() && ConfigurationHandler.MachineSettings.allowHostileSpawns))
         {
-            return original;
+            return this.world.getBiome(pos).getSpawnableList(creatureType);
         }
         else return Collections.emptyList();
     }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTChunkGeneratorMachinesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTChunkGeneratorMachinesMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.mods.compactmachines.spawns.mixin;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import org.dave.compactmachines3.misc.ConfigurationHandler;
+import org.dave.compactmachines3.world.ChunkGeneratorMachines;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = ChunkGeneratorMachines.class)
+public class UTChunkGeneratorMachinesMixin
+{
+    /**
+     * Another spot the CM config should control spawns; here for redundancy.
+     */
+    @ModifyReturnValue(method = "getPossibleCreatures", at = @At(value = "RETURN"))
+    private List<Biome.SpawnListEntry> utCheckAllowedCreatures(List<Biome.SpawnListEntry> original, EnumCreatureType creatureType, BlockPos pos)
+    {
+        if ((creatureType.getPeacefulCreature() && ConfigurationHandler.MachineSettings.allowPeacefulSpawns) ||
+            (!creatureType.getPeacefulCreature() && ConfigurationHandler.MachineSettings.allowHostileSpawns))
+        {
+            return original;
+        }
+        else return Collections.emptyList();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTWorldProviderMachinesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTWorldProviderMachinesMixin.java
@@ -5,7 +5,6 @@ import net.minecraft.world.WorldProvider;
 import org.dave.compactmachines3.misc.ConfigurationHandler;
 import org.dave.compactmachines3.world.WorldProviderMachines;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 
 // Courtesy of jchung01
 @Mixin(value = WorldProviderMachines.class)
@@ -15,7 +14,6 @@ public abstract class UTWorldProviderMachinesMixin extends WorldProvider
      * Let CM config set allowed spawns when the dim loads.
      * This helps server performance especially when both hostile and peaceful spawns are disabled.
      */
-    @Unique
     @Override
     public void setAllowedSpawnTypes(boolean allowHostile, boolean allowPeaceful)
     {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTWorldProviderMachinesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/spawns/mixin/UTWorldProviderMachinesMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.compactmachines.spawns.mixin;
+
+import net.minecraft.world.WorldProvider;
+
+import org.dave.compactmachines3.misc.ConfigurationHandler;
+import org.dave.compactmachines3.world.WorldProviderMachines;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+// Courtesy of jchung01
+@Mixin(value = WorldProviderMachines.class)
+public abstract class UTWorldProviderMachinesMixin extends WorldProvider
+{
+    /**
+     * Let CM config set allowed spawns when the dim loads.
+     * This helps server performance especially when both hostile and peaceful spawns are disabled.
+     */
+    @Unique
+    @Override
+    public void setAllowedSpawnTypes(boolean allowHostile, boolean allowPeaceful)
+    {
+        super.setAllowedSpawnTypes(ConfigurationHandler.MachineSettings.allowHostileSpawns, ConfigurationHandler.MachineSettings.allowPeacefulSpawns);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -27,6 +27,7 @@ public class UTObsoleteModsHandler
             put("bannerpatch", () -> UTConfigBugfixes.BLOCKS.utBannerBoundingBoxToggle);
             put("bedbreakbegone", () -> UTConfigTweaks.BLOCKS.utBedObstructionToggle);
             put("bedfix", () -> UTConfigTweaks.ENTITIES.SLEEPING.utSleepingTime != -1);
+            put("bedpatch", () -> true); // Fix integrated in Forge 14.23.2.2643 (#4784)
             put("bedsaynosleep", () -> UTConfigTweaks.ENTITIES.SLEEPING.utDisableSleepingToggle);
             put("betterburning", () -> UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBArrowsToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBCookedToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBExtinguishToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBOverlayToggle || UTConfigTweaks.ENTITIES.BETTER_BURNING.utBBSpreadingToggle);
             put("betterpingdisplay", () -> UTConfigTweaks.MISC.utBetterPing);
@@ -158,7 +159,7 @@ public class UTObsoleteModsHandler
         }
 
         // Mods checked by class
-        if (UTReflectionUtil.isClassLoaded("com.chocohead.biab.BornInABarn")) messages.add("Born in a Barn");
+        if (UTReflectionUtil.isClassLoaded("com.chocohead.biab.BornInABarn")) messages.add("Born in a Barn"); // Fix integrated in Forge 14.23.2.2623 (#4689)
         if (UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleTweaker") && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
         if (UTReflectionUtil.isClassLoaded("com.cleanroommc.blockdelayremover.BlockDelayRemoverCore") && UTConfigTweaks.BLOCKS.utBlockHitDelay != 5) messages.add("Block Delay Remover");
         if (UTReflectionUtil.isClassLoaded("io.github.barteks2x.chunkgenlimiter.ChunkGenLimitMod") && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");

--- a/src/main/resources/mixins.mods.compactmachines.json
+++ b/src/main/resources/mixins.mods.compactmachines.json
@@ -1,7 +1,0 @@
-{
-  "package": "mod.acgaming.universaltweaks.mods.compactmachines.mixin",
-  "refmap": "universaltweaks.refmap.json",
-  "minVersion": "0.8",
-  "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTCubeToolsMixin"]
-}

--- a/src/main/resources/mixins.mods.compactmachines.render.json
+++ b/src/main/resources/mixins.mods.compactmachines.render.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.compactmachines.render.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTCubeToolsMixin"]
+}

--- a/src/main/resources/mixins.mods.compactmachines.spawns.json
+++ b/src/main/resources/mixins.mods.compactmachines.spawns.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.compactmachines.spawns.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTChunkGeneratorMachinesMixin", "UTWorldProviderMachinesMixin"]
+}


### PR DESCRIPTION
Checks for natural mob spawns can be rather expensive in the Compact Machines (CM) dimension as there is no place for them to spawn. This can have a noticeable impact on server TPS, scaling further based on the number of players loading chunks in the dimension (example [Spark report](https://spark.lucko.me/aXp7VapQIx?hl=50623)). CM actually has config settings that are seemingly related, `allowHostileSpawns` and `allowPeacefulSpawns`, but they only control forced spawns that occur through the machine's actual tile entity updates.

This PR registers the necessary properties for the CM dimension to properly respect its config values to disable both types of mob spawns, potentially improving server performance. I would like to emphasize that this tweak only enhances existing config values in the CM config, so the aforementioned config values also must be disabled for any perceivable change in performance. **Disabling both** results in the best performance, but that is up to the user to configure.

Also added BedPatch to the obsolete mods, with some comments on the relevant Forge PRs.