### PR TITLE
Some Random Things Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Random Things**
     * **Anvil Crafting Fix:** Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart
+    * **Item Collector Dupe:** Fixes a duplication exploit connected to the Advanced Item Collector
 * **Railcraft**
     * **No Beta Warning:** Disables the beta message warning on world join
 * **Requious Frakto**

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Random Things**
     * **Anvil Crafting Fix:** Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart
+    * **Fix Spectre Dimension Teleport Stall:** Fix a bug where teleporting to the Spectre dimension on servers can leave the player stalled out in the void
     * **Item Collector Dupe:** Fixes a duplication exploit connected to the Advanced Item Collector
 * **Railcraft**
     * **No Beta Warning:** Disables the beta message warning on world join

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1018,6 +1018,11 @@ public class UTConfigMods
         @Config.Name("Anvil Crafting Fix")
         @Config.Comment("Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart")
         public boolean utAnvilCraftFix = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Item Collector Dupe")
+        @Config.Comment("Fixes a duplication exploit connected to the Advanced Item Collector")
+        public boolean utItemCollectorDupe = true;
     }
 
     public static class RequiousFraktoCategory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1020,6 +1020,15 @@ public class UTConfigMods
         public boolean utAnvilCraftFix = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fix Spectre Dimension Teleport Stall")
+        @Config.Comment
+            ({
+                "Fix a bug where teleporting to the Spectre dimension on servers can leave the player stalled out in the void",
+                "Only applies to servers"
+            })
+        public boolean utTeleportStall = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Item Collector Dupe")
         @Config.Comment("Fixes a duplication exploit connected to the Advanced Item Collector")
         public boolean utItemCollectorDupe = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -328,7 +328,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 && !mixinConfig.equals("mixins.tweaks.misc.gui.gamewindow.icon.json") // No icon
                 && !mixinConfig.equals("mixins.tweaks.misc.gui.gamewindow.title.json"); // No title
         }
-        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
+        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : serversideMixinConfigs.get(mixinConfig);
         BooleanSupplier commonSupplier = commonMixinConfigs.get(mixinConfig);
         return sidedSupplier != null ? sidedSupplier.getAsBoolean() : commonSupplier == null || commonSupplier.getAsBoolean();
     }

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -184,8 +184,9 @@ public class UTMixinLoader implements ILateMixinLoader
     }
 
     @Override
