### PR TITLE
fix CFB Oven fix remap issue

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/cookingforblockheads/mixin/UTTileOvenMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cookingforblockheads/mixin/UTTileOvenMixin.java
@@ -20,9 +20,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = TileOven.class, remap = false)
 public abstract class UTTileOvenMixin
 {
-    @Shadow
-    public abstract void update();
-
     /**
      * @author Invadermonky
      * @reason Fixing Cooking For Blockheads Oven consuming fuel container items.<br>
@@ -44,7 +41,7 @@ public abstract class UTTileOvenMixin
      *     ItemStack before the shrink.
      * </p>
      */
-    @Inject(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;shrink(I)V"))
+    @Inject(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;shrink(I)V"), remap = true)
     private void updateCaptureFuelItem(CallbackInfo ci, @Local(ordinal = 0) ItemStack fuelItem, @Share("fuelStackCopy") LocalRef<ItemStack> localRef) {
         localRef.set(fuelItem.copy());
     }
@@ -72,7 +69,8 @@ public abstract class UTTileOvenMixin
      */
     @Redirect(
         method = "update",
-        at = @At(value = "INVOKE", target = "Lnet/minecraftforge/items/wrapper/RangedWrapper;setStackInSlot(ILnet/minecraft/item/ItemStack;)V", ordinal = 0)
+        at = @At(value = "INVOKE", target = "Lnet/minecraftforge/items/wrapper/RangedWrapper;setStackInSlot(ILnet/minecraft/item/ItemStack;)V", ordinal = 0),
+        remap = true
     )
     private void updateRedirectFuelConsumption(RangedWrapper instance, int i, ItemStack itemStack, @Share("fuelStackCopy") LocalRef<ItemStack> localRef) {
         ItemStack copy = localRef.get();


### PR DESCRIPTION
Fixes a remap issue with the current `UTTileOvenMixin` for Cooking For Blockheads.