### PR TITLE
Some Immersive Engineering Tool Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ All changes are toggleable via config files.
     * **Fix Restructurer Crash:** Safely access a nullable value when checking recipes in the Restructurer
 * **HWYLA**
     * **Keybindings Fix:** Fixes crashes in all menus when changing HWYLA keybindings to unsupported values
+* **Immersive Engineering**
 * **In Control!**
     * **Spawn Rule Stats Fix:** Fixes onJoin spawn rules repeatedly modifying mob attack/health/speed
 * **IndustrialCraft 2**

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ All changes are toggleable via config files.
     * **Keybindings Fix:** Fixes crashes in all menus when changing HWYLA keybindings to unsupported values
 * **Immersive Engineering**
     * **Tool Break Fire Event:** Fires the PlayerDestroyItemEvent when an Immersive Engineering tool breaks, fixing a number of cross-compatibility issues
+    * **Tool Break Hand Replacement:** Fixes the tool breaking setting the main hand to empty regardless of what hand the tool is in
 * **In Control!**
     * **Spawn Rule Stats Fix:** Fixes onJoin spawn rules repeatedly modifying mob attack/health/speed
 * **IndustrialCraft 2**

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ All changes are toggleable via config files.
 * **HWYLA**
     * **Keybindings Fix:** Fixes crashes in all menus when changing HWYLA keybindings to unsupported values
 * **Immersive Engineering**
+    * **Tool Break Fire Event:** Fires the PlayerDestroyItemEvent when an Immersive Engineering tool breaks, fixing a number of cross-compatibility issues
 * **In Control!**
     * **Spawn Rule Stats Fix:** Fixes onJoin spawn rules repeatedly modifying mob attack/health/speed
 * **IndustrialCraft 2**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -102,6 +102,7 @@ final def mod_dependencies = [
     'curse.maven:geckolib-388172:4020277'                             : [debug_cqrepoured],
     'curse.maven:guideapi-228832:2645992'                             : [debug_blood_magic],
     'curse.maven:hwyla-253449:2568751'                                : [debug_hwyla],
+    'curse.maven:immersive_engineering-231951:2974106'                : [debug_immersive_engineering],
     'curse.maven:incontrol-257356:3101719'                            : [debug_incontrol],
     'curse.maven:industrialcraft-242638:3078604'                      : [debug_industrialcraft],
     'curse.maven:infinitylib-251396:3317119'                          : [debug_agricraft],

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ debug_forgemultipartcbe = false
 debug_fps_reducer = false
 debug_gaiadimension = false
 debug_hwyla = false
+debug_immersive_engineering = false
 debug_incontrol = false
 debug_industrial_foregoing = false
 debug_industrialcraft = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -802,6 +802,11 @@ public class UTConfigMods
         @Config.Name("Tool Break Fire Event")
         @Config.Comment("Fires the PlayerDestroyItemEvent when an Immersive Engineering tool breaks, fixing a number of cross-compatibility issues")
         public boolean utFireBreakEvent = true;
+        
+        @Config.RequiresMcRestart
+        @Config.Name("Tool Break Hand Replacement")
+        @Config.Comment("Fixes the tool breaking setting the main hand to empty regardless of what hand the tool is in")
+        public boolean utFixIncorrectHandReplacement = true;
     }
 
     public static class InControlCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -159,6 +159,10 @@ public class UTConfigMods
     @Config.Name("Gaia Dimension")
     public static final GaiaDimensionCategory GAIA_DIMENSION = new GaiaDimensionCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.immersiveengineering")
+    @Config.Name("Immersive Engineering")
+    public static final ImmersiveEngineeringCategory IMMERSIVE_ENGINEERING = new ImmersiveEngineeringCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.incontrol")
     @Config.Name("In Control!")
     public static final InControlCategory INCONTROL = new InControlCategory();
@@ -790,6 +794,10 @@ public class UTConfigMods
         @Config.Name("Fix Restructurer Crash")
         @Config.Comment("Safely access a nullable array when checking recipes in the Restructurer")
         public boolean utFixNPERestructurerRecipe = true;