-    public boolean shouldMixinConfigQueue(String mixinConfig)
+    public boolean shouldMixinConfigQueue(Context context)
     {
+        String mixinConfig = context.mixinConfig();
         BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : serversideMixinConfigs.get(mixinConfig);
         BooleanSupplier commonSupplier = commonMixinConfigs.get(mixinConfig);
         return sidedSupplier != null ? sidedSupplier.getAsBoolean() : commonSupplier == null || commonSupplier.getAsBoolean();

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -12,10 +12,19 @@ import net.minecraftforge.fml.common.Loader;
 import mod.acgaming.universaltweaks.config.UTConfigGeneral;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import zone.rong.mixinbooter.Context;
 import zone.rong.mixinbooter.ILateMixinLoader;
 
 public class UTMixinLoader implements ILateMixinLoader
 {
+
+    private static final Map<String, BooleanSupplier> serversideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
+    {
+        {
+            put("mixins.mods.randomthings.teleport.json", () -> loaded("randomthings") && UTConfigMods.RANDOM_THINGS.utTeleportStall);
+        }
+    });
+
     private static final Map<String, BooleanSupplier> clientsideMixinConfigs = ImmutableMap.copyOf(new HashMap<String, BooleanSupplier>()
     {
         {
@@ -168,10 +177,8 @@ public class UTMixinLoader implements ILateMixinLoader
     public List<String> getMixinConfigs()
     {
         List<String> configs = new ArrayList<>();
-        if (UTLoadingPlugin.isClient)
-        {
-            configs.addAll(clientsideMixinConfigs.keySet());
-        }
+        if (UTLoadingPlugin.isClient) configs.addAll(clientsideMixinConfigs.keySet());
+        else configs.addAll(serversideMixinConfigs.keySet());
         configs.addAll(commonMixinConfigs.keySet());
         return configs;
     }
@@ -179,7 +186,7 @@ public class UTMixinLoader implements ILateMixinLoader
     @Override
     public boolean shouldMixinConfigQueue(String mixinConfig)
     {
-        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : null;
+        BooleanSupplier sidedSupplier = UTLoadingPlugin.isClient ? clientsideMixinConfigs.get(mixinConfig) : serversideMixinConfigs.get(mixinConfig);
         BooleanSupplier commonSupplier = commonMixinConfigs.get(mixinConfig);
         return sidedSupplier != null ? sidedSupplier.getAsBoolean() : commonSupplier == null || commonSupplier.getAsBoolean();
     }

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -122,6 +122,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.properpumpkins.json", () -> loaded("pumpking") && UTConfigMods.PROPER_PUMPKIN.utFacingFix);
                 put("mixins.mods.quark.dupes.json", () -> loaded("quark") && UTConfigMods.QUARK.utDuplicationFixesToggle);
                 put("mixins.mods.randomthings.anvil.json", () -> loaded("randomthings") && UTConfigMods.RANDOM_THINGS.utAnvilCraftFix);
+                put("mixins.mods.randomthings.collector.json", () -> loaded("randomthings") && UTConfigMods.RANDOM_THINGS.utItemCollectorDupe);
                 put("mixins.mods.requiousfrakto.json", () -> loaded("requious") && UTConfigMods.REQUIOUS_FRAKTO.utParticleFixesToggle);
                 put("mixins.mods.reskillable.json", () -> loaded("reskillable"));
                 put("mixins.mods.rftoolsdimensions.json", () -> loaded("rftoolsdim"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/collector/mixin/UTContainerAdvancedItemCollectorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/collector/mixin/UTContainerAdvancedItemCollectorMixin.java
@@ -1,0 +1,19 @@
+package mod.acgaming.universaltweaks.mods.randomthings.collector.mixin;
+
+import lumien.randomthings.container.ContainerAdvancedItemCollector;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+// Courtesy of WaitingIdly
+@Mixin(value = ContainerAdvancedItemCollector.class, remap = false)
+public class UTContainerAdvancedItemCollectorMixin
+{
+    @ModifyConstant(method = "transferStackInSlot", constant = @Constant(intValue = 3), remap = true)
+    private int utFixSlotDuping(int constant)
+    {
+        if (!UTConfigMods.RANDOM_THINGS.utItemCollectorDupe) return constant;
+        return 1;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/collector/mixin/UTContainerAdvancedItemCollectorMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/collector/mixin/UTContainerAdvancedItemCollectorMixin.java
@@ -10,6 +10,13 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(value = ContainerAdvancedItemCollector.class, remap = false)
 public class UTContainerAdvancedItemCollectorMixin
 {
+    /**
+     * @reason There is only 1 slot in the Advanced Item Collector,
+     * but with it acting as if there are 3, the top left two slots of the player inventory are interacted
+     * with as if they are both in the player inventory and in the Advanced Item Collector,
+     * which allows duplication bugs when shift+clicking if the hotbar is not full.
+     * @author WaitingIdly
+     */
     @ModifyConstant(method = "transferStackInSlot", constant = @Constant(intValue = 3), remap = true)
     private int utFixSlotDuping(int constant)
     {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/teleport/mixin/UTSpectreHandlerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/randomthings/teleport/mixin/UTSpectreHandlerMixin.java
@@ -1,0 +1,34 @@
+package mod.acgaming.universaltweaks.mods.randomthings.teleport.mixin;
+
+import net.minecraft.network.NetHandlerPlayServer;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import lumien.randomthings.handler.spectre.SpectreHandler;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = SpectreHandler.class, remap = false)
+public class UTSpectreHandlerMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason When a player teleports to an already existing Spectre cube in the Spectre dimension on servers,
+     * the player might stall out in the void unless they are in creative (which skips this code path).
+     * Setting their location directly avoids this issue.
+     */
+    @WrapOperation(method = "checkPosition", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetHandlerPlayServer;setPlayerLocation(DDDFF)V"))
+    private void fixSpectreTeleport(NetHandlerPlayServer instance, double x, double y, double z, float yaw, float pitch, Operation<Void> original)
+    {
+        if (UTConfigMods.RANDOM_THINGS.utTeleportStall)
+        {
+            original.call(instance, x, y, z, yaw, pitch);
+        }
+        else
+        {
+            instance.player.setLocationAndAngles(x, y, z, yaw, pitch);
+        }
+    }
+}

--- a/src/main/resources/mixins.mods.randomthings.collector.json
+++ b/src/main/resources/mixins.mods.randomthings.collector.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.randomthings.collector.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTContainerAdvancedItemCollectorMixin"]
+}

--- a/src/main/resources/mixins.mods.randomthings.teleport.json
+++ b/src/main/resources/mixins.mods.randomthings.teleport.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.randomthings.teleport.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "server": ["UTSpectreHandlerMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- fix a bug involving teleporting to the spectre dimension stalling out (default: `false`)
- fix a dupe bug involving the Advanced Item Collector when shift clicking on the top left two slots of the player inventory (default: `true`)
- add `serversideMixinConfigs` to `UTMixinLoader` for teleport stall fix
- fix bug where `serversideMixinConfigs` was ignored in `UTLoadingPlugin` (always true, regardless of config)

related to #460, tested here: 
https://github.com/Krutoy242/Enigmatica2Expert-Extended/blob/master/scripts/mixin/randomthings_server.zs