### PR TITLE
Fix view bobbing unimplemented interface error

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTApplyBobbingInvoker.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTApplyBobbingInvoker.java
@@ -9,5 +9,5 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 public interface UTApplyBobbingInvoker
 {
     @Invoker("applyBobbing")
-    void applyBobbing(float partialTicks);
+    void invokeApplyBobbing(float partialTicks);
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTViewBobbingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/viewbobbing/mixin/UTViewBobbingMixin.java
@@ -14,12 +14,12 @@ public class UTViewBobbingMixin
     @Redirect(method = "setupCameraTransform", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;applyBobbing(F)V"))
     private void utCameraBobbing(EntityRenderer entity, float partialTicks)
     {
-        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.HAND_ONLY) ((UTApplyBobbingInvoker) (Object)entity).applyBobbing(partialTicks);
+        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.HAND_ONLY) ((UTApplyBobbingInvoker) (Object)entity).invokeApplyBobbing(partialTicks);
     }
 
     @Redirect(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;applyBobbing(F)V"))
     private void utHandBobbing(EntityRenderer entity, float partialTicks)
     {
-        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.CAMERA_ONLY) ((UTApplyBobbingInvoker) (Object)entity).applyBobbing(partialTicks);
+        if (UTConfigTweaks.MISC.utViewBobbing != BobbingMode.CAMERA_ONLY) ((UTApplyBobbingInvoker) (Object)entity).invokeApplyBobbing(partialTicks);
     }
 }


### PR DESCRIPTION
Turns out the invoker name cannot be the same with the original method name. This crashes the game when playing. I was renaming the invoker name and didn't test it before pushing the code.

Apologies with the issue, I'm still learning about mixin since a week ago.