### PR TITLE
Miscellaneous EnderIO fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ All changes are toggleable via config files.
 * **Ender IO**
     * **Fix Chorus Farming StackOverflow:** Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow
     * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one
+    * **Save Filter Cycle Buttons Properly:** Fixes an issue where Cycle Buttons for Damage do not report being clicked when in the Picker Overlay, preventing changing Damage values until clicked again
 * **Ender Storage**
     * **Fix Frequency Tracking:** Fixes storage frequencies being tracked multiple times
 * **Epic Siege Mod**

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ All changes are toggleable via config files.
     * **Emoji Context:** Improves emoji context calculation to improve fps when rendering a lot of text
 * **Ender IO**
     * **Fix Chorus Farming StackOverflow:** Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow
+    * **Fix Soul Binder JEI Appearance:** Fixes the Soul Binder having empty ingredients or displaying filled soul vials in the output slot incorrectly
     * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one
     * **Save Filter Cycle Buttons Properly:** Fixes an issue where Cycle Buttons for Damage do not report being clicked when in the Picker Overlay, preventing changing Damage values until clicked again
 * **Ender Storage**

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ All changes are toggleable via config files.
     * **Ingredient Matching:** Changes item matching code to CraftTweaker's ingredient matching system, fixes item NBT issues
 * **Mekanism**
     * **Duplication Fixes:** Fixes various duplication exploits
+* **MmmMmmMmmMmm**
+    * **Copy Armor Stacks to Dummy:** Instead of deleting the original itemstack being equipped, use a copy of it and do not drop armor
 * **Mob Stages**
     * **Spawning Rules Fixes:** Fixes mob replacement ignoring entity spawning rules
 * **Modular Routers**

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ All changes are toggleable via config files.
 * **Emojicord**
     * **Emoji Context:** Improves emoji context calculation to improve fps when rendering a lot of text
 * **Ender IO**
-    * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one 
+    * **Fix Chorus Farming StackOverflow:** Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow
+    * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one
 * **Ender Storage**
     * **Fix Frequency Tracking:** Fixes storage frequencies being tracked multiple times
 * **Epic Siege Mod**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -134,6 +134,7 @@ final def mod_dependencies = [
     'curse.maven:tardis-290247:2903453'                               : [debug_tardis],
     'curse.maven:tech-reborn-233564:2966851'                          : [debug_tech_reborn],
     'curse.maven:teslacorelib-254602:2891841'                         : [debug_industrial_foregoing],
+    'curse.maven:test_dummy-225738:2503041'                           : [debug_test_dummy],
     'curse.maven:thaumcraft-223628:2629023'                           : [debug_thaumcraft, debug_thaumic_wonders],
     'curse.maven:thaumicwonders-316704:2787954'                       : [debug_thaumic_wonders],
     'curse.maven:the-erebus-220698:3211974'                           : [debug_erebus],

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,6 +62,7 @@ debug_steamworld = false
 debug_storage_drawers = false
 debug_tardis = false
 debug_tech_reborn = false
+debug_test_dummy = false
 debug_thaumcraft = false
 debug_thaumic_wonders = false
 debug_the_farlanders = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -243,6 +243,10 @@ public class UTConfigMods
     @Config.Name("Tech Reborn")
     public static final TechRebornCategory TECH_REBORN = new TechRebornCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.test_dummy")
+    @Config.Name("MmmMmmMmmMmm")
+    public static final TestDummyCategory TEST_DUMMY = new TestDummyCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.tc")
     @Config.Name("Thaumcraft")
     public static final ThaumcraftCategory THAUMCRAFT = new ThaumcraftCategory();
@@ -938,6 +942,18 @@ public class UTConfigMods
         @Config.Name("Optimized Rolling Machine")
         @Config.Comment("Optimizes the Rolling Machine to reduce tick time")
         public boolean utOptimizeRollingMachineToggle = true;
+    }
+
+    public static class TestDummyCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Copy Armor Stacks to Dummy")
+        @Config.Comment
+            ({
+                "Instead of deleting the original itemstack being equipped, use a copy of it and do not drop armor.",
+                "This is primarily relevant for fixing a duplication bug involving EnderIO Armor and its interact with being \"destroyed\""
+            })
+        public boolean utCopyArmor = true;
     }
 
     public static class ThaumcraftCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -527,6 +527,11 @@ public class UTConfigMods
     public static class EnderIOCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Fix Chorus Farming StackOverflow")
