### PR TITLE
Fix EBWizardry+Construct's Armory mixin crashing dedicated server

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -24,6 +24,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.compactmachines.memory.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utMemoryLeakFixToggle);
             put("mixins.mods.compactmachines.render.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utCMRenderFixToggle);
             put("mixins.mods.crafttweaker.json", () -> loaded("crafttweaker"));
+            put("mixins.mods.electroblobswizardry.json", () -> loaded("ebwizardry") && loaded("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);
             put("mixins.mods.enderio.itemrender.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
             put("mixins.mods.fpsreducer.json", () -> loaded("fpsreducer") && UTConfigMods.FPS_REDUCER.utCorrectFpsValue);
             put("mixins.mods.hwyla.json", () -> loaded("waila"));
@@ -73,7 +74,6 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.corpse.json", () -> loaded("corpse") && UTConfigMods.CORPSE.utOpeningGuisOffThreadFixToggle);
             put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
             put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
-            put("mixins.mods.electroblobswizardry.json", () -> loaded("ebwizardry") && loaded("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);
             put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
             put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));
             put("mixins.mods.enderio.chorus.json", () -> loaded("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTItemBoundToolMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bloodmagic/mixin/UTItemBoundToolMixin.java
@@ -92,7 +92,8 @@ public abstract class UTItemBoundToolMixin
         at = @At(
             value = "INVOKE",
             target = "LWayofTime/bloodmagic/item/ItemBoundTool;onBoundRelease(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;I)V",
-            shift = At.Shift.AFTER
+            shift = At.Shift.AFTER,
+            remap = false
         ),
         remap = true
     )

--- a/src/main/resources/mixins.mods.electroblobswizardry.json
+++ b/src/main/resources/mixins.mods.electroblobswizardry.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTTinkersArmorMixin"]
+  "client": ["UTTinkersArmorMixin"]
 }


### PR DESCRIPTION
The mentioned mixin needed to be a client-side only mixin, as it itself mixins into a client-side only method (and references `ModelBiped`, client-only class). This would crash in a dedicated server environment.
Also fixes small remap issue with recent Blood Magic tweak.

Should fix #654.