### PR TITLE
Astral Sorcery Crystal Tool Division By Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ All changes are toggleable via config files.
   * **Missing Player Log Level:** Downgrades the message when completing a recipe without an initializing player from a warning to a debug
   * **Sooty Marble Rendering:** Fixes Sooty Marble Pillar blocking the proper rendering of adjacent fluids due to inverted logic
   * **Clear Particle Effects:** Fixes a bug where particle effects would continue to render after changing dimensions
+  * **Fix Division By Zero Crystal Tool:** Fixes a bug where merging Crystal Tool Properties could result in a division by zero
 * **Advent of Ascension**
     * **Improved Player Tick:** Improves AoA player ticking by only sending inventory changes when necessary
 * **Arcane Archives**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -341,6 +341,10 @@ public class UTConfigMods
         @Config.Name("Clear Particle Effects")
         @Config.Comment("Fixes a bug where particle effects would continue to render after changing dimensions")
         public boolean utClearEffectsOnDimensionChange = true;
+
+        @Config.Name("Fix Division By Zero Crystal Tool")
+        @Config.Comment("Fixes a bug where merging Crystal Tool Properties could result in a division by zero")
+        public boolean utEmptyPropertiesZero = true;
     }
 
     public static class AOACategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -45,6 +45,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.aoa3.json", () -> loaded("aoa3") && UTConfigMods.AOA.utImprovedPlayerTickToggle);
             put("mixins.mods.arcanearchives.dupes.json", () -> loaded("arcanearchives") && UTConfigMods.ARCANE_ARCHIVES.utDuplicationFixesToggle);
             put("mixins.mods.astralsorcery.json", () -> loaded("astralsorcery"));
+            put("mixins.mods.astralsorcery.tool.json", () -> loaded("astralsorcery") && UTConfigMods.ASTRAL_SORCERY.utEmptyPropertiesZero);
             put("mixins.mods.biomesoplenty.json", () -> loaded("biomesoplenty"));
             put("mixins.mods.biomesoplenty.sealevel.json", () -> loaded("biomesoplenty") && UTConfigTweaks.WORLD.utSeaLevel != 63);
             put("mixins.mods.bloodmagic.dupes.json", () -> loaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/mixin/UTToolCrystalPropertiesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/mixin/UTToolCrystalPropertiesMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.mixin;
+
+import java.util.List;
+
+import hellfirepvp.astralsorcery.common.item.crystal.CrystalProperties;
+import hellfirepvp.astralsorcery.common.item.crystal.ToolCrystalProperties;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ToolCrystalProperties.class, remap = false)
+public abstract class UTToolCrystalPropertiesMixin
+{
+    @Inject(method = "merge(Ljava/util/List;)Lhellfirepvp/astralsorcery/common/item/crystal/ToolCrystalProperties;", at = @At("HEAD"), cancellable = true)
+    private static void utEmptySkip(List<CrystalProperties> properties, CallbackInfoReturnable<ToolCrystalProperties> cir)
+    {
+        if (UTConfigMods.ASTRAL_SORCERY.utEmptyPropertiesZero && properties.isEmpty())
+        {
+            cir.setReturnValue(new ToolCrystalProperties(0, 0, 0, 0, -1));
+        }
+    }
+}

--- a/src/main/resources/mixins.mods.astralsorcery.tool.json
+++ b/src/main/resources/mixins.mods.astralsorcery.tool.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.astralsorcery.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTToolCrystalPropertiesMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- Fix some situations calling `ToolCrystalProperties.merge(CrystalProperties...)` with an empty array, creating a list with a size of 0, which is then used as a divisor in `ToolCrystalProperties.merge(List<CrystalProperties>)` and generating a `/0` bug. (default: `true`)