### PR TITLE
Some DivineRPG Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,9 @@ All changes are toggleable via config files.
 * **Corpse**
     * **Opening GUIs Off-thread Fix:** Fixes opening up GUIs on a non-client thread
 * **Divine RPG**
-    * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
+    * **Change Water Mob Creature Type:** Changes the creature type for DivineRPG Water Mobs to be WATER_CREATURE, fixing issues with hostile mob spawn caps and infinite water mob spawning
     * **Fix Aquamarine Stack Size:** Aquamarine has durability, yet doesn't have a max stack size of 1
+    * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory
 * **Electroblob's Wizardry**

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ All changes are toggleable via config files.
     * **Oven Fix:** Fixes CFB Oven consuming container fuel items
 * **Corpse**
     * **Opening GUIs Off-thread Fix:** Fixes opening up GUIs on a non-client thread
+* **Divine RPG**
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory
 * **Electroblob's Wizardry**

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ All changes are toggleable via config files.
     * **Opening GUIs Off-thread Fix:** Fixes opening up GUIs on a non-client thread
 * **Divine RPG**
     * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
+    * **Fix Aquamarine Stack Size:** Aquamarine has durability, yet doesn't have a max stack size of 1
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory
 * **Electroblob's Wizardry**

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ All changes are toggleable via config files.
 * **Corpse**
     * **Opening GUIs Off-thread Fix:** Fixes opening up GUIs on a non-client thread
 * **Divine RPG**
+    * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory
 * **Electroblob's Wizardry**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -87,6 +87,7 @@ final def mod_dependencies = [
     'curse.maven:ctm-267602:2915363'                                  : [debug_chisel],
     'curse.maven:cyclops-core-232758:3159497'                         : [debug_evilcraft],
     'curse.maven:effortlessbuilding-302113:2847346'                   : [debug_effortless_building],
+    'curse.maven:official-divinerpg-363543:3081433'                   : [debug_divinerpg],
     'curse.maven:electroblobs-wizardry-265642:5354477'                : [debug_electroblobs_wizardry],
     'curse.maven:elementary-staffs-346007:2995593'                    : [debug_elementary_staffs],
     'curse.maven:elenaidodge2-442962:3343308'                         : [debug_elenai_dodge_2],

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ debug_cooking_for_blockheads = false
 debug_corpse = false
 debug_cqrepoured = false
 debug_crafttweaker = false
+debug_divinerpg = false
 debug_effortless_building = false
 debug_electroblobs_wizardry = false
 debug_elementary_staffs = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -593,6 +593,15 @@ public class UTConfigMods
     public static class DivineRPGCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Fix Aquamarine Stack Size")
+        @Config.Comment
+            ({
+                "Aquamarine nominally has durability, but does not set the max stack size to 1.",
+                "As the tweak \"Fix Consuming Incorrect Hand\" fixes the bug preventing durability from being used, fixing the stack size is also needed."
+            })
+        public boolean utFixAquamarineStackSize = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Consuming Incorrect Hand")
         @Config.Comment("Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used")
         public boolean utFixHandConsumption = true;

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -107,6 +107,10 @@ public class UTConfigMods
     @Config.Name("Corpse")
     public static final CorpseCategory CORPSE = new CorpseCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.divineprg")
+    @Config.Name("Divine RPG")
+    public static final DivineRPGCategory DIVINE_RPG = new DivineRPGCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.effortlessbuilding")
     @Config.Name("Effortless Building")
     public static final EffortlessBuildingCategory EFFORTLESS_BUILDING = new EffortlessBuildingCategory();
@@ -584,6 +588,10 @@ public class UTConfigMods
         @Config.Name("Opening GUIs Off-thread Fix")
         @Config.Comment("Fixes opening up GUIs on a non-client thread")
         public boolean utOpeningGuisOffThreadFixToggle = true;
+    }
+
+    public static class DivineRPGCategory
+    {
     }
 
     public static class EffortlessBuildingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -592,6 +592,10 @@ public class UTConfigMods
 
     public static class DivineRPGCategory
     {
+        @Config.RequiresMcRestart
+        @Config.Name("Fix Consuming Incorrect Hand")
+        @Config.Comment("Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used")
+        public boolean utFixHandConsumption = true;
     }
 
     public static class EffortlessBuildingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -593,6 +593,11 @@ public class UTConfigMods
     public static class DivineRPGCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Change Water Mob Creature Type")
