### PR TITLE
Add RandomPatches timeout tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ All changes are toggleable via config files.
 * **Chicken Shedding:** Allows chickens to have a chance to shed feathers (similarly to laying eggs)
 * **Chunk Gen Limit:** Limits maximum chunk generation per tick for improved server performance
 * **Cobweb Slowness:** Modifies the applied slowness factor when entities are moving in cobwebs
+* **Connection Timeouts:** Allows configuring read/login timeouts
+    * Helps slow clients log into a server of a large modpack
 * **Copy World Seed:** Enables clicking of `/seed` world seed in chat to copy to clipboard
 * **Crafting Cache:** Adds an IRecipe cache to improve recipe performance in large modpacks
 * **Creeper Confetti:** Replaces deadly creeper explosions with delightful confetti (with a configurable chance)

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -20,6 +20,7 @@ import mod.acgaming.universaltweaks.tweaks.misc.armorcurve.UTArmorCurve;
 import mod.acgaming.universaltweaks.tweaks.misc.incurablepotions.UTIncurablePotions;
 import mod.acgaming.universaltweaks.tweaks.misc.loadsound.UTLoadSound;
 import mod.acgaming.universaltweaks.tweaks.misc.swingthroughgrass.UTSwingThroughGrassLists;
+import mod.acgaming.universaltweaks.tweaks.misc.timeouts.UTTimeoutManager;
 import mod.acgaming.universaltweaks.tweaks.performance.autosave.UTAutoSaveOFCompat;
 import mod.acgaming.universaltweaks.tweaks.performance.entityradiuscheck.UTEntityRadiusCheck;
 
@@ -1374,6 +1375,10 @@ public class UTConfigTweaks
         @Config.Name("Chat")
         public final ChatCategory CHAT = new ChatCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.misc.timeouts")
+        @Config.Name("Connection Timeouts")
+        public final TimeoutsCategory TIMEOUTS = new TimeoutsCategory();
+
         @Config.LangKey("cfg.universaltweaks.tweaks.misc.incurablepotions")
         @Config.Name("Incurable Potions")
         public final IncurablePotionsCategory INCURABLE_POTIONS = new IncurablePotionsCategory();
@@ -1948,6 +1953,34 @@ public class UTConfigTweaks
             public String[] utSwingThroughGrassWhitelist = new String[] {};
         }
 
