### PR TITLE
Allow Armor Swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ All changes are toggleable via config files.
 * **Anvil XP Level Cap:** Sets the experience level cap for anvil recipes
 * **Armed Armor Stands:** Enables arms for armor stands by default
 * **Armor Curve:** Adjusts the armor scaling and degradation formulae for mobs and players
+* **Armor Swap:** Enable the ability to swap equipped armor when right-clicking armor, instead of only being able to equip armor when the slot is empty. Also applies to Elytra
 * **Attributes:** Sets custom ranges for entity attributes
 * **Auto Jump Replacement:** Replaces auto jump with an increased step height (singleplayer only)
 * **Auto Save Interval:** Configurable interval in ticks between world auto saves

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1587,6 +1587,11 @@ public class UTConfigTweaks
         public boolean utReturnToMainMenu = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Armor Swap")
+        @Config.Comment("Enable the ability to swap equipped armor when right-clicking armor, instead of only being able to equip armor when the slot is empty. Also applies to Elytra")
+        public boolean utArmorSwap = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Copy World Seed")
         @Config.Comment
             ({

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -148,6 +148,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins.tweaks.items.xpbottle.json", () -> UTConfigTweaks.ITEMS.utXPBottleAmount != -1);
                 put("mixins.tweaks.misc.advancements.json", () -> UTConfigTweaks.MISC.utDisableAdvancementsToggle);
                 put("mixins.tweaks.misc.armorcurve.json", () -> UTConfigTweaks.MISC.ARMOR_CURVE.utArmorCurveToggle);
+                put("mixins.tweaks.misc.armorswap.json", () -> UTConfigTweaks.MISC.utArmorSwap);
                 put("mixins.tweaks.misc.bannerlayers.json", () -> UTConfigTweaks.MISC.utBannerLayers != 6);
                 put("mixins.tweaks.misc.commands.seed.json", () -> UTConfigTweaks.MISC.utCopyWorldSeedToggle);
                 put("mixins.tweaks.misc.difficulty.singleplayer.json", () -> true);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/armorswap/mixin/UTItemArmorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/armorswap/mixin/UTItemArmorMixin.java
@@ -1,0 +1,39 @@
+package mod.acgaming.universaltweaks.tweaks.misc.armorswap.mixin;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemElytra;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin({ItemArmor.class, ItemElytra.class})
+public class UTItemArmorMixin
+{
+    /**
+     * @reason change check from "is armor slot empty" to "does armor slot not have curse of binding"
+     * @author WaitingIdly
+     */
+    @WrapOperation(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
+    private boolean utCheckNotBindingCurse(ItemStack stack, Operation<Boolean> original)
+    {
+        return !EnchantmentHelper.hasBindingCurse(stack);
+    }
+
+    /**
+     * @reason set the return value to be the itemstack that was in the armor slot, which will cause the hand to be replaced by it
+     * @author WaitingIdly
+     */
+    @ModifyReturnValue(method = "onItemRightClick", at = @At(value = "RETURN", ordinal = 0))
+    private ActionResult<ItemStack> utSwapEquippedArmorStack(ActionResult<ItemStack> original, @Local(ordinal = 1) ItemStack armorStack)
+    {
+        return new ActionResult<>(EnumActionResult.SUCCESS, armorStack);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/armorswap/mixin/UTItemArmorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/armorswap/mixin/UTItemArmorMixin.java
@@ -28,12 +28,13 @@ public class UTItemArmorMixin
     }
 
     /**
-     * @reason set the return value to be the itemstack that was in the armor slot, which will cause the hand to be replaced by it
+     * @reason if the hand stack is empty, set the return value to be the itemstack that was in the armor slot,
+     * which will cause the hand to be replaced by it
      * @author WaitingIdly
      */
     @ModifyReturnValue(method = "onItemRightClick", at = @At(value = "RETURN", ordinal = 0))
-    private ActionResult<ItemStack> utSwapEquippedArmorStack(ActionResult<ItemStack> original, @Local(ordinal = 1) ItemStack armorStack)
+    private ActionResult<ItemStack> utSwapEquippedArmorStack(ActionResult<ItemStack> original, @Local(ordinal = 0) ItemStack handStack, @Local(ordinal = 1) ItemStack armorStack)
     {
-        return new ActionResult<>(EnumActionResult.SUCCESS, armorStack);
+        return handStack.isEmpty() ? new ActionResult<>(EnumActionResult.SUCCESS, armorStack) : original;
     }
 }

--- a/src/main/resources/mixins.tweaks.misc.armorswap.json
+++ b/src/main/resources/mixins.tweaks.misc.armorswap.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.armorswap.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemArmorMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add a mixin to `ItemArmor` and `ItemElytra` that changes the logic from "if slot empty, put in slot" to "if slot not binding, if hand empty place armor in hand" (default: `false`)

resolves #683 