### PR TITLE
Fix Mekanism Fluid Tank Fluid Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ All changes are toggleable via config files.
     * **Ingredient Matching:** Changes item matching code to CraftTweaker's ingredient matching system, fixes item NBT issues
 * **Mekanism**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Fluid Tank Extraction:** Fixes a logic error with extracting fluids from fluid tanks
 * **MmmMmmMmmMmm**
     * **Copy Armor Stacks to Dummy:** Instead of deleting the original itemstack being equipped, use a copy of it and do not drop armor
 * **Moar Tinkers**

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ All changes are toggleable via config files.
     * **Ingredient Matching:** Changes item matching code to CraftTweaker's ingredient matching system, fixes item NBT issues
 * **Mekanism**
     * **Duplication Fixes:** Fixes various duplication exploits
-    * **Fluid Tank Extraction:** Fixes a logic error with extracting fluids from fluid tanks
+    * **Fluid Tank Extraction:** Fixes a logic error allowing extracting fluids from fluid tanks regardless of requested fluid
 * **MmmMmmMmmMmm**
     * **Copy Armor Stacks to Dummy:** Instead of deleting the original itemstack being equipped, use a copy of it and do not drop armor
 * **Moar Tinkers**

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -27,7 +27,7 @@ import mod.acgaming.universaltweaks.mods.collective.UTCollectiveEvents;
 import mod.acgaming.universaltweaks.mods.cqrepoured.UTGoldenFeatherEvent;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Burning;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Sprinting;
-import mod.acgaming.universaltweaks.mods.mekanism.UTMekanismFixes;
+import mod.acgaming.universaltweaks.mods.mekanism.dupes.UTMekanismFixes;
 import mod.acgaming.universaltweaks.mods.projectred.UTProjectRedWorldEvents;
 import mod.acgaming.universaltweaks.mods.simplyjetpacks.UTSimplyJetpacksEvents;
 import mod.acgaming.universaltweaks.mods.simplyjetpacks.network.message.MessageClientStatesReset;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -790,7 +790,11 @@ public class UTConfigMods
 
         @Config.RequiresMcRestart
         @Config.Name("Fluid Tank Extraction")
-        @Config.Comment("Fixes a logic error with extracting fluids from fluid tanks")
+        @Config.Comment
+            ({
+                "Fixes a logic error allowing extracting fluids from fluid tanks regardless of requested fluid",
+                "Has no effect when playing with Mekanism CEu"
+            })
         public boolean utFluidTankExtraction = true;
 
     }

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -787,6 +787,12 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Fluid Tank Extraction")
+        @Config.Comment("Fixes a logic error with extracting fluids from fluid tanks")
+        public boolean utFluidTankExtraction = true;
+
     }
 
     public static class MoarTinkersCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -95,6 +95,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.ironbackpacks.dupes.json", () -> loaded("ironbackpacks") && UTConfigMods.IRON_BACKPACKS.utDuplicationFixesToggle);
             put("mixins.mods.itemstages.json", () -> loaded("itemstages"));
             put("mixins.mods.mekanism.dupes.json", () -> loaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle);
