### PR TITLE
Downgrade Potion Recipes Log Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ All changes are toggleable via config files.
     * **Fix Deep Dark Stats:** Fixes Mob Attack and Health Statistics being repeatedly doubled
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.
     * **Creative Mill Harvestability:** Fixes the Creative Mill Generator not respecting the Creative Block Breaking config
+    * **Downgrade Potion Recipes Log Level:** Downgrades the message when creating a potion recipe from info to a debug
 * **Forestry**
     * **Arborist Villager Trades:** Adds custom emerald to germling trades to the arborist villager
     * **Disable Bee Damage Armor Bypass:** Disables damage caused by bees bypassing player armor

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -566,6 +566,11 @@ public class UTConfigMods
         @Config.Name("Mutable Machine Block Drops")
         @Config.Comment("Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list")
         public boolean utMutableBlockDrops = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Downgrade Potion Recipes Log Level")
+        @Config.Comment("Downgrades the message when creating a potion recipe from info to a debug")
+        public boolean utDowngradePotionLogging = true;
     }
 
     public static class ForestryCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -69,6 +69,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
             put("mixins.mods.extrautilities.mutabledrops.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);
+            put("mixins.mods.extrautilities.potionlogging.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDowngradePotionLogging);
             put("mixins.mods.extrautilities.radar.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utCatchRadarException);
             put("mixins.mods.forestry.cocoa.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utFOCocoaBeansToggle);
             put("mixins.mods.forestry.dupes.json", () -> loaded("forestry") && UTConfigMods.FORESTRY.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/potionlogging/mixin/UTBrewingEnergyRecipeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/potionlogging/mixin/UTBrewingEnergyRecipeMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.potionlogging.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.rwtema.extrautils2.utils.LogHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "com.rwtema.extrautils2.machine.BrewingEnergyRecipe", remap = false)
+public abstract class UTBrewingEnergyRecipeMixin
+{
+    @WrapOperation(method = "checkTypes", at = @At(value = "INVOKE", target = "Lcom/rwtema/extrautils2/utils/LogHelper;info(Ljava/lang/Object;[Ljava/lang/Object;)V"))
+    private static void utDowngradePotionLogging(Object info, Object[] info2, Operation<Void> original)
+    {
+        if (!UTConfigMods.EXTRA_UTILITIES.utDowngradePotionLogging) original.call(info, info2);
+        else LogHelper.fine(info, info2);
+    }
+}

--- a/src/main/resources/mixins.mods.extrautilities.potionlogging.json
+++ b/src/main/resources/mixins.mods.extrautilities.potionlogging.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.potionlogging.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBrewingEnergyRecipeMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- downgrade the potion log level that Extra Utilities 2 runs when finishing loading, which logs a line for every potion in the game, from `info` to `debug`. (default: `true`)

currently, it spams your log with every potion effect when starting the game.