### PR TITLE
Get ExtendedBlockState before rendering in block overlay fix

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/UTBlockOverlay.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/UTBlockOverlay.java
@@ -66,6 +66,8 @@ public class UTBlockOverlay
                 bufferBuilder.setTranslation(-x, -(y - player.getEyeHeight()), -z);
             }
             IBlockState state1 = state.getActualState(world, pos);
+            // Call extendedBlockState if it has one: see BlockRendererDispatcher#renderBlock()
+            state1 = state.getBlock().getExtendedState(state1, world, pos);
             mc.getBlockRendererDispatcher().getBlockModelRenderer().renderModel(world, mc.getBlockRendererDispatcher().getModelForState(state1), state1, pos, bufferBuilder, false);
         });
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -112,10 +112,7 @@ public class UTConfigBugfixes
                     "Excludes blocks from the block overlay bugfix",
                     "Syntax: modid:block"
                 })
-            public String[] utBlockOverlayBlacklist = new String[]
-                {
-                    "appliedenergistics2:drive"
-                };
+            public String[] utBlockOverlayBlacklist = new String[] {};
 
             @Config.Name("[3] Whitelist")
             @Config.Comment


### PR DESCRIPTION
Not entirely an expert on rendering, but the block of code used to render the overlay in the block overlay fix seems to mirror `BlockRendererDispatcher#renderBlock()`. However, unlike that method, the fix was missing a call to get the block's `IExtendedBlockState` if it had one. This was the root cause of the crashes that have been reported with this fix. I tested AE2-UEL v0.56.4 (which has the ME Drive crash) and Roost (which has the roost block crash), and neither of them crash now. This means the ME Drive doesn't need to be in the blacklist now.
Fixes #533. Fixes #547.