### PR TITLE
Fix Null Ingredient for Modular Magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ All changes are toggleable via config files.
     * **Copy Armor Stacks to Dummy:** Instead of deleting the original itemstack being equipped, use a copy of it and do not drop armor
 * **Mob Stages**
     * **Spawning Rules Fixes:** Fixes mob replacement ignoring entity spawning rules
+* **Modular Magic**
 * **Modular Routers**
     * **Particle Thread Fix:** Fixes particles being added from the wrong thread which corrupted the particle manager
 * **MrTJPCore**

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ All changes are toggleable via config files.
 * **Mob Stages**
     * **Spawning Rules Fixes:** Fixes mob replacement ignoring entity spawning rules
 * **Modular Magic**
+    * **Fix Null Ingredient:** Fix a Null Pointer Exception caused by not checking if the Aspect List ingredient is null before attempting to rendering it
 * **Modular Routers**
     * **Particle Thread Fix:** Fixes particles being added from the wrong thread which corrupted the particle manager
 * **MrTJPCore**

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ All changes are toggleable via config files.
 * **Mob Stages**
     * **Spawning Rules Fixes:** Fixes mob replacement ignoring entity spawning rules
 * **Modular Magic**
-    * **Fix Null Ingredient:** Fix a Null Pointer Exception caused by not checking if the Aspect List ingredient is null before attempting to rendering it
+    * **Fix Null Ingredient:** Fix a Null Pointer Exception in a few places caused by not checking if the ingredient is null before attempting to rendering it
 * **Modular Routers**
     * **Particle Thread Fix:** Fixes particles being added from the wrong thread which corrupted the particle manager
 * **MrTJPCore**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -102,6 +102,8 @@ final def mod_dependencies = [
     'curse.maven:mcjtylib-233105:2745846'                             : [debug_rftools],
     'curse.maven:mekanism-268560:2835175'                             : [debug_mekanism],
     'curse.maven:modtweaker-220954:3840577'                           : [debug_crafttweaker],
+    'curse.maven:modular-machinery-270790:2761302'                    : [debug_modular_magic],
+    'curse.maven:modular-magic-324318:2947301'                        : [debug_modular_magic],
     'curse.maven:modular-routers-250294:2954953'                      : [debug_modular_routers],
     'curse.maven:mrtjpcore-229002:2735197'                            : [debug_mrtjpcore, debug_project_red],
     'curse.maven:mysticallib-277064:3483816'                          : [debug_arcane_archives],

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ debug_industrialcraft = false
 debug_iron_backpacks = false
 debug_iron_chests = false
 debug_mekanism = false
+debug_modular_magic = false
 debug_modular_routers = false
 debug_mrtjpcore = false
 debug_netherchest = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -163,6 +163,10 @@ public class UTConfigMods
     @Config.Name("Mob Stages")
     public static final MobStagesCategory MOB_STAGES = new MobStagesCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.modularmagic")
+    @Config.Name("Modular Magic")
+    public static final ModularMagicCategory MODULAR_MAGIC = new ModularMagicCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.modularrouters")
     @Config.Name("Modular Routers")
     public static final ModularRoutersCategory MODULAR_ROUTERS = new ModularRoutersCategory();
@@ -753,6 +757,10 @@ public class UTConfigMods
         @Config.Name("Spawning Rules Fixes")
         @Config.Comment("Fixes mob replacement ignoring entity spawning rules")
         public boolean utSpawningRules = true;
+    }
+
+    public static class ModularMagicCategory
+    {
     }
 
     public static class ModularRoutersCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -763,7 +763,7 @@ public class UTConfigMods
     {
         @Config.RequiresMcRestart
         @Config.Name("Fix Null Ingredient")
-        @Config.Comment("Fix a Null Pointer Exception caused by not checking if the Aspect List ingredient is null before attempting to rendering it")
+        @Config.Comment("Fix a Null Pointer Exception in a few places caused by not checking if the ingredient is null before attempting to rendering it")
         public boolean utEnsureIngredientNotNull = true;
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -761,6 +761,10 @@ public class UTConfigMods
 
     public static class ModularMagicCategory
     {
+        @Config.RequiresMcRestart
+        @Config.Name("Fix Null Ingredient")
+        @Config.Comment("Fix a Null Pointer Exception caused by not checking if the Aspect List ingredient is null before attempting to rendering it")
+        public boolean utEnsureIngredientNotNull = true;
     }
 
     public static class ModularRoutersCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -26,6 +26,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.enderio.itemrender.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
             put("mixins.mods.hwyla.json", () -> loaded("waila"));
             put("mixins.mods.ironchests.json", () -> loaded("ironchest") && UTConfigMods.IRON_CHESTS.utReplaceItemRenderer);
+            put("mixins.mods.modularmagic.nullingredient.json", () -> loaded("modularmagic") && UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull);
             put("mixins.mods.modularrouters.json", () -> loaded("modularrouters") && UTConfigMods.MODULAR_ROUTERS.utParticleThreadToggle);
             put("mixins.mods.roost.json", () -> loaded("roost") && loaded("contenttweaker"));
             put("mixins.mods.storagedrawers.client.json", () -> loaded("storagedrawers"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/mixin/UTToolCrystalPropertiesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/mixin/UTToolCrystalPropertiesMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+// Courtesy of WaitingIdly
 @Mixin(value = ToolCrystalProperties.class, remap = false)
 public abstract class UTToolCrystalPropertiesMixin
 {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTAspectRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTAspectRendererMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.modularmagic.nullingredient.mixin;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.client.Minecraft;
+
+import fr.frinn.modularmagic.common.integration.jei.render.AspectRenderer;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.api.aspects.AspectList;
+
+// Courtesy of WaitingIdly
+@Mixin(value = AspectRenderer.class, remap = false)
+public abstract class UTAspectRendererMixin
+{
+    @Inject(method = "render(Lnet/minecraft/client/Minecraft;IILthaumcraft/api/aspects/AspectList;)V", at = @At("HEAD"), cancellable = true)
+    private void utCheckIngredientNotNull(Minecraft minecraft, int xPosition, int yPosition, @Nullable AspectList ingredient, CallbackInfo ci)
+    {
+        if (UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull && ingredient == null) ci.cancel();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTAuraRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTAuraRendererMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.modularmagic.nullingredient.mixin;
+
+import net.minecraft.client.Minecraft;
+
+import fr.frinn.modularmagic.common.integration.jei.ingredient.Aura;
+import fr.frinn.modularmagic.common.integration.jei.render.AuraRenderer;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = AuraRenderer.class, remap = false)
+public abstract class UTAuraRendererMixin
+{
+    @Inject(method = "render(Lnet/minecraft/client/Minecraft;IILfr/frinn/modularmagic/common/integration/jei/ingredient/Aura;)V", at = @At("HEAD"), cancellable = true)
+    private void utCheckIngredientNotNull(Minecraft minecraft, int xPosition, int yPosition, Aura ingredient, CallbackInfo ci)
+    {
+        if (UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull && ingredient == null) ci.cancel();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTConstellationRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTConstellationRendererMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.modularmagic.nullingredient.mixin;
+
+import net.minecraft.client.Minecraft;
+
+import fr.frinn.modularmagic.common.integration.jei.ingredient.Constellation;
+import fr.frinn.modularmagic.common.integration.jei.render.ConstellationRenderer;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ConstellationRenderer.class, remap = false)
+public abstract class UTConstellationRendererMixin
+{
+    @Inject(method = "render(Lnet/minecraft/client/Minecraft;IILfr/frinn/modularmagic/common/integration/jei/ingredient/Constellation;)V", at = @At("HEAD"), cancellable = true)
+    private void utCheckIngredientNotNull(Minecraft minecraft, int xPosition, int yPosition, Constellation ingredient, CallbackInfo ci)
+    {
+        if (UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull && ingredient == null) ci.cancel();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTDemonWillRendererMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/modularmagic/nullingredient/mixin/UTDemonWillRendererMixin.java
@@ -1,0 +1,23 @@
+package mod.acgaming.universaltweaks.mods.modularmagic.nullingredient.mixin;
+
+import net.minecraft.client.Minecraft;
+
+import fr.frinn.modularmagic.common.integration.jei.ingredient.DemonWill;
+import fr.frinn.modularmagic.common.integration.jei.render.DemonWillRenderer;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = DemonWillRenderer.class, remap = false)
+public abstract class UTDemonWillRendererMixin
+{
+    // This method actually has a null check, the issue is that it makes changes to the GLState prior to that null check.
+    @Inject(method = "render(Lnet/minecraft/client/Minecraft;IILfr/frinn/modularmagic/common/integration/jei/ingredient/DemonWill;)V", at = @At("HEAD"), cancellable = true)
+    private void utCheckIngredientNotNull(Minecraft minecraft, int xPosition, int yPosition, DemonWill ingredient, CallbackInfo ci)
+    {
+        if (UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull && ingredient == null) ci.cancel();
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -86,6 +86,7 @@ cfg.universaltweaks.modintegration.ironchests=Iron Chests
 cfg.universaltweaks.modintegration.itemstages=Item Stages
 cfg.universaltweaks.modintegration.mekanism=Mekanism
 cfg.universaltweaks.modintegration.mobstages=Mob Stages
+cfg.universaltweaks.modintegration.modularmagic=Modular Magic
 cfg.universaltweaks.modintegration.modularrouters=Modular Routers
 cfg.universaltweaks.modintegration.mrtjpcore=MrTJPCore
 cfg.universaltweaks.modintegration.netherchest=Nether Chest

--- a/src/main/resources/mixins.mods.modularmagic.nullingredient.json
+++ b/src/main/resources/mixins.mods.modularmagic.nullingredient.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.modularmagic.nullingredient.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTAspectRendererMixin"]
+}

--- a/src/main/resources/mixins.mods.modularmagic.nullingredient.json
+++ b/src/main/resources/mixins.mods.modularmagic.nullingredient.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTAspectRendererMixin"]
+  "mixins": ["UTAspectRendererMixin", "UTAuraRendererMixin", "UTConstellationRendererMixin", "UTDemonWillRendererMixin"]
 }


### PR DESCRIPTION
changes in this PR:
- add modular magic (and modular machinery) as optional deps for the buildscript.
- fix multiple of modular magic's renderers from throwing an NPE when the ingredient being rendered is null (default: `true`). 
- add a comment indicating that the `UTToolCrystalPropertiesMixin` was created by me (whoops!).

related issues: https://github.com/Frinn38/Modular-Magic/issues/25, https://github.com/Divine-Journey-2/Divine-Journey-2/issues/940