+            put("mixins.mods.mekanism.fluidtank.json", () -> loaded("mekanism") && UTConfigMods.MEKANISM.utFluidTankExtraction);
             put("mixins.mods.moartinkers.json", () -> loaded("moartinkers") && UTConfigMods.MOAR_TINKERS.utBaublesCompatibility);
             put("mixins.mods.mobstages.json", () -> loaded("mobstages"));
             put("mixins.mods.mrtjpcore.json", () -> loaded("mrtjpcore") && UTConfigMods.MRTJPCORE.utMemoryLeakFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/dupes/UTMekanismFixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/dupes/UTMekanismFixes.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.mekanism;
+package mod.acgaming.universaltweaks.mods.mekanism.dupes;
 
 import java.util.ArrayList;
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/dupes/mixin/UTContainerPersonalChestMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/dupes/mixin/UTContainerPersonalChestMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.mekanism.mixin;
+package mod.acgaming.universaltweaks.mods.mekanism.dupes.mixin;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/fluidtank/mixin/UTTileEntityFluidTankMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/fluidtank/mixin/UTTileEntityFluidTankMixin.java
@@ -26,6 +26,8 @@ public abstract class UTTileEntityFluidTankMixin
      * Converts the code as such:
      * <br><code>- fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && !isActive || from != EnumFacing.DOWN</code>
      * <br><code>+ fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && (!isActive || from != EnumFacing.DOWN)</code>
+     * <br>
+     * This only has a difference with Mekanism. <a href="https://github.com/sddsd2332/Mekanism-CE-Unofficial-1.12.2/commit/64e2af3ed10f359a9876315811631f44cfa603cb">Mekanism CEu</a> has this change integrated
      *
      * @author WaitingIdly
      * @reason Mekanism's default logic always returns true if the direction is anywhere except down,

--- a/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/fluidtank/mixin/UTTileEntityFluidTankMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/mekanism/fluidtank/mixin/UTTileEntityFluidTankMixin.java
@@ -1,0 +1,41 @@
+package mod.acgaming.universaltweaks.mods.mekanism.fluidtank.mixin;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTank;
+
+import mekanism.common.tile.TileEntityFluidTank;
+import mekanism.common.util.FluidContainerUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(value = TileEntityFluidTank.class, remap = false)
+public abstract class UTTileEntityFluidTankMixin
+{
+    @Shadow
+    public boolean isActive;
+
+    @Shadow
+    public FluidTank fluidTank;
+
+    /**
+     * Converts the code as such:
+     * <br><code>- fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && !isActive || from != EnumFacing.DOWN</code>
+     * <br><code>+ fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && (!isActive || from != EnumFacing.DOWN)</code>
+     *
+     * @author WaitingIdly
+     * @reason Mekanism's default logic always returns true if the direction is anywhere except down,
+     * instead of the direction being down only being relevant in relation to isActive.
+     * This issue was introduced in <a href="https://github.com/mekanism/Mekanism/commit/7a726f3695cf70d11f6fe6eb4d0f3457a21eb5c6">this commit</a>,
+     * while simplifying code.
+     */
+    @Inject(method = "canDrain", at = @At("HEAD"), cancellable = true)
+    private void fixFluidTank(EnumFacing from, FluidStack fluid, CallbackInfoReturnable<Boolean> cir)
+    {
+        cir.setReturnValue(fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && (!isActive || from != EnumFacing.DOWN));
+    }
+}

--- a/src/main/resources/mixins.mods.mekanism.dupes.json
+++ b/src/main/resources/mixins.mods.mekanism.dupes.json
@@ -1,5 +1,5 @@
 {
-  "package": "mod.acgaming.universaltweaks.mods.mekanism.mixin",
+  "package": "mod.acgaming.universaltweaks.mods.mekanism.dupes.mixin",
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",

--- a/src/main/resources/mixins.mods.mekanism.fluidtank.json
+++ b/src/main/resources/mixins.mods.mekanism.fluidtank.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.mekanism.fluidtank.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTTileEntityFluidTankMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add a mixin addressing a bug with Mekanism that causes requests to drain fluid to always succeed if the side isnt DOWN, causing some pipes to freely convert between fluids (default: `true`).
- move the `UTMekanismFixes` and related to a `dupes` folder.

this is fixed in Mekanism CEu, but as the code diff between UT and theirs is the same there shouldnt be any issue with the mixin still applying.

here is a non-exhaustive list of bug reports i believe are caused solely by this:
- https://github.com/AE2-UEL/Applied-Energistics-2/issues/340
- https://github.com/EnigmaticaModpacks/Enigmatica2Expert/issues/1832 (note the other fluids being drained in the attached video)
- https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/4774 (forward of prior)
- https://github.com/Divine-Journey-2/Divine-Journey-2/issues/982
- https://github.com/Divine-Journey-2/Divine-Journey-2/issues/1188

this bug was introduced in https://github.com/mekanism/Mekanism/commit/7a726f3695cf70d11f6fe6eb4d0f3457a21eb5c6 and fixed as a byproduct of https://github.com/mekanism/Mekanism/commit/3c84d0f87c1d76667205ea1168e2ae84dde3b44a, with another fix in Mekanism CEu in https://github.com/sddsd2332/Mekanism-CE-Unofficial-1.12.2/commit/64e2af3ed10f359a9876315811631f44cfa603cb.