### PR TITLE
Random Things Anvil Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ All changes are toggleable via config files.
 * **Quark**
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Random Things**
+  * **Anvil Crafting Fix:** Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart
 * **Railcraft**
   * **No Beta Warning:** Disables the beta message warning on world join
 * **Requious Frakto**

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Quark**
     * **Duplication Fixes:** Fixes various duplication exploits
+* **Random Things**
 * **Railcraft**
   * **No Beta Warning:** Disables the beta message warning on world join
 * **Requious Frakto**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -114,6 +114,7 @@ final def mod_dependencies = [
     'curse.maven:projectredworld-229049:2745551'                      : [debug_project_red],
     'curse.maven:quark-243121:2924091'                                : [debug_quark],
     'curse.maven:railcraft-51195:3853491'                             : [debug_railcraft],
+    'curse.maven:random-things-59816:2905241'                         : [debug_random_things],
     'curse.maven:reach-fix-556777:4633407'                            : [debug_cqrepoured],
     'curse.maven:reborn-core-237903:3330308'                          : [debug_tech_reborn],
     'curse.maven:redstone-flux-270789:2920436'                        : [debug_thermal_expansion],

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,7 @@ debug_opencomputers = false
 debug_project_red = false
 debug_quark = false
 debug_railcraft = false
+debug_random_things = false
 debug_requious_frakto = false
 debug_reskillable = false
 debug_rftools = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -195,6 +195,10 @@ public class UTConfigMods
     @Config.Name("Railcraft")
     public static final RailcraftCategory RAILCRAFT = new RailcraftCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.randomthings")
+    @Config.Name("Random Things")
+    public static final RandomThingsCategory RANDOM_THINGS = new RandomThingsCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.requiousfrakto")
     @Config.Name("Requious Frakto")
     public static final RequiousFraktoCategory REQUIOUS_FRAKTO = new RequiousFraktoCategory();
@@ -818,6 +822,10 @@ public class UTConfigMods
         @Config.Name("No Beta Warning")
         @Config.Comment("Disables the beta message warning on world join")
         public boolean utNoBetaWarningToggle = true;
+    }
+
+    public static class RandomThingsCategory
+    {
     }
 
     public static class RequiousFraktoCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -826,6 +826,10 @@ public class UTConfigMods
 
     public static class RandomThingsCategory
     {
+        @Config.RequiresMcRestart
+        @Config.Name("Anvil Crafting Fix")
+        @Config.Comment("Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart")
+        public boolean utAnvilCraftFix = true;
     }
 
     public static class RequiousFraktoCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -92,6 +92,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.openblocks.json", () -> loaded("openblocks") && UTConfigMods.OPEN_BLOCKS.utLastStandFixToggle);
             put("mixins.mods.opencomputers.json", () -> loaded("opencomputers") && UTConfigMods.OPEN_COMPUTERS.utPacketLeakFixToggle);
             put("mixins.mods.quark.dupes.json", () -> loaded("quark") && UTConfigMods.QUARK.utDuplicationFixesToggle);
+            put("mixins.mods.randomthings.anvil.json", () -> loaded("randomthings") && UTConfigMods.RANDOM_THINGS.utAnvilCraftFix);
             put("mixins.mods.requiousfrakto.json", () -> loaded("requious") && UTConfigMods.REQUIOUS_FRAKTO.utParticleFixesToggle);
             put("mixins.mods.reskillable.json", () -> loaded("reskillable"));
             put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/anvil/mixin/UTAnvilCraftFixMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/anvil/mixin/UTAnvilCraftFixMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.randomthings.anvil.mixin;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.AnvilUpdateEvent;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import lumien.randomthings.handler.RTEventHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(value = RTEventHandler.class, remap = false)
+public class UTAnvilCraftFixMixin
+{
+    @WrapOperation(method = "anvilUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/AnvilUpdateEvent;setOutput(Lnet/minecraft/item/ItemStack;)V"))
+    private void utFixRecipeVoiding(AnvilUpdateEvent instance, ItemStack item, Operation<Void> original)
+    {
+        if (!UTConfigMods.RANDOM_THINGS.utAnvilCraftFix) original.call(instance, item);
+        else original.call(instance, item.copy());
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -94,6 +94,7 @@ cfg.universaltweaks.modintegration.projectred=ProjectRed
 cfg.universaltweaks.modintegration.quark=Quark
 cfg.universaltweaks.modintegration.rftoolsdimensions=RFTools Dimensions
 cfg.universaltweaks.modintegration.railcraft=Railcraft
+cfg.universaltweaks.modintegration.randomthings=Random Things
 cfg.universaltweaks.modintegration.requiousfrakto=Requious Frakto
 cfg.universaltweaks.modintegration.roost=Roost
 cfg.universaltweaks.modintegration.steamworld=SteamWorld

--- a/src/main/resources/mixins.mods.randomthings.anvil.json
+++ b/src/main/resources/mixins.mods.randomthings.anvil.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.randomthings.anvil.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTAnvilCraftFixMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- adds Random Things to the dev environment.
- fixes a bug wherein crafting* the output of an anvil recipe would modify the recipe itself, meaning that the recipe could only be crafted* once before requiring the game to be restarted. (default: `true`)

*only applied to picking up the itemstack in your hand, using the number keys to obtain the output doesnt cause this effect. will the wonders never cease?