### PR TITLE
Updated MixinBooter to 10.5, fixes Corpse's gui issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -518,7 +518,7 @@ configurations {
     testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
 }
 
-String mixinProviderSpec = 'zone.rong:mixinbooter:9.1'
+String mixinProviderSpec = 'zone.rong:mixinbooter:10.5'
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -79,6 +79,7 @@ final def mod_dependencies = [
     'curse.maven:collective-342584:3533131'                           : [debug_collective],
     'curse.maven:compactmachines-224218:2707509'                      : [debug_compact_machines],
     'curse.maven:constructs-armory-287683:3174535'                    : [debug_tinkers_construct],
+    'curse.maven:corpse-316582:3010808'                               : [debug_corpse],
     'curse.maven:cqrepoured-303422:3953103'                           : [debug_cqrepoured],
     'curse.maven:ctm-267602:2915363'                                  : [debug_chisel],
     'curse.maven:cyclops-core-232758:3159497'                         : [debug_evilcraft],

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ debug_chickens = false
 debug_chisel = false
 debug_collective = false
 debug_compact_machines = false
+debug_corpse = false
 debug_cqrepoured = false
 debug_crafttweaker = false
 debug_effortless_building = false

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -70,7 +70,7 @@ public class UniversalTweaks
     public static final String MODID = Tags.MOD_ID;
     public static final String NAME = Tags.MOD_NAME;
     public static final String VERSION = Tags.VERSION;
-    public static final String DEPENDENCIES = "required-after:mixinbooter@[9.0,);required-after:configanytime@[3.0,);"
+    public static final String DEPENDENCIES = "required-after:mixinbooter@[10.5,);required-after:configanytime@[3.0,);"
         + "after:abyssalcraft;"
         + "after:actuallyadditions;"
         + "after:aoa3;"

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -83,6 +83,10 @@ public class UTConfigMods
     @Config.Name("Compact Machines")
     public static final CompactMachinesCoreCategory COMPACT_MACHINES = new CompactMachinesCoreCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.corpse")
+    @Config.Name("Corpse")
+    public static final CorpseCategory CORPSE = new CorpseCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.effortlessbuilding")
     @Config.Name("Effortless Building")
     public static final EffortlessBuildingCategory EFFORTLESS_BUILDING = new EffortlessBuildingCategory();
@@ -490,6 +494,14 @@ public class UTConfigMods
         @Config.Name("Memory Leak Fix")
         @Config.Comment("Fixes client-side memory leak associated with miniaturization recipes")
         public boolean utMemoryLeakFixToggle = true;
+    }
+
+    public static class CorpseCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Opening GUIs Off-thread Fix")
+        @Config.Comment("Fixes opening up GUIs on a non-client thread")
+        public boolean utOpeningGuisOffThreadFixToggle = true;
     }
 
     public static class EffortlessBuildingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -61,6 +61,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.cofhcore.json", () -> loaded("cofhcore"));
             put("mixins.mods.collective.json", () -> loaded("collective"));
             put("mixins.mods.compactmachines.spawns.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utAllowedSpawnsImprovementToggle);
+            put("mixins.mods.corpse.json", () -> loaded("corpse") && UTConfigMods.CORPSE.utOpeningGuisOffThreadFixToggle);
             put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
             put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
             put("mixins.mods.electroblobswizardry.json", () -> loaded("ebwizardry") && loaded("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/corpse/mixin/UTMessageOpenHistoryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/corpse/mixin/UTMessageOpenHistoryMixin.java
@@ -1,0 +1,24 @@
+package mod.acgaming.universaltweaks.mods.corpse.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import de.maxhenkel.corpse.net.MessageOpenHistory;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(MessageOpenHistory.class)
+public class UTMessageOpenHistoryMixin
+{
+    @WrapMethod(method = "onMessage(Lde/maxhenkel/corpse/net/MessageOpenHistory;Lnet/minecraftforge/fml/common/network/simpleimpl/MessageContext;)Lnet/minecraftforge/fml/common/network/simpleimpl/IMessage;")
+    private IMessage wrapOnMessage(MessageOpenHistory message, MessageContext ctx, Operation<IMessage> original)
+    {
+        Minecraft.getMinecraft().addScheduledTask(() -> original.call(message, ctx));
+        return null;
+    }
+
+}

--- a/src/main/resources/mixins.mods.corpse.json
+++ b/src/main/resources/mixins.mods.corpse.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.corpse.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTMessageOpenHistoryMixin"]
+}


### PR DESCRIPTION
Issue was found in Cleanroom's environment because of the switch from LWJGL 2 => 3. Using GLFW exasperated the problem.