### PR TITLE
Improve Vengeance Spirit Spawn Random Performance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ All changes are toggleable via config files.
     * **Fix Quake Hammer Texture:** Fixes the Quake Hammer using the incorrect config option to control its size
 * **EvilCraft**
     * **Vengeance Spirit Regex Cache:** Cache the result of Vengeance Spirit checks against the config, which may attempt to build and check against hundreds of Regex Patterns every tick
+    * **Vengeance Spirit Random Performance:** Avoid repeatedly running intensive calculations involving spawning a random Vengeance Spirit
 * **The Farlanders**
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Thermal Expansion**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -688,6 +688,11 @@ public class UTConfigMods
         @Config.Name("Vengeance Spirit Regex Cache")
         @Config.Comment("Cache the result of Vengeance Spirit checks against the config, which may attempt to build and check against hundreds of Regex Patterns every tick")
         public boolean utVengeanceSpiritCache = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Vengeance Spirit Random Performance")
+        @Config.Comment("Avoid repeatedly running intensive calculations involving spawning a random Vengeance Spirit")
+        public boolean utVengeanceSpiritRandom = true;
     }
 
     public static class ExtraUtilitiesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -84,7 +84,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.erebus.cabbage.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utCabbageDrop);
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
             put("mixins.mods.erebus.quakehammer.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utFixQuakeHammerTexture);
-            put("mixins.mods.evilcraft.vengeancespirit.json", () -> loaded("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritCache);
+            put("mixins.mods.evilcraft.vengeancespirit.regex.json", () -> loaded("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritCache);
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
             put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -85,6 +85,7 @@ public class UTMixinLoader implements ILateMixinLoader
             put("mixins.mods.erebus.json", () -> loaded("erebus"));
             put("mixins.mods.erebus.quakehammer.json", () -> loaded("erebus") && UTConfigMods.EREBUS.utFixQuakeHammerTexture);
             put("mixins.mods.evilcraft.vengeancespirit.regex.json", () -> loaded("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritCache);
+            put("mixins.mods.evilcraft.vengeancespirit.random.json", () -> loaded("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritRandom);
             put("mixins.mods.extrautilities.breakcreativemill.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
             put("mixins.mods.extrautilities.deepdarkstats.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
             put("mixins.mods.extrautilities.dupes.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/evilcraft/vengeancespirit/regex/mixin/UTVengeanceSpiritMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/evilcraft/vengeancespirit/regex/mixin/UTVengeanceSpiritMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.mixin;
+package mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.regex.mixin;
 
 import net.minecraft.util.ResourceLocation;
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/evilcraft/vengeancespirit/spawn/mixin/UTVengeanceSpiritMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/evilcraft/vengeancespirit/spawn/mixin/UTVengeanceSpiritMixin.java
@@ -1,0 +1,56 @@
+package mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.spawn.mixin;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.cyclops.evilcraft.entity.monster.VengeanceSpirit;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(value = VengeanceSpirit.class, remap = false)
+public abstract class UTVengeanceSpiritMixin
+{
+    @Shadow
+    public static boolean canSpawnNew(World world, BlockPos blockPos)
+    {
+        return false;
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason check {@link VengeanceSpirit#spawnRandom} at the start of the method,
+     * as all calls to it use the same parameters. The only way the return value of it could change
+     * is if a {@link VengeanceSpirit} was spawned - but if that happens, the loop returns that entity,
+     * meaning this method is called up to 50 times every time this check is requested.
+     * <p>
+     * This can be significantly intensive, as by default every call checks {@code (15*2)^3} block positions
+     * against {@link org.cyclops.evilcraft.block.GemStoneTorchConfig#getBlockInstance() GemStoneTorchConfig#getBlockInstance()}.
+     * This effect can be triggered every time a block is broken or entity attacked via
+     * {@link org.cyclops.evilcraft.enchantment.EnchantmentVengeance EnchantmentVengeance}.
+     */
+    @Inject(method = "spawnRandom", at = @At("HEAD"), cancellable = true)
+    private static void failFastIfSpawnBlocked(World world, BlockPos blockPos, int area, CallbackInfoReturnable<VengeanceSpirit> cir)
+    {
+        if (!UTConfigMods.EVIL_CRAFT.utVengeanceSpiritRandom) return;
+        if (canSpawnNew(world, blockPos)) return;
+        cir.setReturnValue(null);
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason skip further {@link VengeanceSpirit#spawnRandom} checks, as they will always be true due to {@link #failFastIfSpawnBlocked}.
+     */
+    @WrapOperation(method = "spawnRandom", at = @At(value = "INVOKE", target = "Lorg/cyclops/evilcraft/entity/monster/VengeanceSpirit;canSpawnNew(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)Z"))
+    private static boolean skipCanSpawnNewCheck(World world, BlockPos blockPos, Operation<Boolean> original)
+    {
+        if (!UTConfigMods.EVIL_CRAFT.utVengeanceSpiritRandom) return original.call(world, blockPos);
+        return true;
+    }
+}

--- a/src/main/resources/mixins.mods.evilcraft.vengeancespirit.random.json
+++ b/src/main/resources/mixins.mods.evilcraft.vengeancespirit.random.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.spawn.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTVengeanceSpiritMixin"]
+}

--- a/src/main/resources/mixins.mods.evilcraft.vengeancespirit.regex.json
+++ b/src/main/resources/mixins.mods.evilcraft.vengeancespirit.regex.json
@@ -1,5 +1,5 @@
 {
-  "package": "mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.mixin",
+  "package": "mod.acgaming.universaltweaks.mods.evilcraft.vengeancespirit.regex.mixin",
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",


### PR DESCRIPTION
changes in this PR:
- move `UTVengeanceSpiritMixin` to a new `regex` folder
- create a mixin to skip repeatedly calling a very expensive method with the same parameters each time (default: `true`).
	- every time this was called, this would trigger up to 1.35m blockstate checks over the exact same set of blocks.
	- this can safely be moved outside the loop because the only way the outcome ever changes is if a new vengeance spirit is created - but if the loop spawns a vengeance spirit, the method returns.