### PR TITLE
Set gui default text color

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1451,6 +1451,16 @@ public class UTConfigTweaks
         @Config.Comment("Sets the default difficulty for newly generated worlds")
         public EnumDifficulty utDefaultDifficulty = EnumDifficulty.NORMAL;
 
+
+        @Config.RequiresMcRestart
+        @Config.Name("Default Gui Text Color")
+        @Config.Comment
+            ({
+                "Sets the default gui text color (hex rgb code). It is useful for dark mode texture pack",
+                "404040 for vanilla default"
+            })
+        public String utDefaultGuiTextColor = "404040";
+
         @Config.RequiresMcRestart
         @Config.Name("Disable Advancements")
         @Config.Comment("Prevents the advancement system from loading entirely")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -201,6 +201,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.misc.credits.json", () -> UTConfigTweaks.MISC.utSkipCreditsToggle);
             put("mixins.tweaks.misc.glint.enchantedbook.json", () -> UTConfigTweaks.MISC.utDisableEnchantmentBookGlint);
             put("mixins.tweaks.misc.glint.potion.json", () -> UTConfigTweaks.MISC.utDisablePotionGlint);
+            put("mixins.tweaks.misc.gui.defaultguitextcolor.json", () -> !UTConfigTweaks.MISC.utDefaultGuiTextColor.equals("404040"));
             put("mixins.tweaks.misc.gui.keybindlistentry.json", () -> UTConfigTweaks.MISC.utPreventKeybindingEntryOverflow);
             put("mixins.tweaks.misc.gui.lanserverproperties.json", () -> UTConfigTweaks.MISC.utLANServerProperties);
             put("mixins.tweaks.misc.gui.overlaymessage.json", () -> UTConfigTweaks.MISC.utOverlayMessageHeight != -4);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/mixin/UTDefaultGuiTextColor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/mixin/UTDefaultGuiTextColor.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.tweaks.misc.gui.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+// Courtesy of youyihj
+@Mixin(FontRenderer.class)
+public class UTDefaultGuiTextColor
+{
+    @ModifyVariable(method = "drawString(Ljava/lang/String;FFIZ)I", at = @At("HEAD"), argsOnly = true)
+    private int utSetDefaultGuiTextColor(int color)
+    {
+        if (color == 0x404040) {
+            return Integer.parseInt(UTConfigTweaks.MISC.utDefaultGuiTextColor, 16);
+        } else {
+            return color;
+        }
+    }
+}

--- a/src/main/resources/mixins.tweaks.misc.gui.defaultguitextcolor.json
+++ b/src/main/resources/mixins.tweaks.misc.gui.defaultguitextcolor.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.gui.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTDefaultGuiTextColor"]
+}


### PR DESCRIPTION
Adds a way to change actual color when font render draws color in `#404040` color. It is helpful for dark mode texture pack.