### PR TITLE
Second Attempt for fixing Storage Drawers Voiding near full capacity

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/api/IAuxData.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/api/IAuxData.java
@@ -1,0 +1,26 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.api;
+
+import it.unimi.dsi.fastutil.ints.Int2IntArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface IAuxData
+{
+    String KEY = "insertion_data";
+
+    void UT$setData(String key, Object value);
+
+    @Nullable
+    Object UT$getData(String key);
+
+    @NotNull
+    default Int2IntMap getOrCreateData() {
+        Int2IntMap v = (Int2IntMap) UT$getData(KEY);
+        if (v == null) {
+            v = new Int2IntArrayMap();
+            UT$setData(KEY, v);
+        }
+        return v;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/api/SlotGroupAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/api/SlotGroupAccessor.java
@@ -1,0 +1,10 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.api;
+
+public interface SlotGroupAccessor
+{
+    int UT$getSlot();
+
+    int UT$getIndex();
+
+    Class<?> UT$getType();
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerControllerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerControllerMixin.java
@@ -1,0 +1,127 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemRepository;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.IAuxData;
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.SlotGroupAccessor;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+
+@Mixin(value = TileEntityController.class, remap = false)
+public class UTDrawerControllerMixin {
+
+    @Mixin(targets = "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController$ItemRepository",
+        remap = false)
+    public static abstract class RepositoryMixin extends DrawerItemRepository {
+
+        @Shadow
+        @Final
+        TileEntityController this$0;
+
+        @Shadow
+        protected abstract boolean hasAccess(IDrawerGroup group, IDrawer drawer);
+
+        public RepositoryMixin(IDrawerGroup group) {
+            super(group);
+        }
+
+        // should probably use unreflect for this
+        @Unique
+        Method UT$getGroupForSlotRecord = null;
+
+        @Unique
+        private IDrawerGroup UT$getDrawerGroup(TileEntityController controller, SlotGroupAccessor o) {
+            try {
+                if (UT$getGroupForSlotRecord == null) {
+                    UT$getGroupForSlotRecord = TileEntityController.class
+                        .getDeclaredMethod("getGroupForSlotRecord", o.UT$getType());
+                    UT$getGroupForSlotRecord.setAccessible(true);
+                }
+
+                return (IDrawerGroup) UT$getGroupForSlotRecord.invoke(controller, o);
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Inject(method = "insertItem",
+            at = @At(value = "INVOKE_ASSIGN",
+                target = "Ljava/util/Collection;iterator()Ljava/util/Iterator;"),
+            cancellable = true)
+        public void readData(ItemStack stack, boolean simulate, Predicate<ItemStack> predicate,
+                             CallbackInfoReturnable<ItemStack> cir,
+                             @Local Iterator<SlotGroupAccessor> iterator,
+                             @Local LocalIntRef amount,
+                             @Local Set<Integer> checkedSlots) {
+            while (iterator.hasNext()) {
+                SlotGroupAccessor record = iterator.next();
+                IDrawerGroup candidateGroup = UT$getDrawerGroup(this$0, record);
+                if (candidateGroup != null) {
+                    IDrawer drawerx = candidateGroup.getDrawer(record.UT$getSlot());
+                    if (!drawerx.isEmpty() && this.testPredicateInsert(drawerx, stack, predicate) &&
+                        this.hasAccess(candidateGroup, drawerx)) {
+                        if (simulate) {
+                            int inserted = ((IAuxData) drawerx).getOrCreateData().get(record.UT$getSlot());
+                            if (inserted + drawerx.getStoredItemCount() == drawerx.getMaxCapacity()) {
+                                continue;
+                            }
+                        }
+                        amount.set(simulate ?
+                            Math.max(amount.get() - drawerx.getAcceptingRemainingCapacity(), 0) :
+                            drawerx.adjustStoredItemCount(amount.get()));
+                        if (amount.get() == 0) {
+                            cir.setReturnValue(ItemStack.EMPTY);
+                        }
+
+                        if (simulate) {
+                            checkedSlots.add(record.UT$getIndex());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Mixin(targets = "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController$SlotRecord", remap = false)
+    private static abstract class SlotRecordMixin implements SlotGroupAccessor {
+
+        @Shadow
+        public int slot;
+
+        @Shadow
+        public int index;
+
+        @Override
+        public int UT$getSlot() {
+            return slot;
+        }
+
+        @Override
+        public int UT$getIndex() {
+            return index;
+        }
+
+        @Override
+        public Class<?> UT$getType() {
+            return getClass();
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerGroupMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerGroupMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.StandardDrawerGroup;
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.IAuxData;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = StandardDrawerGroup.class, remap = false)
+public abstract class UTDrawerGroupMixin {
+
+    @Mixin(value = StandardDrawerGroup.DrawerData.class, remap = false)
+    public abstract static class DrawerDataMixin implements IAuxData
+    {
+
+        @Shadow
+        public abstract void setExtendedData(String key, Object data);
+
+        @Shadow
+        public abstract Object getExtendedData(String key);
+
+        @Override
+        public void UT$setData(String key, Object value) {
+            setExtendedData(key, value);
+        }
+
+        @Override
+        public @Nullable Object UT$getData(String key) {
+            return getExtendedData(key);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerHandlerMixin.java
@@ -1,0 +1,32 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.IAuxData;
+
+import net.minecraft.item.ItemStack;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = DrawerItemHandler.class, remap = false)
+public abstract class UTDrawerHandlerMixin {
+
+    @Inject(method = "insertItemInternal",
+        at = @At(value = "INVOKE_ASSIGN",
+            target = "Lcom/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup;getDrawer(I)Lcom/jaquadro/minecraft/storagedrawers/api/storage/IDrawer;"))
+    public void setData(int slot, ItemStack stack, boolean simulate,
+                        CallbackInfoReturnable<ItemStack> cir,
+                        @Local IDrawer drawer) {
+        int inserted = drawer.isEmpty() ?
+            drawer.getAcceptingMaxCapacity(stack) :
+            drawer.getAcceptingRemainingCapacity();
+
+        if (drawer instanceof IAuxData) {
+            ((IAuxData) drawer).getOrCreateData().put(slot, inserted);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerRepositoryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawerRepositoryMixin.java
@@ -1,0 +1,36 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemRepository;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.IAuxData;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Predicate;
+
+@Mixin(value = DrawerItemRepository.class, remap = false)
+public class UTDrawerRepositoryMixin {
+
+    @Inject(method = "insertItem",
+        at = @At(value = "INVOKE_ASSIGN",
+            target = "Lcom/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup;getDrawer(I)Lcom/jaquadro/minecraft/storagedrawers/api/storage/IDrawer;"),
+        cancellable = true)
+    public void readData(ItemStack stack, boolean simulate, Predicate<ItemStack> predicate,
+                         CallbackInfoReturnable<ItemStack> cir,
+                         @Local IDrawer drawer, @Local(ordinal = 3) int slot) {
+        if (drawer instanceof IAuxData) {
+            int inserted = ((IAuxData) drawer).getOrCreateData().get(slot);
+            if (simulate && inserted + drawer.getStoredItemCount() == drawer.getMaxCapacity()) {
+                cir.setReturnValue(stack);
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTFractionalGroupMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTFractionalGroupMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.FractionalDrawerGroup;
+import mod.acgaming.universaltweaks.mods.storagedrawers.api.IAuxData;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = FractionalDrawerGroup.class, remap = false)
+public abstract class UTFractionalGroupMixin {
+
+    @Mixin(targets = "com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.FractionalDrawerGroup$FractionalDrawer",
+        remap = false)
+    public static abstract class FractionalDataMixin implements IAuxData {
+
+        @Shadow
+        public abstract void setExtendedData(String key, Object data);
+
+        @Shadow
+        public abstract Object getExtendedData(String key);
+
+        @Override
+        public void UT$setData(String key, Object value) {
+            setExtendedData(key, value);
+        }
+
+        @Override
+        public @Nullable Object UT$getData(String key) {
+            return getExtendedData(key);
+        }
+    }
+}

--- a/src/main/resources/mixins.mods.storagedrawers.client.json
+++ b/src/main/resources/mixins.mods.storagedrawers.client.json
@@ -3,5 +3,18 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["UTDrawersRendererMixin"]
+  "client": [
+    "UTDrawersRendererMixin"
+  ],
+  "mixins": [
+    "UTDrawerControllerMixin",
+    "UTDrawerControllerMixin$RepositoryMixin",
+    "UTDrawerControllerMixin$SlotRecordMixin",
+    "UTDrawerGroupMixin",
+    "UTDrawerGroupMixin$DrawerDataMixin",
+    "UTDrawerHandlerMixin",
+    "UTDrawerRepositoryMixin",
+    "UTFractionalGroupMixin",
+    "UTFractionalGroupMixin$FractionalDataMixin"
+  ]
 }


### PR DESCRIPTION
Another attempt to fix this voiding issue when near capacity in a Storage Drawer. Originally i was doing testing within Gregtech, and decided to port that work over here.

This issue and fix can be easily observed using Gregtech's item transportation (item pipes and conveyors).

I utilize the `auxData` map found in `DrawerData` and `FractionalDrawer` to store an Int2IntMap tracking the simulated insertions into each slot. the data is written to in `UTDrawerHandlerMixin`, then read in `UTDrawerControllerMixin$RepositoryMixin` and `UTDrawerRepositoryMixin`.

`FractionalDrawer` and `DrawerData` implement `IAuxData` to make checking the insertion data easier
`FractionalDrawer`, `ItemRepository`, and `SlotRecord` have special handling because their visibility level is `private`
the method reflection is needed because that method is protected and cannot be accessed directly