+        public static class TimeoutsCategory
+        {
+            @Config.Name("[1] Connection Timeouts Toggle")
+            @Config.Comment
+                ({
+                    "Allows configuring read/login timeouts.",
+                    "If you are having trouble logging into a server of a large modpack, try changing the timeouts below."
+                })
+            public boolean utTimeoutsToggle = true;
+
+            @Config.Name("[2] Read Timeout")
+            @Config.Comment
+                ({
+                    "The connection read timeout in seconds.",
+                    "This value is used on both client and server.",
+                    "On the server, also extends the time allowed to respond to a KeepAlive packet."
+                })
+            public int utReadTimeout = 90;
+
+            @Config.Name("[3] Login Timeout")
+            @Config.Comment
+                ({
+                    "The login timeout in seconds. (Vanilla default: 600 ticks, or 30 secs)",
+                    "Only used on the server.",
+                })
+            public int utLoginTimeout = 90;
+        }
+
         public static class ToastControlCategory
         {
             @Config.RequiresMcRestart
@@ -2303,6 +2336,7 @@ public class UTConfigTweaks
     static
     {
         ConfigAnytime.register(UTConfigTweaks.class);
+        UTTimeoutManager.init();
     }
 
     @Mod.EventBusSubscriber(modid = UniversalTweaks.MODID)

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -142,8 +142,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.lightning.damage.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningDamage != 5.0D || UTConfigTweaks.MISC.LIGHTNING.utLightningFireTicks != 8);
             put("mixins.tweaks.misc.lightning.fire.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFireToggle);
             put("mixins.tweaks.misc.recipebook.server.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);
-            // TODO: add config
-            put("mixins.tweaks.misc.timeouts.json", () -> true);
+            put("mixins.tweaks.misc.timeouts.json", () -> UTConfigTweaks.MISC.TIMEOUTS.utTimeoutsToggle);
             put("mixins.tweaks.misc.xp.cap.json", () -> UTConfigTweaks.MISC.utXPLevelCap > -1);
             put("mixins.tweaks.misc.xp.linear.json", () -> UTConfigTweaks.MISC.utLinearXP > 0);
             put("mixins.tweaks.misc.xp.smelting.json", () -> UTConfigTweaks.MISC.utSmeltingXPToggle);
@@ -219,8 +218,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.personalpotionparticles.json", () -> UTConfigTweaks.MISC.utPoVEffectParticles);
             put("mixins.tweaks.misc.recipebook.client.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);
             put("mixins.tweaks.misc.smoothscrolling.json", () -> UTConfigTweaks.MISC.SMOOTH_SCROLLING.utSmoothScrollingToggle);
-            // TODO: add config
-            put("mixins.tweaks.misc.timeouts.client.json", () -> true);
+            put("mixins.tweaks.misc.timeouts.client.json", () -> UTConfigTweaks.MISC.TIMEOUTS.utTimeoutsToggle);
             put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
             put("mixins.tweaks.performance.audioreload.json", () -> UTConfigTweaks.PERFORMANCE.utDisableAudioDebugToggle && !surgeLoaded);
             put("mixins.tweaks.performance.connectionspeed.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -142,6 +142,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.lightning.damage.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningDamage != 5.0D || UTConfigTweaks.MISC.LIGHTNING.utLightningFireTicks != 8);
             put("mixins.tweaks.misc.lightning.fire.json", () -> UTConfigTweaks.MISC.LIGHTNING.utLightningFireToggle);
             put("mixins.tweaks.misc.recipebook.server.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);
+            // TODO: add config
+            put("mixins.tweaks.misc.timeouts.json", () -> true);
             put("mixins.tweaks.misc.xp.cap.json", () -> UTConfigTweaks.MISC.utXPLevelCap > -1);
             put("mixins.tweaks.misc.xp.linear.json", () -> UTConfigTweaks.MISC.utLinearXP > 0);
             put("mixins.tweaks.misc.xp.smelting.json", () -> UTConfigTweaks.MISC.utSmeltingXPToggle);
@@ -217,6 +219,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.personalpotionparticles.json", () -> UTConfigTweaks.MISC.utPoVEffectParticles);
             put("mixins.tweaks.misc.recipebook.client.json", () -> UTConfigTweaks.MISC.utRecipeBookToggle);
             put("mixins.tweaks.misc.smoothscrolling.json", () -> UTConfigTweaks.MISC.SMOOTH_SCROLLING.utSmoothScrollingToggle);
+            // TODO: add config
+            put("mixins.tweaks.misc.timeouts.client.json", () -> true);
             put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
             put("mixins.tweaks.performance.audioreload.json", () -> UTConfigTweaks.PERFORMANCE.utDisableAudioDebugToggle && !surgeLoaded);
             put("mixins.tweaks.performance.connectionspeed.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/UTTimeoutManager.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/UTTimeoutManager.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.tweaks.misc.timeouts;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+public class UTTimeoutManager
+{
+    public static long readTimeoutMillis;
+    public static int loginTimeoutTicks;
+
+    public static void init()
+    {
+        if (!UTConfigTweaks.MISC.TIMEOUTS.utTimeoutsToggle) return;
+        int readTimeout = NumberUtils.toInt(System.getProperty("fml.readTimeout"), UTConfigTweaks.MISC.TIMEOUTS.utReadTimeout);
+        // Don't overwrite read timeout that was specified by command line.
+        if (readTimeout == UTConfigTweaks.MISC.TIMEOUTS.utReadTimeout)
+        {
+            System.setProperty("fml.readTimeout", String.valueOf(UTConfigTweaks.MISC.TIMEOUTS.utReadTimeout));
+        }
+        readTimeoutMillis = UTConfigTweaks.MISC.TIMEOUTS.utReadTimeout * 1000L;
+        loginTimeoutTicks = UTConfigTweaks.MISC.TIMEOUTS.utLoginTimeout * 20;
+        // fml.loginTimeout is unused
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTClientReadTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTClientReadTimeoutMixin.java
@@ -1,5 +1,6 @@
 package mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin;
 
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
@@ -12,6 +13,6 @@ public class UTClientReadTimeoutMixin
     @ModifyConstant(method = "initChannel", constant = @Constant(intValue = 30))
     private int utModifyReadTimeout(int original)
     {
-        return 90;
+        return UTConfigTweaks.MISC.TIMEOUTS.utReadTimeout;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTClientReadTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTClientReadTimeoutMixin.java
@@ -1,0 +1,17 @@
+package mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+// Courtesy of jchung01, TheRandomLabs (RandomPatches)
+@Mixin(targets = "net.minecraft.network.NetworkManager$5")
+public class UTClientReadTimeoutMixin
+{
+    @SuppressWarnings("UnresolvedMixinReference")
+    @ModifyConstant(method = "initChannel", constant = @Constant(intValue = 30))
+    private int utModifyReadTimeout(int original)
+    {
+        return 90;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTLoginTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTLoginTimeoutMixin.java
@@ -2,6 +2,7 @@ package mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin;
 
 import net.minecraft.server.network.NetHandlerLoginServer;
 
+import mod.acgaming.universaltweaks.tweaks.misc.timeouts.UTTimeoutManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
@@ -13,6 +14,6 @@ public class UTLoginTimeoutMixin
     @ModifyConstant(method = "update", constant = @Constant(intValue = 600))
     private int utModifyLoginTimeout(int original)
     {
-        return 1800;
+        return UTTimeoutManager.loginTimeoutTicks;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTLoginTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTLoginTimeoutMixin.java
@@ -1,0 +1,18 @@
+package mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin;
+
+import net.minecraft.server.network.NetHandlerLoginServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+// Courtesy of jchung01, TheRandomLabs (RandomPatches)
+@Mixin(value = NetHandlerLoginServer.class)
+public class UTLoginTimeoutMixin
+{
+    @ModifyConstant(method = "update", constant = @Constant(intValue = 600))
+    private int utModifyLoginTimeout(int original)
+    {
+        return 1800;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTServerReadTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTServerReadTimeoutMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.util.text.ITextComponent;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import mod.acgaming.universaltweaks.tweaks.misc.timeouts.UTTimeoutManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,7 +26,7 @@ public class UTServerReadTimeoutMixin
         at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetHandlerPlayServer;disconnect(Lnet/minecraft/util/text/ITextComponent;)V"))
     private void utKeepAliveUntilReadTimeout(NetHandlerPlayServer instance, ITextComponent textComponent, Operation<Void> original, @Local long currentTimeMillis)
     {
-        if (currentTimeMillis - field_194402_f >= 90)
+        if (currentTimeMillis - field_194402_f >= UTTimeoutManager.readTimeoutMillis)
         {
             original.call(instance, textComponent);
         }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTServerReadTimeoutMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/timeouts/mixin/UTServerReadTimeoutMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin;
+
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.util.text.ITextComponent;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+// Courtesy of jchung01, TheRandomLabs (RandomPatches)
+@Mixin(value = NetHandlerPlayServer.class)
+public class UTServerReadTimeoutMixin
+{
+    // lastPingTime, not sure why this is MCP name
+    @Shadow
+    private long field_194402_f;
+
+    @WrapOperation(method = "update",
+        slice = @Slice(from = @At(value = "CONSTANT", args = "stringValue=keepAlive"),
+            to = @At(value = "INVOKE", target = "Lnet/minecraft/profiler/Profiler;endSection()V")),
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetHandlerPlayServer;disconnect(Lnet/minecraft/util/text/ITextComponent;)V"))
+    private void utKeepAliveUntilReadTimeout(NetHandlerPlayServer instance, ITextComponent textComponent, Operation<Void> original, @Local long currentTimeMillis)
+    {
+        if (currentTimeMillis - field_194402_f >= 90)
+        {
+            original.call(instance, textComponent);
+        }
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -152,6 +152,7 @@ cfg.universaltweaks.tweaks.misc.loadsounds=Load Sounds
 cfg.universaltweaks.tweaks.misc.pickupnotification=Pickup Notification
 cfg.universaltweaks.tweaks.misc.smoothscrolling=Smooth Scrolling
 cfg.universaltweaks.tweaks.misc.stg=Swing Through Grass
+cfg.universaltweaks.tweaks.misc.timeouts=Connection Timeouts
 cfg.universaltweaks.tweaks.misc.toastcontrol=Toast Control
 cfg.universaltweaks.tweaks.performance.entityradiuscheck=Entity Radius Check
 cfg.universaltweaks.tweaks.world.chunkgenlimit=Chunk Gen Limit

--- a/src/main/resources/mixins.tweaks.misc.timeouts.client.json
+++ b/src/main/resources/mixins.tweaks.misc.timeouts.client.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTClientReadTimeoutMixin"]
+}

--- a/src/main/resources/mixins.tweaks.misc.timeouts.json
+++ b/src/main/resources/mixins.tweaks.misc.timeouts.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.timeouts.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTLoginTimeoutMixin", "UTServerReadTimeoutMixin"]
+}


### PR DESCRIPTION
Adds read/login timeout patches from RandomPatches (RP). Helps slower PCs connect to servers in a large modpack. I did not include the `keepAlivePacketInterval` patch because it didn't seem necessary judging from the pinned issues in RP's repo.

Shouldn't cause issues if RandomPatches is installed, RP's modifications either take priority or stack with these.