### PR TITLE
Render block overlay fix based on state

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/UTBlockOverlay.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/UTBlockOverlay.java
@@ -23,16 +23,28 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.relauncher.Side;
 
-import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 
 // Courtesy of Meldexun
-@Mod.EventBusSubscriber(modid = UniversalTweaks.MODID, value = Side.CLIENT)
 public class UTBlockOverlay
 {
+    /**
+     * Flag to only render block overlay when expected.
+     * Necessary as some other mods (i.e. Portal Gun) render the world an additional time sometime in the pass.
+     */
+    private static boolean render = false;
+
+    public static boolean shouldRender()
+    {
+        return render;
+    }
+
+    public static void setRender(boolean value)
+    {
+        UTBlockOverlay.render = value;
+    }
+
     @SuppressWarnings("deprecation")
     public static void renderNearbyBlocks(float partialTicks)
     {

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/mixin/UTBlockOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/mixin/UTBlockOverlayMixin.java
@@ -30,9 +30,9 @@ public class UTBlockOverlayMixin
     private Minecraft mc;
 
     @Inject(method = "renderBlockLayer(Lnet/minecraft/util/BlockRenderLayer;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ChunkRenderContainer;renderChunkLayer(Lnet/minecraft/util/BlockRenderLayer;)V"))
-    public void utBlockOverlay(BlockRenderLayer blockLayerIn, CallbackInfo info)
+    public void utRenderBlockOverlay(BlockRenderLayer blockLayerIn, CallbackInfo info)
     {
-        if (!UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle) return;
+        if (!UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle || !UTBlockOverlay.shouldRender()) return;
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTBlockOverlay ::: Render block layer");
         Block block = world.getBlockState(mc.player.getPosition().up()).getBlock();
         if ((blockLayerIn == BlockRenderLayer.SOLID && !UTBlockOverlayLists.blacklistedBlocks.contains(block)) || UTBlockOverlayLists.whitelistedBlocks.contains(block))

--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/mixin/UTEntityRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/blocks/blockoverlay/mixin/UTEntityRendererMixin.java
@@ -1,0 +1,34 @@
+package mod.acgaming.universaltweaks.bugfixes.blocks.blockoverlay.mixin;
+
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.BlockRenderLayer;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.bugfixes.blocks.blockoverlay.UTBlockOverlay;
+import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+// Courtesy of jchung01
+@Mixin(value = EntityRenderer.class)
+public class UTEntityRendererMixin
+{
+    @WrapOperation(method = "renderWorldPass",
+        slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/util/BlockRenderLayer;SOLID:Lnet/minecraft/util/BlockRenderLayer;", opcode = Opcodes.GETSTATIC),
+            to = @At(value = "FIELD", target = "Lnet/minecraft/util/BlockRenderLayer;CUTOUT_MIPPED:Lnet/minecraft/util/BlockRenderLayer;", opcode = Opcodes.GETSTATIC)),
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;renderBlockLayer(Lnet/minecraft/util/BlockRenderLayer;DILnet/minecraft/entity/Entity;)I"))
+    private int utSetBlockOverlayState(RenderGlobal instance, BlockRenderLayer layer, double partialTicks, int pass, Entity entity, Operation<Integer> original)
+    {
+        if (!UTConfigBugfixes.BLOCKS.BLOCK_OVERLAY.utBlockOverlayToggle) return original.call(instance, layer, partialTicks, pass, entity);
+        int ret;
+        UTBlockOverlay.setRender(true);
+        ret = original.call(instance, layer, partialTicks, pass, entity);
+        UTBlockOverlay.setRender(false);
+        return ret;
+    }
+}

--- a/src/main/resources/mixins.bugfixes.blocks.blockoverlay.json
+++ b/src/main/resources/mixins.bugfixes.blocks.blockoverlay.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["UTBlockOverlayMixin"]
+  "client": ["UTBlockOverlayMixin", "UTEntityRendererMixin"]
 }


### PR DESCRIPTION
The block overlay fix was being called on _any_ call to `RenderGlobal#renderBlockLayer()`, which may include other mods (i.e. Portal Gun) that render the world again in the same pass. So a solution is to use a flag to only call the block overlay fix exactly where we want to. Fixes #549.