+        @Config.Comment("Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow")
+        public boolean utChorusStackOverflow = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Replace Obelisk Renderer")
         @Config.Comment("Fixes client-side memory leak by replacing obelisk renderer with a simpler one")
         public boolean utReplaceItemRenderer = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -536,6 +536,11 @@ public class UTConfigMods
         public boolean utChorusStackOverflow = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fix Soul Binder JEI Appearance")
+        @Config.Comment("Fix the Soul Binder having empty ingredients or displaying filled soul vials in the output slot incorrectly")
+        public boolean utFixSoulBinderJEI = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Replace Obelisk Renderer")
         @Config.Comment("Fixes client-side memory leak by replacing obelisk renderer with a simpler one")
         public boolean utReplaceItemRenderer = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -539,6 +539,11 @@ public class UTConfigMods
         @Config.Name("Replace Obelisk Renderer")
         @Config.Comment("Fixes client-side memory leak by replacing obelisk renderer with a simpler one")
         public boolean utReplaceItemRenderer = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Save Filter Cycle Buttons Properly")
+        @Config.Comment("Fixes an issue where Cycle Buttons for Damage do not report being clicked when in the Picker Overlay, preventing changing Damage values until clicked again")
+        public boolean utSaveFilterCycleButtonProperly = true;
     }
 
     public static class EnderStorageCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -117,12 +117,12 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.tweaks.entities.spawning.golem.json", () -> UTConfigTweaks.ENTITIES.NO_GOLEMS.utNGIronGolemToggle || UTConfigTweaks.ENTITIES.NO_GOLEMS.utNGSnowGolemToggle || UTConfigTweaks.ENTITIES.NO_GOLEMS.utNGWitherToggle);
             put("mixins.tweaks.entities.spawning.husk.json", () -> UTConfigTweaks.ENTITIES.utHuskStraySpawningToggle);
             put("mixins.tweaks.entities.spawning.portal.json", () -> UTConfigTweaks.ENTITIES.utPortalSpawningToggle);
+            put("mixins.tweaks.entities.spawning.skeletontrap.json", () -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utSkeletonTrapSpawningToggle);
             put("mixins.tweaks.entities.spawning.stray.json", () -> UTConfigTweaks.ENTITIES.utHuskStraySpawningToggle);
             put("mixins.tweaks.entities.speed.boat.json", () -> UTConfigTweaks.ENTITIES.utBoatSpeed != 0.04D);
             put("mixins.tweaks.entities.speed.cobweb.json", () -> UTConfigTweaks.ENTITIES.COBWEB_SLOWNESS.utCobwebSlownessToggle);
             put("mixins.tweaks.entities.speed.player.json", () -> UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle);
             put("mixins.tweaks.entities.taming.horse.json", () -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utTamingUndeadHorsesToggle);
-            put("mixins.tweaks.entities.spawning.skeletontrap.json", () -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utSkeletonTrapSpawningToggle);
             put("mixins.tweaks.entities.trading.json", () -> UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle);
             put("mixins.tweaks.entities.voidteleport.json", () -> UTConfigTweaks.ENTITIES.VOID_TELEPORT.utVoidTeleportToggle);
             put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);