+    }
+
+    public static class ImmersiveEngineeringCategory
+    {
     }
 
     public static class InControlCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -798,6 +798,10 @@ public class UTConfigMods
 
     public static class ImmersiveEngineeringCategory
     {
+        @Config.RequiresMcRestart
+        @Config.Name("Tool Break Fire Event")
+        @Config.Comment("Fires the PlayerDestroyItemEvent when an Immersive Engineering tool breaks, fixing a number of cross-compatibility issues")
+        public boolean utFireBreakEvent = true;
     }
 
     public static class InControlCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -103,6 +103,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.forestry.extratrees.json", () -> loaded("extratrees") && UTConfigMods.FORESTRY.utFOGatherWindfallToggle);
                 put("mixins.mods.forestry.json", () -> loaded("forestry"));
                 put("mixins.mods.immersiveengineering.toolevent.json", () -> loaded("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utFireBreakEvent);
+                put("mixins.mods.immersiveengineering.toolhand.json", () -> loaded("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utFixIncorrectHandReplacement);
                 put("mixins.mods.incontrol.json", () -> loaded("incontrol") && UTConfigMods.INCONTROL.utStatsFixToggle);
                 put("mixins.mods.industrialcraft.dupes.json", () -> loaded("ic2") && UTConfigMods.INDUSTRIALCRAFT.utDuplicationFixesToggle);
                 put("mixins.mods.industrialforegoing.dupes.json", () -> loaded("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -102,6 +102,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.extrautilities.radar.json", () -> loaded("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utCatchRadarException);
                 put("mixins.mods.forestry.extratrees.json", () -> loaded("extratrees") && UTConfigMods.FORESTRY.utFOGatherWindfallToggle);
                 put("mixins.mods.forestry.json", () -> loaded("forestry"));
+                put("mixins.mods.immersiveengineering.toolevent.json", () -> loaded("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utFireBreakEvent);
                 put("mixins.mods.incontrol.json", () -> loaded("incontrol") && UTConfigMods.INCONTROL.utStatsFixToggle);
                 put("mixins.mods.industrialcraft.dupes.json", () -> loaded("ic2") && UTConfigMods.INDUSTRIALCRAFT.utDuplicationFixesToggle);
                 put("mixins.mods.industrialforegoing.dupes.json", () -> loaded("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/handreplacement/mixin/UTIEToolMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/handreplacement/mixin/UTIEToolMixin.java
@@ -1,0 +1,37 @@
+package mod.acgaming.universaltweaks.mods.immersivenegineering.handreplacement.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+import blusunrize.immersiveengineering.common.items.ItemIETool;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemIETool.class, remap = false)
+public abstract class UTIEToolMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason Fix setting the stack not accounting for what hand was used
+     */
+    @WrapOperation(method = "onItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;setItemStackToSlot(Lnet/minecraft/inventory/EntityEquipmentSlot;Lnet/minecraft/item/ItemStack;)V"))
+    private void utReplaceCorrectItem(EntityPlayer instance, EntityEquipmentSlot slotIn, ItemStack stack, Operation<Void> original, @Local(ordinal = 0, argsOnly = true) EnumHand hand)
+    {
+        if (UTConfigMods.IMMERSIVE_ENGINEERING.utFixIncorrectHandReplacement)
+        {
+            instance.setHeldItem(hand, stack);
+        }
+        else
+        {
+            original.call(instance, slotIn, stack);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/toolevent/mixin/UTIEToolMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/toolevent/mixin/UTIEToolMixin.java
@@ -1,0 +1,83 @@
+package mod.acgaming.universaltweaks.mods.immersivenegineering.toolevent.mixin;
+
+import java.util.Random;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
+
+import blusunrize.immersiveengineering.common.items.ItemIETool;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ItemIETool.class, remap = false)
+public abstract class UTIEToolMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason if the container itemstack used is empty, fire {@link PlayerDestroyItemEvent} with the original stack.
+     */
+    @Inject(method = "getContainerItem", at = @At(value = "INVOKE", target = "Lblusunrize/immersiveengineering/common/items/ItemIETool;damageIETool(Lnet/minecraft/item/ItemStack;ILjava/util/Random;Lnet/minecraft/entity/player/EntityPlayer;)V", shift = At.Shift.AFTER))
+    private void utFireDestroyForContainer(ItemStack stack, CallbackInfoReturnable<ItemStack> cir, @Local(ordinal = 1) ItemStack container)
+    {
+        if (container.isEmpty())
+        {
+            ForgeEventFactory.onPlayerDestroyItem(ForgeHooks.getCraftingPlayer(), stack, null);
+        }
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason store a copy of the original itemstack for use in {@link #utFireDestroyOnDamage}.
+     */
+    @Inject(method = "damageIETool", at = @At("HEAD"))
+    private void utStoreHand(ItemStack stack, int amount, Random rand, EntityPlayer player, CallbackInfo ci, @Share("original") LocalRef<ItemStack> original)
+    {
+        original.set(stack.copy());
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason if the current stack is empty and player is not null
+     * (which means not handled by {@link #utFireDestroyForContainer}) fire {@link PlayerDestroyItemEvent} with the original itemstack.
+     * Due to not having direct access to the hand used, we use the best approximation of "main hand then offhand" - since this section will only
+     * be called when breaking a block, there should not be situations where this approximation is incorrect.
+     */
+    @Inject(method = "damageIETool", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;shrink(I)V", shift = At.Shift.AFTER))
+    private void utFireDestroyOnDamage(ItemStack stack, int amount, Random rand, EntityPlayer player, CallbackInfo ci, @Share("original") LocalRef<ItemStack> original)
+    {
+        // use original instead of stack for the destroy part because the stack has been mutated
+        if (stack.isEmpty() && player != null)
+        {
+            ItemStack itemStack = original.get();
+            EnumHand hand = null;
+            if (player.getHeldItem(EnumHand.MAIN_HAND).isItemEqual(itemStack)) hand = EnumHand.MAIN_HAND;
+            else if (player.getHeldItem(EnumHand.OFF_HAND).isItemEqual(itemStack)) hand = EnumHand.OFF_HAND;
+            ForgeEventFactory.onPlayerDestroyItem(player, itemStack, hand);
+        }
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason if the itemstack is being set to empty, fire {@link PlayerDestroyItemEvent} with the original stack.
+     */
+    @Inject(method = "onItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;setItemStackToSlot(Lnet/minecraft/inventory/EntityEquipmentSlot;Lnet/minecraft/item/ItemStack;)V", shift = At.Shift.AFTER))
+    private void utFireDestroyOnUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ, CallbackInfoReturnable<EnumActionResult> cir, @Local(ordinal = 0) ItemStack stack)
+    {
+        ForgeEventFactory.onPlayerDestroyItem(player, stack, hand);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -87,6 +87,7 @@ cfg.universaltweaks.modintegration.extrautilities=Extra Utilities 2
 cfg.universaltweaks.modintegration.forestry=Forestry
 cfg.universaltweaks.modintegration.fpsreducer=FPS Reducer
 cfg.universaltweaks.modintegration.gaia_dimension=Gaia Dimension
+cfg.universaltweaks.modintegration.immersiveengineering=Immersive Engineering
 cfg.universaltweaks.modintegration.incontrol=In Control!
 cfg.universaltweaks.modintegration.industrialcraft=IndustrialCraft 2
 cfg.universaltweaks.modintegration.industrialforegoing=Industrial Foregoing

--- a/src/main/resources/mixins.mods.immersiveengineering.toolevent.json
+++ b/src/main/resources/mixins.mods.immersiveengineering.toolevent.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.immersivenegineering.toolevent.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTIEToolMixin"]
+}

--- a/src/main/resources/mixins.mods.immersiveengineering.toolhand.json
+++ b/src/main/resources/mixins.mods.immersiveengineering.toolhand.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.immersivenegineering.handreplacement.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTIEToolMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add Immersive Engineering to dev environment
- fix the break stack for ie tool always using the main hand, potentially causing duping or voiding bugs (default: `true`) 
- fire the forge break event when breaking an ie tool, fixing a lot of crosscompat issues (default: `true`)

related to https://github.com/Invadermonky/Omniwand/issues/2