### PR TITLE
Only suppress chunk-loads for ChunkCache if pathfinding

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/NavigationCacheFlag.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/NavigationCacheFlag.java
@@ -1,0 +1,17 @@
+package mod.acgaming.universaltweaks.tweaks.performance.pathfinding;
+
+public class NavigationCacheFlag
+{
+    private static final ThreadLocal<Boolean> usedForNavigation = ThreadLocal.withInitial(() -> false);
+
+    public static boolean get()
+    {
+        return usedForNavigation.get();
+    }
+
+    public static void set(boolean usedForNavigation)
+    {
+        NavigationCacheFlag.usedForNavigation.set(usedForNavigation);
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathNavigateMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathNavigateMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.tweaks.performance.pathfinding.mixin;
+
+import net.minecraft.pathfinding.PathNavigate;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.World;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.tweaks.performance.pathfinding.NavigationCacheFlag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = PathNavigate.class)
+public class UTPathNavigateMixin
+{
+    @WrapOperation(method = {"getPathToPos", "getPathToEntityLiving"}, at = @At(value = "NEW", target = "(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;I)Lnet/minecraft/world/ChunkCache;"))
+    private ChunkCache utMarkCacheForNavigation(World worldIn, BlockPos posFromIn, BlockPos posToIn, int subIn, Operation<ChunkCache> original)
+    {
+        ChunkCache ret;
+        NavigationCacheFlag.set(true);
+        ret = original.call(worldIn, posFromIn, posToIn, subIn);
+        NavigationCacheFlag.set(false);
+        return ret;
+    }
+
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathfindingChunkCacheMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/pathfinding/mixin/UTPathfindingChunkCacheMixin.java
@@ -3,11 +3,10 @@ package mod.acgaming.universaltweaks.tweaks.performance.pathfinding.mixin;
 import net.minecraft.world.ChunkCache;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.gen.ChunkProviderServer;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.performance.pathfinding.NavigationCacheFlag;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -18,10 +17,10 @@ public class UTPathfindingChunkCacheMixin
     @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getChunk(II)Lnet/minecraft/world/chunk/Chunk;"))
     private Chunk utCheckChunkLoaded(World instance, int chunkX, int chunkZ, Operation<Chunk> original)
     {
-        // Pathfinding is the only server-side use of ChunkCache (in vanilla).
-        if (!instance.isRemote && UTConfigTweaks.PERFORMANCE.utPathfindingChunkCacheFixToggle && !((ChunkProviderServer) instance.getChunkProvider()).chunkExists(chunkX, chunkZ))
+        if (!instance.isRemote && NavigationCacheFlag.get())
         {
-            return null;
+            // Don't let pathfinding load unloaded or ungenerated chunks
+            return instance.getChunkProvider().getLoadedChunk(chunkX, chunkZ);
         }
         return original.call(instance, chunkX, chunkZ);
     }

--- a/src/main/resources/mixins.tweaks.performance.pathfinding.json
+++ b/src/main/resources/mixins.tweaks.performance.pathfinding.json
@@ -3,5 +3,5 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTPathfindingChunkCacheMixin"]
+  "mixins": ["UTPathfindingChunkCacheMixin", "UTPathNavigateMixin"]
 }


### PR DESCRIPTION
Apply the pathfinding chunk loading tweak only to specific places where `ChunkCache`s are created in `PathNavigate`. There's no guarantee all `ChunkCache` instances on the server-side are for pathfinding (i.e. other mods creating it for other uses).