### PR TITLE
Use primitive Supplier and improve obsolete mod list handling

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -234,7 +234,7 @@ public class UniversalTweaks
         if (Loader.isModLoaded("tconstruct") && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle) UTOreDictCache.onLoadComplete();
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle) UTEntityRadiusCheck.onLoadComplete();
         if (UTConfigGeneral.DEBUG.utLoadingTimeToggle) LOGGER.info("The game loaded in approximately {} seconds", (System.currentTimeMillis() - UTLoadingPlugin.launchTime) / 1000F);
-        if (UTObsoleteModsHandler.showObsoleteMods && UTObsoleteModsHandler.obsoleteModsMessage().size() > 5 && !UTConfigGeneral.DEBUG.utBypassIncompatibilityToggle)
+        if (UTObsoleteModsHandler.hasObsoleteModsMessage())
         {
             for (String line : UTObsoleteModsHandler.obsoleteModsMessage())
             {

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigGeneral.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigGeneral.java
@@ -46,7 +46,7 @@ public class UTConfigGeneral
             if (event.getModID().equals(UniversalTweaks.MODID))
             {
                 ConfigManager.sync(UniversalTweaks.MODID, Config.Type.INSTANCE);
-                UTObsoleteModsHandler.showObsoleteMods = true;
+                UTObsoleteModsHandler.resetObsoleteMods();
             }
         }
     }

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigGeneral.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigGeneral.java
@@ -46,7 +46,7 @@ public class UTConfigGeneral
             if (event.getModID().equals(UniversalTweaks.MODID))
             {
                 ConfigManager.sync(UniversalTweaks.MODID, Config.Type.INSTANCE);
-                UTObsoleteModsHandler.resetObsoleteMods();
+                UTObsoleteModsHandler.setHasShownObsoleteMods(false);
             }
         }
     }

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -1,7 +1,7 @@
 package mod.acgaming.universaltweaks.core;
 
 import java.util.*;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableMap;
@@ -35,7 +35,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
 
     public static long launchTime;
 
-    private static final Map<String, Supplier<Boolean>> serversideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> serversideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("mixins.tweaks.misc.buttons.snooper.server.json", () -> UTConfigTweaks.MISC.utSnooperToggle);
@@ -43,7 +43,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         }
     });
 
-    private static final Map<String, Supplier<Boolean>> commonMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> commonMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("mixins.bugfixes.blocks.comparatortiming.json", () -> UTConfigBugfixes.BLOCKS.utComparatorTimingToggle);
@@ -170,7 +170,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
         }
     });
 
-    private static final Map<String, Supplier<Boolean>> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("mixins.bugfixes.blocks.banner.json", () -> UTConfigBugfixes.BLOCKS.utBannerBoundingBoxToggle && !renderLibLoaded);
@@ -307,8 +307,8 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
             // Causes crashes in dev env only
             return !mixinConfig.equals("mixins.tweaks.misc.armorcurve.json");
         }
-        Supplier<Boolean> sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
-        Supplier<Boolean> commonSupplier = commonMixinConfigs.get(mixinConfig);
-        return sidedSupplier != null ? sidedSupplier.get() : commonSupplier == null || commonSupplier.get();
+        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
+        BooleanSupplier commonSupplier = commonMixinConfigs.get(mixinConfig);
+        return sidedSupplier != null ? sidedSupplier.getAsBoolean() : commonSupplier == null || commonSupplier.getAsBoolean();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 
 import com.google.common.collect.ImmutableMap;
 import net.minecraftforge.fml.common.Loader;
@@ -15,7 +15,7 @@ import zone.rong.mixinbooter.ILateMixinLoader;
 
 public class UTMixinLoader implements ILateMixinLoader
 {
-    private static final Map<String, Supplier<Boolean>> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("mixins.mods.bibliocraft.json", () -> loaded("bibliocraft") && UTConfigMods.BIBLIOCRAFT.utDisableVersionCheckToggle);
@@ -34,7 +34,7 @@ public class UTMixinLoader implements ILateMixinLoader
         }
     });
 
-    private static final Map<String, Supplier<Boolean>> commonMixinConfigs = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> commonMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("mixins.mods.abyssalcraft.json", () -> loaded("abyssalcraft"));
@@ -140,8 +140,8 @@ public class UTMixinLoader implements ILateMixinLoader
     @Override
     public boolean shouldMixinConfigQueue(String mixinConfig)
     {
-        Supplier<Boolean> sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
-        Supplier<Boolean> commonSupplier = commonMixinConfigs.get(mixinConfig);
-        return sidedSupplier != null ? sidedSupplier.get() : commonSupplier == null || commonSupplier.get();
+        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
+        BooleanSupplier commonSupplier = commonMixinConfigs.get(mixinConfig);
+        return sidedSupplier != null ? sidedSupplier.getAsBoolean() : commonSupplier == null || commonSupplier.getAsBoolean();
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTCompatScreenHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTCompatScreenHandler.java
@@ -8,7 +8,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
-import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 
 @Mod.EventBusSubscriber(modid = UniversalTweaks.MODID, value = Side.CLIENT)
 public class UTCompatScreenHandler
@@ -16,10 +15,10 @@ public class UTCompatScreenHandler
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void utDisplayCompatScreens(GuiOpenEvent event)
     {
-        if (event.getGui() instanceof GuiMainMenu && UTObsoleteModsHandler.showObsoleteMods && UTObsoleteModsHandler.obsoleteModsMessage().size() > 5 && !UTConfigGeneral.DEBUG.utBypassIncompatibilityToggle)
+        if (event.getGui() instanceof GuiMainMenu && UTObsoleteModsHandler.hasObsoleteModsMessage())
         {
             event.setGui(new UTCompatScreen(UTObsoleteModsHandler.obsoleteModsMessage()));
-            UTObsoleteModsHandler.showObsoleteMods = false;
+            UTObsoleteModsHandler.setHasShownObsoleteMods(true);
         }
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 
 import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import mod.acgaming.universaltweaks.util.UTReflectionUtil;
@@ -141,7 +142,13 @@ public class UTObsoleteModsHandler
         }
     });
 