+        @Config.Comment("Changes the creature type for DivineRPG Water Mobs to be WATER_CREATURE, fixing issues with hostile mob spawn caps and infinite water mob spawning")
+        public boolean utChangeWaterMobCreatureType = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Aquamarine Stack Size")
         @Config.Comment
             ({

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -82,6 +82,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
                 put("mixins.mods.divinerpg.aquamarine.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
                 put("mixins.mods.divinerpg.hand.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixHandConsumption);
+                put("mixins.mods.divinerpg.waterspawning.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utChangeWaterMobCreatureType);
                 put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
                 put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
                 put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -80,6 +80,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.cookingforblockheads.json", () -> loaded("cookingforblockheads") && UTConfigMods.COOKING_FOR_BLOCKHEADS.utOvenFixToggle);
                 put("mixins.mods.corpse.json", () -> loaded("corpse") && UTConfigMods.CORPSE.utOpeningGuisOffThreadFixToggle);
                 put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
+                put("mixins.mods.divinerpg.aquamarine.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
                 put("mixins.mods.divinerpg.hand.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixHandConsumption);
                 put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
                 put("mixins.mods.elementarystaffs.json", () -> loaded("element"));

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -80,6 +80,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.cookingforblockheads.json", () -> loaded("cookingforblockheads") && UTConfigMods.COOKING_FOR_BLOCKHEADS.utOvenFixToggle);
                 put("mixins.mods.corpse.json", () -> loaded("corpse") && UTConfigMods.CORPSE.utOpeningGuisOffThreadFixToggle);
                 put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
+                put("mixins.mods.divinerpg.hand.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixHandConsumption);
                 put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
                 put("mixins.mods.elementarystaffs.json", () -> loaded("element"));
                 put("mixins.mods.elenaidodge2.json", () -> loaded("elenaidodge2"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/aquamarine/mixin/UTItemAquamarineMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/aquamarine/mixin/UTItemAquamarineMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.aquamarine.mixin;
+
+import divinerpg.objects.items.arcana.ItemAquamarine;
+import divinerpg.objects.items.base.ItemMod;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemAquamarine.class, remap = false)
+public abstract class UTItemAquamarineMixin extends ItemMod
+{
+    private UTItemAquamarineMixin(String name)
+    {
+        super(name);
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason Aquamarine has durability, but doesn't set max stack size to 1.
+     */
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void utCorrectMaxStackSize(String name, CallbackInfo ci)
+    {
+        setMaxStackSize(1);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemAquamarineMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemAquamarineMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.objects.items.arcana.ItemAquamarine;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemAquamarine.class, remap = false)
+public abstract class UTItemAquamarineMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason fix completely ignoring the actual itemstack being used and instead creating and modifying the durability of a new instance.
+     */
+    @WrapOperation(method = "onItemUse", at = @At(value = "NEW", target = "(Lnet/minecraft/item/Item;)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utUseCorrectHand(Item itemIn, Operation<ItemStack> original, @Local(argsOnly = true) EntityPlayer player, @Local(argsOnly = true) EnumHand hand)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixHandConsumption) return original.call(itemIn);
+        return player.getHeldItem(hand);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemBossSpawnerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemBossSpawnerMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.objects.items.twilight.ItemBossSpawner;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemBossSpawner.class, remap = false)
+public abstract class UTItemBossSpawnerMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason fix item voiding and duplication when using any of the boss spawning items in the offhand
+     */
+    @WrapOperation(method = "onItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;getHeldItemMainhand()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utUseCorrectHand(EntityPlayer instance, Operation<ItemStack> original, @Local(argsOnly = true) EnumHand hand)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixHandConsumption) return original.call(instance);
+        return instance.getHeldItem(hand);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemEnderScepterMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemEnderScepterMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.objects.items.arcana.ItemEnderScepter;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemEnderScepter.class, remap = false)
+public abstract class UTItemEnderScepterMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason fix item deletion and ghost item bugs when using the staff in the offhand
+     */
+    @WrapOperation(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;getHeldItemMainhand()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utUseCorrectHand(EntityPlayer instance, Operation<ItemStack> original, @Local(argsOnly = true) EnumHand hand)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixHandConsumption) return original.call(instance);
+        return instance.getHeldItem(hand);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemGrenadeMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemGrenadeMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.objects.items.arcana.ItemGrenade;
+import divinerpg.objects.items.twilight.ItemBossSpawner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemGrenade.class, remap = false)
+public abstract class UTItemGrenadeMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason fix item voiding and duplication when using the grenade in the offhand
+     */
+    @WrapOperation(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;getHeldItemMainhand()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utUseCorrectHand(EntityPlayer instance, Operation<ItemStack> original, @Local(argsOnly = true) EnumHand hand)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixHandConsumption) return original.call(instance);
+        return instance.getHeldItem(hand);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemHordeHornMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/hand/mixin/UTItemHordeHornMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.objects.items.twilight.ItemBossSpawner;
+import divinerpg.objects.items.vanilla.ItemHordeHorn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemHordeHorn.class, remap = false)
+public abstract class UTItemHordeHornMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason fix item voiding and duplication when using the horde horn in the offhand
+     */
+    @WrapOperation(method = "onItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;getHeldItemMainhand()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack utUseCorrectHand(EntityPlayer instance, Operation<ItemStack> original, @Local(argsOnly = true) EnumHand hand)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixHandConsumption) return original.call(instance);
+        return instance.getHeldItem(hand);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/waterspawning/mixin/UTEntityDivineWaterMobMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/waterspawning/mixin/UTEntityDivineWaterMobMixin.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.waterspawning.mixin;
+
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+
+import divinerpg.objects.entities.entity.EntityDivineWaterMob;
+import divinerpg.objects.entities.entity.EntityPeacefulUntilAttacked;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+
+// Courtesy of WaitingIdly
+@Mixin(value = EntityDivineWaterMob.class, remap = false)
+public abstract class UTEntityDivineWaterMobMixin extends EntityPeacefulUntilAttacked
+{
+    public UTEntityDivineWaterMobMixin(World worldIn)
+    {
+        super(worldIn);
+    }
+
+    /**
+     * Changes the effective creature type to water creature because it replaces squid spawns.
+     * Without this, if water mob spawning is blocked via {@link LivingSpawnEvent.CheckSpawn}
+     * then infinite divinerpg water mobs can spawn, which also takes up the hostile mob cap.
+     *
+     * @author WaitingIdly
+     * @see divinerpg.registry.EntitySpawnRegistry#onLivingSpawn(LivingSpawnEvent.CheckSpawn) EntitySpawnRegistry.onLivingSpawn(LivingSpawnEvent.CheckSpawn)
+     */
+    @Override
+    public boolean isCreatureType(@NotNull EnumCreatureType type, boolean forSpawnCount)
+    {
+        if (forSpawnCount && this.isNoDespawnRequired()) return false;
+        return type == EnumCreatureType.WATER_CREATURE;
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -73,6 +73,7 @@ cfg.universaltweaks.modintegration.collective=Collective
 cfg.universaltweaks.modintegration.compactmachines=Compact Machines
 cfg.universaltweaks.modintegration.cookingforblockheads=Cooking For Blockheads
 cfg.universaltweaks.modintegration.corpse=Corpse
+cfg.universaltweaks.modintegration.divinerpg=Divine RPG
 cfg.universaltweaks.modintegration.cqrepoured=Chocolate Quest Repoured
 cfg.universaltweaks.modintegration.effortlessbuilding=Effortless Building
 cfg.universaltweaks.modintegration.electroblobswizardry=Electroblob's Wizardry

--- a/src/main/resources/mixins.mods.divinerpg.aquamarine.json
+++ b/src/main/resources/mixins.mods.divinerpg.aquamarine.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.divinerpg.aquamarine.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemAquamarineMixin"]
+}

--- a/src/main/resources/mixins.mods.divinerpg.hand.json
+++ b/src/main/resources/mixins.mods.divinerpg.hand.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.divinerpg.hand.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemAquamarineMixin", "UTItemBossSpawnerMixin", "UTItemEnderScepterMixin", "UTItemGrenadeMixin", "UTItemHordeHornMixin"]
+}

--- a/src/main/resources/mixins.mods.divinerpg.waterspawning.json
+++ b/src/main/resources/mixins.mods.divinerpg.waterspawning.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.divinerpg.waterspawning.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTEntityDivineWaterMobMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add fixes for DivineRPG
- fix a number of instances where an itemstack was consumed from the main hand instead of the using hand, leading to duplication and voiding effects (default: `true`)
	- fix one case where it modifies a new itemstack (aquamarine)
- fix aquamarine being stackable despite having durability (only matters if the hand fix is true) (default: `true`)
- change `EntityDivineWaterMob` to be of type `EnumCreatureType.WATER_CREATURE`, fixing issues where they took up (and exceeded) hostile mob caps or continued to spawn infinitely if squid spawning was also blocked (default: `false`)