### PR TITLE
Cleanup Woot ticket when server is stopped

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -240,6 +240,12 @@ public class UniversalTweaks
     }
 
     @Mod.EventHandler
+    public void onServerStopped(FMLServerStoppedEvent event)
+    {
+        if (Loader.isModLoaded("woot")) UTWootTicketManager.resetTicket();
+    }
+
+    @Mod.EventHandler
     public void onLoadComplete(FMLLoadCompleteEvent event)
     {
         if (UTConfigTweaks.PERFORMANCE.ENTITY_RADIUS_CHECK.utEntityRadiusCheckCategoryToggle) UTEntityRadiusCheck.onLoadComplete();

--- a/src/main/java/mod/acgaming/universaltweaks/mods/woot/UTWootTicketManager.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/woot/UTWootTicketManager.java
@@ -66,4 +66,10 @@ public class UTWootTicketManager
         UTWootTicketManager.ticket = tickets.get(0);
         ((ITartarusCleaner) Woot.tartarusManager).ut$freeBoxes();
     }
+
+    // Guarantee the manager doesn't leak the ticket to a different save
+    public static void resetTicket()
+    {
+        ticket = null;
+    }
 }


### PR DESCRIPTION
Fixes an edge-case in singleplayer upon enabling the Woot tweak where joining a world, leaving, and then joining a different world that did not originally have the Woot tweak enabled would cause a crash due to the leaked ticket being used.
```
Caused by: java.lang.NullPointerException: Cannot invoke "com.google.common.collect.Multimap.containsEntry(Object, Object)" because the return value of "java.util.Map.get(Object)" is null
	at net.minecraftforge.common.ForgeChunkManager.forceChunk(ForgeChunkManager.java:812) ~[ForgeChunkManager.class:14.23.5.2860]
	at mod.acgaming.universaltweaks.mods.woot.UTWootTicketManager.forceChunk(UTWootTicketManager.java:34) ~[UTWootTicketManager.class:?]
	...
```