### PR TITLE
Refactor coremod detection

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/core/Coremods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/Coremods.java
@@ -1,0 +1,41 @@
+package mod.acgaming.universaltweaks.core;
+
+import zone.rong.mixinbooter.Context;
+
+public enum Coremods
+{
+    CHUNKGEN_LIMITER("chunkgenlimit"),
+    OPENMODS("openmods"),
+    OPTIFINE("optifine"),
+    RANDOM_PATCHES("randompatches"),
+    RENDERLIB("renderlib"),
+    SPONGEFORGE("spongeforge"),
+    SURGE("surge"),
+    ;
+
+    private static boolean initialized = false;
+
+    public final String modId;
+    private boolean isLoaded;
+
+    Coremods(String modId)
+    {
+        this.modId = modId;
+        this.isLoaded = false;
+    }
+
+    public static void initFromContext(Context context)
+    {
+        if (initialized) return;
+        initialized = true;
+        for (Coremods coreMod : Coremods.values())
+        {
+            coreMod.isLoaded = context.isModPresent(coreMod.modId);
+        }
+    }
+
+    public boolean isLoaded()
+    {
+        return this.isLoaded;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/buttons/anaglyph/mixin/UT3DAnaglyphMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/buttons/anaglyph/mixin/UT3DAnaglyphMixin.java
@@ -4,7 +4,7 @@ import net.minecraft.client.gui.GuiVideoSettings;
 import net.minecraft.client.settings.GameSettings;
 
 import com.llamalad7.mixinextras.lib.apache.commons.ArrayUtils;
-import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
+import mod.acgaming.universaltweaks.core.Coremods;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -24,7 +24,7 @@ public class UT3DAnaglyphMixin
     @Inject(method = "initGui", at = @At(value = "HEAD"))
     public void ut3DAnaglyph(CallbackInfo ci)
     {
-        if (UTLoadingPlugin.optiFineLoaded) return;
+        if (Coremods.OPTIFINE.isLoaded()) return;
         for (int i = 0; i < VIDEO_OPTIONS.length; i++)
         {
             if (VIDEO_OPTIONS[i] == GameSettings.Options.ANAGLYPH)

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/autosave/UTAutoSaveOFCompat.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/autosave/UTAutoSaveOFCompat.java
@@ -11,8 +11,8 @@ import net.minecraft.launchwrapper.Launch;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.core.Coremods;
 import mod.acgaming.universaltweaks.core.UTLoadingPlugin;
-import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTAutoSaveOFCompat
 {
@@ -21,7 +21,7 @@ public class UTAutoSaveOFCompat
     public static void updateOFConfig()
     {
         if (!UTLoadingPlugin.isClient) return;
-        if (!UTLoadingPlugin.optiFineLoaded) return;
+        if (!Coremods.OPTIFINE.isLoaded()) return;
         try
         {
             UniversalTweaks.LOGGER.info("OptiFine detected, updating config file...");

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -15,6 +15,7 @@ import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.core.Coremods;
 import mod.acgaming.universaltweaks.util.UTReflectionUtil;
 
 public class UTObsoleteModsHandler
@@ -187,9 +188,10 @@ public class UTObsoleteModsHandler
 
         // Mods checked by class
         if (UTReflectionUtil.isClassLoaded("com.chocohead.biab.BornInABarn")) messages.add("Born in a Barn"); // Fix integrated in Forge 14.23.2.2623 (#4689)
-        if (UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleTweaker") && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
+        if ((UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleTweaker") || UTReflectionUtil.isClassLoaded("io.github.jikuja.LocaleFixer"))
+            && UTConfigBugfixes.MISC.utLocaleToggle) messages.add("LocaleFixer");
         if (UTReflectionUtil.isClassLoaded("com.cleanroommc.blockdelayremover.BlockDelayRemoverCore") && UTConfigTweaks.BLOCKS.utBlockHitDelay != 5) messages.add("Block Delay Remover");
-        if (UTReflectionUtil.isClassLoaded("io.github.barteks2x.chunkgenlimiter.ChunkGenLimitMod") && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");
+        if (Coremods.CHUNKGEN_LIMITER.isLoaded() && UTConfigTweaks.WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) messages.add("Chunk Generation Limiter");
         return messages;
     }
 


### PR DESCRIPTION
Uses Mixinbooter 10.x's new Context API. This should be safer than loading coremod classes. Some mods are still detected with `UTReflectionUtil` as the Context API reads `mcmod.info`, which certain coremods don't have or are configured incorrectly.

Fixes #634.