@@ -189,8 +189,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             put("mixins.mods.emojicord.emojicontext.json", () -> UTConfigMods.EMOJICORD.utEmojiContextToggle && emojicordLoaded);
             put("mixins.tweaks.blocks.betterplacement.json", () -> UTConfigTweaks.BLOCKS.BETTER_PLACEMENT.utBetterPlacementToggle);
             put("mixins.tweaks.blocks.hitdelay.json", () -> UTConfigTweaks.BLOCKS.utBlockHitDelay != 5);
-            put("mixins.tweaks.entities.jumping.autojump.json", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
             put("mixins.tweaks.entities.burning.player.json", () -> UTConfigTweaks.ENTITIES.utFirstPersonBurningOverlay != -0.3D);
+            put("mixins.tweaks.entities.jumping.autojump.json", () -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
             put("mixins.tweaks.entities.playerdismount.json", () -> UTConfigTweaks.MISC.utUseSeparateDismountKey);
             put("mixins.tweaks.entities.playerf5.json", () -> UTConfigTweaks.ENTITIES.utThirdPersonIgnoresNonSolidBlocks);
             put("mixins.tweaks.items.attackcooldown.client.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -105,6 +105,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.tconstruct.toolcustomization.json", () -> loaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle);
             put("mixins.mods.tconstruct.toolcustomization.plustic.json", () -> loaded("tconstruct") && loaded("plustic") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle);
             put("mixins.mods.techreborn.json", () -> loaded("techreborn"));
+            put("mixins.mods.testdummy.copyarmor.json", () -> loaded("testdummy") && UTConfigMods.TEST_DUMMY.utCopyArmor);
             put("mixins.mods.thaumcraft.foci.focuseffects.json", () -> loaded("thaumcraft"));
             put("mixins.mods.thaumcraft.foci.focusmediums.json", () -> loaded("thaumcraft"));
             put("mixins.mods.thaumcraft.json", () -> loaded("thaumcraft"));

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -63,6 +63,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
             put("mixins.mods.enderio.chorus.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);
             put("mixins.mods.enderio.cyclebutton.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utSaveFilterCycleButtonProperly);
+            put("mixins.mods.enderio.soulbinderjei.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utFixSoulBinderJEI);
             put("mixins.mods.enderstorage.json", () -> loaded("enderstorage") && UTConfigMods.ENDER_STORAGE.utFrequencyTrackFixToggle);
             put("mixins.mods.epicsiegemod.json", () -> loaded("epicsiegemod"));
             put("mixins.mods.erebus.cabbage.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utCabbageDrop);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -61,6 +61,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding"));
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
+            put("mixins.mods.enderio.chorus.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);
             put("mixins.mods.enderstorage.json", () -> loaded("enderstorage") && UTConfigMods.ENDER_STORAGE.utFrequencyTrackFixToggle);
             put("mixins.mods.epicsiegemod.json", () -> loaded("epicsiegemod"));
             put("mixins.mods.erebus.cabbage.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utCabbageDrop);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -62,6 +62,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
             put("mixins.mods.enderio.chorus.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);
+            put("mixins.mods.enderio.cyclebutton.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utSaveFilterCycleButtonProperly);
             put("mixins.mods.enderstorage.json", () -> loaded("enderstorage") && UTConfigMods.ENDER_STORAGE.utFrequencyTrackFixToggle);
             put("mixins.mods.epicsiegemod.json", () -> loaded("epicsiegemod"));
             put("mixins.mods.erebus.cabbage.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utCabbageDrop);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -98,8 +98,8 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));
             put("mixins.mods.roost.contenttweaker.json", () -> loaded("contenttweaker"));
             put("mixins.mods.simpledifficulty.json", () -> loaded("simpledifficulty"));
-            put("mixins.mods.steamworld.json", () -> loaded("steamworld") && UTConfigMods.STEAMWORLD.utSkyOfOldFixToggle);
             put("mixins.mods.spiceoflife.dupes.json", () -> loaded("spiceoflife") && UTConfigMods.SPICE_OF_LIFE.utDuplicationFixesToggle);
+            put("mixins.mods.steamworld.json", () -> loaded("steamworld") && UTConfigMods.STEAMWORLD.utSkyOfOldFixToggle);
             put("mixins.mods.tconstruct.json", () -> loaded("tconstruct"));
             put("mixins.mods.tconstruct.oredictcache.json", () -> loaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle);
             put("mixins.mods.tconstruct.toolcustomization.json", () -> loaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConToolCustomizationToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -23,7 +23,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.compactmachines.memory.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utMemoryLeakFixToggle);
             put("mixins.mods.compactmachines.render.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle);
             put("mixins.mods.crafttweaker.json", () -> loaded("crafttweaker"));
-            put("mixins.mods.enderio.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
+            put("mixins.mods.enderio.itemrender.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
             put("mixins.mods.hwyla.json", () -> loaded("waila"));
             put("mixins.mods.ironchests.json", () -> loaded("ironchest") && UTConfigMods.IRON_CHESTS.utReplaceItemRenderer);
             put("mixins.mods.modularrouters.json", () -> loaded("modularrouters") && UTConfigMods.MODULAR_ROUTERS.utParticleThreadToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/chorus/mixin/UTChorusWalkerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/chorus/mixin/UTChorusWalkerMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.enderio.chorus.mixin;
+
+import java.util.Set;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "crazypants.enderio.base.farming.farmers.ChorusFarmer$ChorusWalker", remap = false)
+public abstract class UTChorusWalkerMixin
+{
+    @Unique
+    private final Set<BlockPos> universalTweaks$checkedPositions = new ObjectOpenHashSet<>();
+
+    /**
+     * @author WaitingIdly
+     * @reason Prevent StackOverflows by skipping previously already checked positions.
+     */
+    @Inject(method = "collect", at = @At("HEAD"), cancellable = true)
+    protected void utIgnoreDuplicatePositions(BlockPos pos, EnumFacing from, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!universalTweaks$checkedPositions.add(pos)) cir.setReturnValue(false);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTBasicItemFilterGuiAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTBasicItemFilterGuiAccessor.java
@@ -1,0 +1,14 @@
+package mod.acgaming.universaltweaks.mods.enderio.cyclebutton.mixin;
+
+import com.enderio.core.client.gui.button.CycleButton;
+import crazypants.enderio.base.filter.gui.BasicItemFilterGui;
+import crazypants.enderio.base.filter.gui.DamageModeIconHolder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = BasicItemFilterGui.class, remap = false)
+public interface UTBasicItemFilterGuiAccessor
+{
+    @Accessor("damageB")
+    CycleButton<DamageModeIconHolder> getDamageB();
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTPickerOverlayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTPickerOverlayMixin.java
@@ -1,0 +1,44 @@
+package mod.acgaming.universaltweaks.mods.enderio.cyclebutton.mixin;
+
+import java.io.IOException;
+
+import com.enderio.core.api.client.gui.IGuiScreen;
+import com.enderio.core.client.gui.button.CycleButton;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "com.enderio.core.client.gui.button.CycleButton$PickerOverlay", remap = false)
+public abstract class UTPickerOverlayMixin
+{
+    @Shadow
+    CycleButton<?> cycleButton;
+
+    /**
+     * @author WaitingIdly
+     * @reason Update the filter that the damage button was changed when
+     * interacting with any of internal buttons of the picker overlay.
+     * This is required to ensure that the filter damage setting is saved.
+     */
+    @Inject(method = "handleMouseInput", at = @At(value = "INVOKE", target = "Lcom/enderio/core/client/gui/button/CycleButton;setMode(Ljava/lang/Enum;)V", shift = At.Shift.AFTER))
+    private void utNotifyFilterOfChange(int x, int y, int b, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigMods.ENDER_IO.utSaveFilterCycleButtonProperly) return;
+        try
+        {
+            if (cycleButton instanceof UTTooltipButtonAccessor)
+            {
+                IGuiScreen gui = ((UTTooltipButtonAccessor) cycleButton).getGui();
+                if (gui instanceof UTBasicItemFilterGuiAccessor)
+                {
+                    gui.doActionPerformed(((UTBasicItemFilterGuiAccessor) gui).getDamageB());
+                }
+            }
+        }
+        catch (IOException ignored) {}
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTTooltipButtonAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/cyclebutton/mixin/UTTooltipButtonAccessor.java
@@ -1,0 +1,14 @@
+package mod.acgaming.universaltweaks.mods.enderio.cyclebutton.mixin;
+
+import com.enderio.core.api.client.gui.IGuiScreen;
+import com.enderio.core.client.gui.button.TooltipButton;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = TooltipButton.class, remap = false)
+public interface UTTooltipButtonAccessor
+{
+    @Accessor("gui")
+    @NotNull IGuiScreen getGui();
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/itemrender/mixin/UTObeliskSpecialRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/itemrender/mixin/UTObeliskSpecialRendererMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.enderio.mixin;
+package mod.acgaming.universaltweaks.mods.enderio.itemrender.mixin;
 
 import java.util.Random;
 import javax.annotation.Nonnull;

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/soulbinderjei/mixin/UTSoulBinderRecipeCategoryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/soulbinderjei/mixin/UTSoulBinderRecipeCategoryMixin.java
@@ -1,0 +1,45 @@
+package mod.acgaming.universaltweaks.mods.enderio.soulbinderjei.mixin;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import crazypants.enderio.machines.integration.jei.SoulBinderRecipeCategory;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.recipe.IFocus;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import static crazypants.enderio.base.init.ModObject.itemSoulVial;
+
+// Courtesy of WaitingIdly
+@Mixin(value = SoulBinderRecipeCategory.class, remap = false)
+public abstract class UTSoulBinderRecipeCategoryMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason ensure list replacing prior entries isn't empty,
+     * as this will cause JEI to appear in an incorrect state.
+     */
+    @WrapWithCondition(method = "setRecipe(Lmezz/jei/api/gui/IRecipeLayout;Lcrazypants/enderio/machines/integration/jei/SoulBinderRecipeCategory$SoulBinderRecipeWrapper;Lmezz/jei/api/ingredients/IIngredients;)V", at = @At(value = "INVOKE", target = "Lmezz/jei/api/gui/IGuiItemStackGroup;set(ILjava/util/List;)V"))
+    private boolean utEnsureListNotEmpty(IGuiItemStackGroup instance, int i, List<?> list)
+    {
+        return !list.isEmpty();
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason check that the focus is not an soul vial, as
+     * checking for recipes that output that will cause
+     * soul vials to replace the second output slot on all recipes.
+     */
+    @ModifyExpressionValue(method = "setRecipe(Lmezz/jei/api/gui/IRecipeLayout;Lcrazypants/enderio/machines/integration/jei/SoulBinderRecipeCategory$SoulBinderRecipeWrapper;Lmezz/jei/api/ingredients/IIngredients;)V", at = @At(value = "INVOKE", target = "Lcrazypants/enderio/util/CapturedMob;containsSoul(Lnet/minecraft/item/ItemStack;)Z", ordinal = 1))
+    private boolean utCheckFocusNotVial(boolean original, @Local IFocus<?> focus)
+    {
+        // at this point, focus.getValue() has already been checked if its an instanceof ItemStack.
+        return original && ((ItemStack) focus.getValue()).getItem() != itemSoulVial.getItemNN();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/testdummy/copyarmor/mixin/UTEntityDummyMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/testdummy/copyarmor/mixin/UTEntityDummyMixin.java
@@ -1,0 +1,42 @@
+package mod.acgaming.universaltweaks.mods.testdummy.copyarmor.mixin;
+
+import net.minecraft.item.ItemStack;
+
+import boni.dummy.EntityDummy;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(value = EntityDummy.class, remap = false)
+public abstract class UTEntityDummyMixin
+{
+    /**
+     * @author WaitingIdly
+     */
+    @WrapWithCondition(method = "equipArmor", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;shrink(I)V", remap = true))
+    private boolean utDisableShrink(ItemStack instance, int quantity)
+    {
+        return !UTConfigMods.TEST_DUMMY.utCopyArmor;
+    }
+
+    /**
+     * @author WaitingIdly
+     */
+    @WrapWithCondition(method = {"equipArmor", "removeArmor"}, at = @At(value = "INVOKE", target = "Lboni/dummy/EntityDummy;entityDropItem(Lnet/minecraft/item/ItemStack;F)Lnet/minecraft/entity/item/EntityItem;", remap = true))
+    private boolean utDisableDrop(EntityDummy instance, ItemStack itemStack, float v)
+    {
+        return !UTConfigMods.TEST_DUMMY.utCopyArmor;
+    }
+
+    /**
+     * @author WaitingIdly
+     */
+    @WrapWithCondition(method = {"dismantle"}, at = @At(value = "INVOKE", target = "Lboni/dummy/EntityDummy;dropEquipment(ZI)V", remap = true))
+    private boolean utDisableDismantleEquipmentDrop(EntityDummy instance, boolean b, int i)
+    {
+        return !UTConfigMods.TEST_DUMMY.utCopyArmor;
+    }
+
+}

--- a/src/main/resources/mixins.mods.enderio.chorus.json
+++ b/src/main/resources/mixins.mods.enderio.chorus.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderio.chorus.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTChorusWalkerMixin"]
+}

--- a/src/main/resources/mixins.mods.enderio.cyclebutton.json
+++ b/src/main/resources/mixins.mods.enderio.cyclebutton.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderio.cyclebutton.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBasicItemFilterGuiAccessor", "UTPickerOverlayMixin", "UTTooltipButtonAccessor"]
+}

--- a/src/main/resources/mixins.mods.enderio.itemrender.json
+++ b/src/main/resources/mixins.mods.enderio.itemrender.json
@@ -1,5 +1,5 @@
 {
-  "package": "mod.acgaming.universaltweaks.mods.enderio.mixin",
+  "package": "mod.acgaming.universaltweaks.mods.enderio.itemrender.mixin",
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",

--- a/src/main/resources/mixins.mods.enderio.soulbinderjei.json
+++ b/src/main/resources/mixins.mods.enderio.soulbinderjei.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderio.soulbinderjei.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTSoulBinderRecipeCategoryMixin"]
+}

--- a/src/main/resources/mixins.mods.testdummy.copyarmor.json
+++ b/src/main/resources/mixins.mods.testdummy.copyarmor.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.testdummy.copyarmor.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEntityDummyMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- fix Chorus Farming StackOverflow via ensuring duplicate positions are not checked. (default: `true`)
- fix broken entries appearing in the Soul Binder JEI category via skipping the output if its focused on a soul vial and not overriding the contents of a slot if the list is empty. (default: `true`)
- fix the damage panel for advanced filters not saving the state selected. (default: `true`)
- fix a duplication issue involving `MmmMmmMmmMmm` via making the Dummy copy the equipment and not drop any instead of consume the equipment from the main hand. (default: `true`)
  - i investigated multiple ways to fix this problem without requiring this step and couldnt identify such a way. it is caused because `EntityDummy#equipArmor` reduces the stack size during `EntityLiving#processInitialInteract`, and if that stack is empty, it uses a previously copied instance to fire `PlayerDestroyItemEvent`, which EnderIO subscribes to and when it outputs all the items.
  - this may need more testing to ensure there isnt some edge case in which the armor can be extracted
- sorted the mixin maps alphabetically, as a few were out of order.