-    public static boolean showObsoleteMods = true;
+    private static List<String> obsoleteModsList;
+    private static boolean hasShownObsoleteMods = false;
+
+    public static boolean hasObsoleteModsMessage()
+    {
+        return !UTObsoleteModsHandler.hasShownObsoleteMods() && !UTConfigGeneral.DEBUG.utBypassIncompatibilityToggle && !getObsoleteModsList().isEmpty();
+    }
 
     public static List<String> obsoleteModsMessage()
     {
@@ -149,7 +156,21 @@ public class UTObsoleteModsHandler
         messages.add(new TextComponentTranslation("msg.universaltweaks.obsoletemods.warning1").getFormattedText());
         messages.add(new TextComponentTranslation("msg.universaltweaks.obsoletemods.warning2").getFormattedText());
         messages.add("");
+        messages.addAll(getObsoleteModsList());
+        messages.add("");
+        messages.add(new TextComponentTranslation("msg.universaltweaks.obsoletemods.warning3").getFormattedText());
+        return messages;
+    }
 
+    private static List<String> getObsoleteModsList()
+    {
+        if (obsoleteModsList == null) obsoleteModsList = generateObsoleteModsList();
+        return obsoleteModsList;
+    }
+
+    private static List<String> generateObsoleteModsList()
+    {
+        List<String> messages = new ArrayList<>();
         Map<String, ModContainer> modIdMap = Loader.instance().getIndexedModList();
         for (String modId : obsoleteModMap.keySet())
         {
@@ -164,9 +185,23 @@ public class UTObsoleteModsHandler
         if (UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleTweaker") && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
         if (UTReflectionUtil.isClassLoaded("com.cleanroommc.blockdelayremover.BlockDelayRemoverCore") && UTConfigTweaks.BLOCKS.utBlockHitDelay != 5) messages.add("Block Delay Remover");
         if (UTReflectionUtil.isClassLoaded("io.github.barteks2x.chunkgenlimiter.ChunkGenLimitMod") && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");
-        messages.add("");
-        messages.add(new TextComponentTranslation("msg.universaltweaks.obsoletemods.warning3").getFormattedText());
         return messages;
+    }
+
+    public static boolean hasShownObsoleteMods()
+    {
+        return hasShownObsoleteMods;
+    }
+
+    public static void setHasShownObsoleteMods(boolean value)
+    {
+        hasShownObsoleteMods = value;
+    }
+
+    public static void resetObsoleteMods()
+    {
+        hasShownObsoleteMods = false;
+        obsoleteModsList = null;
     }
 
 }

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -18,7 +18,7 @@ import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTObsoleteModsHandler
 {
-    private static final Map<String, Supplier<Boolean>> obsoleteModMap = ImmutableMap.copyOf(new HashMap<String, Supplier<Boolean>>()
+    private static final Map<String, BooleanSupplier> obsoleteModMap = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
             put("aiimprovements", () -> UTConfigTweaks.ENTITIES.utAIReplacementToggle || UTConfigTweaks.ENTITIES.utAIRemovalToggle);
@@ -153,7 +153,7 @@ public class UTObsoleteModsHandler
         Map<String, ModContainer> modIdMap = Loader.instance().getIndexedModList();
         for (String modId : obsoleteModMap.keySet())
         {
-            if (Loader.isModLoaded(modId) && obsoleteModMap.get(modId).get())
+            if (Loader.isModLoaded(modId) && obsoleteModMap.get(modId).getAsBoolean())
             {
                 messages.add(modIdMap.get(modId).getName());
             }

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -197,11 +197,4 @@ public class UTObsoleteModsHandler
     {
         hasShownObsoleteMods = value;
     }
-
-    public static void resetObsoleteMods()
-    {
-        hasShownObsoleteMods = false;
-        obsoleteModsList = null;
-    }
-
 }


### PR DESCRIPTION
changes in this PR:
- use `BooleanSupplier` instead of `Supplier<Boolean>` for the mixin and obsolete mods maps.
- centralize code determining the behavior of obsolete mods.
- ensure the obsolete mods list is not run twice when starting a pack. minor thing, but it was weird.