### PR TITLE
Add view bobbing tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -97,6 +97,13 @@ public class UTConfigTweaks
         }
     }
 
+    public enum BobbingMode
+    {
+        DEFAULT,
+        HAND_ONLY,
+        CAMERA_ONLY
+    }
+
     public static class BlocksCategory
     {
         @Config.LangKey("cfg.universaltweaks.tweaks.blocks.anvil")
@@ -1810,6 +1817,15 @@ public class UTConfigTweaks
             })
         public int utXPLevelCap = -1;
 
+        @Config.Name("View Bobbing Mode")
+        @Config.Comment
+            ({
+                "Sets the view bobbing mode",
+                "Default: Bobs both hand and camera (vanilla default)",
+                "Hand only: Bobs only hand",
+                "Camera only: Bobs only camera"
+            })
+        public BobbingMode utViewBobbing = BobbingMode.DEFAULT;
 
         public static class AdvancementsCategory
         {

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -248,6 +248,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins.tweaks.misc.sound.pitch.json", () -> UTConfigTweaks.MISC.utUnlimitedSoundPitchRange);
                 put("mixins.tweaks.misc.timeouts.client.json", () -> UTConfigTweaks.MISC.TIMEOUTS.utTimeoutsToggle);
                 put("mixins.tweaks.misc.toastcontrol.json", () -> UTConfigTweaks.MISC.TOAST_CONTROL.utToastControlToggle);
+                put("mixins.tweaks.misc.viewbobbing.json", () -> true);
                 put("mixins.tweaks.performance.audioreload.json", () -> UTConfigTweaks.PERFORMANCE.utDisableAudioDebugToggle && !Coremods.SURGE.isLoaded());
                 put("mixins.tweaks.performance.connectionspeed.json", () -> UTConfigTweaks.PERFORMANCE.utImproveLanguageSwitchingSpeed);
                 put("mixins.tweaks.performance.fps.json", () -> UTConfigTweaks.PERFORMANCE.utUncapFPSToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTApplyBobbingInvoker.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTApplyBobbingInvoker.java
@@ -1,0 +1,13 @@
+package mod.acgaming.universaltweaks.tweaks.misc.viewbobbing.mixin;
+
+import net.minecraft.client.renderer.EntityRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(EntityRenderer.class)
+public interface UTApplyBobbingInvoker
+{
+    @Invoker("applyBobbing")
+    void applyBobbing(float partialTicks);
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTViewBobbingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTViewBobbingMixin.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.tweaks.misc.viewbobbing.mixin;
+
+import net.minecraft.client.renderer.EntityRenderer;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks.BobbingMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(EntityRenderer.class)
+public class UTViewBobbingMixin
+{
+    @Redirect(method = "setupCameraTransform", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;applyBobbing(F)V"))
+    private void utCameraBobbing(EntityRenderer entity, float partialTicks)
+    {
+        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.HAND_ONLY) ((UTApplyBobbingInvoker) (Object)entity).applyBobbing(partialTicks);
+    }
+
+    @Redirect(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;applyBobbing(F)V"))
+    private void utHandBobbing(EntityRenderer entity, float partialTicks)
+    {
+        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.CAMERA_ONLY) ((UTApplyBobbingInvoker) (Object)entity).applyBobbing(partialTicks);
+    }
+}

--- a/src/main/resources/mixins.tweaks.misc.viewbobbing.json
+++ b/src/main/resources/mixins.tweaks.misc.viewbobbing.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.viewbobbing.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTViewBobbingMixin", "UTApplyBobbingInvoker"]
+}


### PR DESCRIPTION
Implements https://github.com/ACGaming/UniversalTweaks/discussions/710

Adds option to bob only the hand or the camera. This tweak requires Minecraft view bobbing setting to be enabled.