### PR TITLE
Tweaks for Unsafe Sleeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ All changes are toggleable via config files.
 * **Undead Horses**
     * **Burning:** Lets untamed undead horses burn in daylight
     * **Taming:** Allows taming of undead horses
+* **Unsafe Sleeping**
+    * **Highlight Unsafe Mobs:** Apply the Glowing potion effect for a configurable length of time to nearby mobs preventing sleeping
+    * **Ignore Unsafe Sleeping:** Allow sleeping even if mobs are nearby
 * **Unlimited Sound Pitch Range:** Removes the hardcoded range for sound pitches (0.5-2.0)
 * **Use Separate Dismount Key:** Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently
 * **Use Separate Narrator Key:** Allows using a custom Narrator key, instead of being stuck with CTRL+B

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -527,6 +527,10 @@ public class UTConfigTweaks
         @Config.Name("Undead Horses")
         public final UndeadHorsesCategory UNDEAD_HORSES = new UndeadHorsesCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.entities.unsafesleeping")
+        @Config.Name("Unsafe Sleeping")
+        public final UnsafeSleepingCategory UNSAFE_SLEEPING = new UnsafeSleepingCategory();
+
         @Config.LangKey("cfg.universaltweaks.tweaks.entities.waterfalldamage")
         @Config.Name("Water Fall Damage")
         public final WaterFallDamageCategory WATER_FALL_DAMAGE = new WaterFallDamageCategory();
@@ -1050,6 +1054,31 @@ public class UTConfigTweaks
             @Config.Name("No Skeleton Trap Spawning")
             @Config.Comment("Prevents skeleton traps spawning during thunderstorms")
             public boolean utSkeletonTrapSpawningToggle = false;
+        }
+
+        public static class UnsafeSleepingCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[1] Unsafe Sleeping Toggle")
+            @Config.Comment("Enables the use of any of the settings in this category")
+            public boolean utUnsafeSleepingToggle = false;
+
+            @Config.Name("[2] Ignore Unsafe Sleeping")
+            @Config.Comment("Allow sleeping even if mobs are nearby")
+            public boolean utAllowUnsafeSleeping = false;
+
+            @Config.Name("[3] Highlight Unsafe Mobs")
+            @Config.Comment("Apply the Glowing potion effect to nearby mobs preventing sleeping")
+            public boolean utApplyGlowingToUnsafeMobs = false;
+
+            @Config.Name("[4] Highlight Duration")
+            @Config.Comment("Time in ticks the highlight will last. Only applies if \"[3] Highlight Unsafe Mobs\" is true")
+            @Config.RangeInt(min = 1)
+            public int utGlowingTime = 100;
+
+            @Config.Name("[4] Show Glowing Particles")
+            @Config.Comment("If the Glowing potion effect will apply particles. Only applies if \"[3] Highlight Unsafe Mobs\" is true")
+            public boolean utShowGlowingParticles = false;
         }
 
         public static class WaterFallDamageCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -132,6 +132,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins.tweaks.entities.speed.player.json", () -> UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle);
                 put("mixins.tweaks.entities.taming.horse.json", () -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utTamingUndeadHorsesToggle);
                 put("mixins.tweaks.entities.trading.json", () -> UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle);
+                put("mixins.tweaks.entities.unsafesleeping.json", () -> UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utUnsafeSleepingToggle);
                 put("mixins.tweaks.entities.villagerprofessions.json", () -> UTConfigTweaks.ENTITIES.utVillagerProfessionBiomeRestriction.length > 0);
                 put("mixins.tweaks.entities.voidteleport.json", () -> UTConfigTweaks.ENTITIES.VOID_TELEPORT.utVoidTeleportToggle);
                 put("mixins.tweaks.items.attackcooldown.server.json", () -> UTConfigTweaks.ITEMS.ATTACK_COOLDOWN.utAttackCooldownToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/unsafesleeping/mixin/UTUnsafeSleepingMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/unsafesleeping/mixin/UTUnsafeSleepingMixin.java
@@ -1,0 +1,44 @@
+package mod.acgaming.universaltweaks.tweaks.entities.unsafesleeping.mixin;
+
+import java.util.List;
+
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.math.BlockPos;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityPlayer.class)
+public class UTUnsafeSleepingMixin
+{
+    /**
+     * @reason apply the glowing potion effect to mobs making sleeping unsafe
+     * @author WaitingIdly
+     */
+    @Inject(method = "trySleep", at = @At(value = "RETURN", ordinal = 5))
+    private void utHighlightMobs(BlockPos bedLocation, CallbackInfoReturnable<EntityPlayer.SleepResult> cir, @Local List<EntityMob> list)
+    {
+        if (!UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utApplyGlowingToUnsafeMobs) return;
+        final int duration = UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utGlowingTime;
+        final boolean showParticles = UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utShowGlowingParticles;
+        list.forEach(mob -> mob.addPotionEffect(new PotionEffect(MobEffects.GLOWING, duration, 0, false, showParticles)));
+    }
+
+    /**
+     * @reason allow sleeping if either the list is empty or the config to allow unsafe sleeping is set
+     * @author WaitingIdly
+     */
+    @ModifyExpressionValue(method = "trySleep", at = @At(value = "INVOKE", target = "Ljava/util/List;isEmpty()Z"))
+    private boolean utCheckUnsafeSleeping(boolean original)
+    {
+        return original || UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utAllowUnsafeSleeping;
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -157,6 +157,7 @@ cfg.universaltweaks.tweaks.entities.rallyhealth=Rally Health
 cfg.universaltweaks.tweaks.entities.sleeping=Sleeping
 cfg.universaltweaks.tweaks.entities.spawncaps=Spawn Caps
 cfg.universaltweaks.tweaks.entities.undeadhorses=Undead Horses
+cfg.universaltweaks.tweaks.entities.unsafesleeping=Unsafe Sleeping
 cfg.universaltweaks.tweaks.entities.waterfalldamage=Water Fall Damage
 cfg.universaltweaks.tweaks.entities.voidteleport=Void Teleport
 cfg.universaltweaks.tweaks.items.attackcooldown=Attack Cooldown

--- a/src/main/resources/mixins.tweaks.entities.unsafesleeping.json
+++ b/src/main/resources/mixins.tweaks.entities.unsafesleeping.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.unsafesleeping.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTUnsafeSleepingMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add a toggle for all unsafe sleeping changes (default: `false`)
- allow sleeping even if there a mobs making it unsafe (default: `false`)
- highlight nearby mobs with Glowing (presuming the prior option wasnt enabled) (default: `false`)
	- set the time in ticks glowing lasts (default: `100`)
	- set if the glowing effect has particles (default: `false`)

these settings could have gone into the Sleeping category, but i think it would have required renaming the existing config settings to be numbered, so i decided against it