### PR TITLE
Disable Narrator Thread

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
@@ -13,7 +13,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(NarratorChatListener.class)
 public class UTNarratorMixin
@@ -39,11 +38,5 @@ public class UTNarratorMixin
     public void utNarratorAnnounceMode(int p_193641_1_, CallbackInfo ci)
     {
         if (UTConfigTweaks.MISC.utDisableNarratorToggle) ci.cancel();
-    }
-
-    @Inject(method = "isActive", at = @At("RETURN"), cancellable = true)
-    public void utNarratorState(CallbackInfoReturnable<Boolean> cir)
-    {
-        if (UTConfigTweaks.MISC.utDisableNarratorToggle) cir.setReturnValue(false);
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
@@ -28,12 +28,20 @@ public class UTNarratorMixin
         return new NarratorDummy();
     }
 
+    /**
+     * @author ACGaming
+     * @reason short circuit making the narrator say something
+     */
     @Inject(method = "say", at = @At("HEAD"), cancellable = true)
     public void utNarratorSay(ChatType chatTypeIn, ITextComponent message, CallbackInfo ci)
     {
         if (UTConfigTweaks.MISC.utDisableNarratorToggle) ci.cancel();
     }
 
+    /**
+     * @author ACGaming
+     * @reason short circuit making the narrator announce the mode (active/inactive)
+     */
     @Inject(method = "announceMode", at = @At("HEAD"), cancellable = true)
     public void utNarratorAnnounceMode(int p_193641_1_, CallbackInfo ci)
     {

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/narrator/mixin/UTNarratorMixin.java
@@ -4,6 +4,10 @@ import net.minecraft.client.gui.chat.NarratorChatListener;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.text2speech.Narrator;
+import com.mojang.text2speech.NarratorDummy;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,6 +18,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(NarratorChatListener.class)
 public class UTNarratorMixin
 {
+    /**
+     * @author WaitingIdly
+     * @reason disable the initialization of the narrator and the narrator thread by redirecting to use {@link NarratorDummy}
+     */
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/text2speech/Narrator;getNarrator()Lcom/mojang/text2speech/Narrator;", remap = false))
+    private Narrator utUseDummyNarrator(Operation<Narrator> original)
+    {
+        if (!UTConfigTweaks.MISC.utDisableNarratorToggle) return original.call();
+        return new NarratorDummy();
+    }
+
     @Inject(method = "say", at = @At("HEAD"), cancellable = true)
     public void utNarratorSay(ChatType chatTypeIn, ITextComponent message, CallbackInfo ci)
     {


### PR DESCRIPTION
changes in this PR:
- the current implementation of the Narrator mixin disables *using* the narrator, but does not disable the creation of the narrator thread. this changes the code to create a `DummyNarrator` instead of creating a narrator based on the platform.
- remove the `utNarratorState` method mixin, as with `DummyNarrator` that will always be false regardless.
- add javadocs comments to the mixin methods 