### PR TITLE
Optimize desync entity lookup

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/UTEntityDesync.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/entities/desync/UTEntityDesync.java
@@ -1,12 +1,12 @@
 package mod.acgaming.universaltweaks.bugfixes.entities.desync;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityEntry;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 import mod.acgaming.universaltweaks.UniversalTweaks;
@@ -14,7 +14,7 @@ import mod.acgaming.universaltweaks.config.UTConfigBugfixes;
 
 public class UTEntityDesync
 {
-    public static List<EntityEntry> blacklistedEntityEntries = new ArrayList<>();
+    public static final Set<Class<? extends Entity>> blacklistedEntityEntries = new ObjectOpenHashSet<>();
 
     public static void initBlacklistedEntityEntries()
     {
@@ -24,7 +24,14 @@ public class UTEntityDesync
             for (String entry : UTConfigBugfixes.ENTITIES.ENTITY_DESYNC.utEntityDesyncBlacklist)
             {
                 ResourceLocation resLoc = new ResourceLocation(entry);
-                if (ForgeRegistries.ENTITIES.containsKey(resLoc)) blacklistedEntityEntries.add(ForgeRegistries.ENTITIES.getValue(resLoc));
+                if (ForgeRegistries.ENTITIES.containsKey(resLoc))
+                {
+                    EntityEntry entityEntry = ForgeRegistries.ENTITIES.getValue(resLoc);
+                    if (entityEntry == null) continue;
+                    Class<? extends Entity> entityClass = entityEntry.getEntityClass();
+                    if (entityClass == null) continue;
+                    blacklistedEntityEntries.add(entityClass);
+                }
             }
         }
         catch (Exception e)
@@ -36,6 +43,6 @@ public class UTEntityDesync
 
     public static boolean isBlacklisted(Entity entity)
     {
-        return blacklistedEntityEntries.contains(EntityRegistry.getEntry(entity.getClass())) || !(((IPrevMotion) entity).hasSuperUpdate());
+        return blacklistedEntityEntries.contains(entity.getClass()) || !(((IPrevMotion) entity).hasSuperUpdate());
     }
 }


### PR DESCRIPTION
The UTEntityDesync blacklist is in the entity tracker hot path, the original method took much time to lookup the array list.

This PR replaces list with hashset to provide faster lookup, avoids lookup the registry every time when checking the blacklist.