### PR TITLE
Fix music control tweak crash & simplify mixins

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -86,6 +86,7 @@ import mod.acgaming.universaltweaks.tweaks.misc.gui.lanserverproperties.UTLanSer
 import mod.acgaming.universaltweaks.tweaks.misc.incurablepotions.UTIncurablePotions;
 import mod.acgaming.universaltweaks.tweaks.misc.lightning.damage.UTLightningItemDestruction;
 import mod.acgaming.universaltweaks.tweaks.misc.loadsound.UTLoadSound;
+import mod.acgaming.universaltweaks.tweaks.misc.music.UTMusicType;
 import mod.acgaming.universaltweaks.tweaks.misc.offhand.mixin.UTOffhand;
 import mod.acgaming.universaltweaks.tweaks.misc.pickupnotification.UTPickupNotificationOverlay;
 import mod.acgaming.universaltweaks.tweaks.misc.potionshift.UTPotionShift;
@@ -139,6 +140,8 @@ public class UniversalTweaks
             if (UTConfigTweaks.ENTITIES.ATTRIBUTES.utAttributesToggle) UTAttributes.utSetAttributes();
             if (UTConfigTweaks.MISC.utSkipRegistryScreenToggle) System.setProperty("fml.queryResult", "confirm");
         }
+
+        if (UTLoadingPlugin.isClient) UTMusicType.init();
 
         LOGGER.info(NAME + " pre-initialized");
     }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/UTMusicType.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/UTMusicType.java
@@ -1,11 +1,18 @@
 package mod.acgaming.universaltweaks.tweaks.misc.music;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import net.minecraft.client.audio.MusicTicker.MusicType;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public enum UTMusicType
 {
-    // When the mod is loading, MusicTicker.MusicType isn't initialized yet.
-    // Otherwise we can use enumerated field instead of getting the value with method.
+    // MusicTicker.MusicType might not exist yet if this class is loaded during core-mod stage.
+    // If so, use these enum members instead of getting the type.
     MENU,
     OVERWORLD,
     CREATIVE,
@@ -14,18 +21,34 @@ public enum UTMusicType
     END_BOSS,
     CREDITS;
 
-    public MusicType getMusicTickerType()
+    // Must be lazy as MusicType may not exist yet.
+    @Nullable
+    @SideOnly(Side.CLIENT)
+    private Supplier<MusicType> musicTypeSupplier;
+
+    @SideOnly(Side.CLIENT)
+    public void setMusicTypeSupplier(@Nonnull Supplier<MusicType> musicTypeSupplier)
     {
-        switch (this)
-        {
-            default:
-            case MENU: return MusicType.MENU;
-            case OVERWORLD: return MusicType.GAME;
-            case CREATIVE: return MusicType.CREATIVE;
-            case NETHER: return MusicType.NETHER;
-            case END: return MusicType.END;
-            case END_BOSS: return MusicType.END_BOSS;
-            case CREDITS: return MusicType.CREDITS;
-        }
+        this.musicTypeSupplier = musicTypeSupplier;
+    }
+
+    // Must call this instead of initializing in constructor to avoid early class-loading
+    @SideOnly(Side.CLIENT)
+    public static void init()
+    {
+        MENU.setMusicTypeSupplier(() -> MusicType.MENU);
+        OVERWORLD.setMusicTypeSupplier(() -> MusicType.GAME);
+        CREATIVE.setMusicTypeSupplier(() -> MusicType.CREATIVE);
+        NETHER.setMusicTypeSupplier(() -> MusicType.NETHER);
+        END.setMusicTypeSupplier(() -> MusicType.END);
+        END_BOSS.setMusicTypeSupplier(() -> MusicType.END_BOSS);
+        CREDITS.setMusicTypeSupplier(() -> MusicType.CREDITS);
+    }
+
+    @Nonnull
+    @SideOnly(Side.CLIENT)
+    public Supplier<MusicType> getMusicTickerType()
+    {
+        return Objects.requireNonNull(musicTypeSupplier);
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTAmbientMusicMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTAmbientMusicMixin.java
@@ -1,69 +1,39 @@
 package mod.acgaming.universaltweaks.tweaks.misc.music.mixin;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.audio.MusicTicker;
-import net.minecraft.client.entity.EntityPlayerSP;
-import net.minecraft.client.gui.GuiIngame;
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.GuiWinGame;
-import net.minecraft.client.multiplayer.WorldClient;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldProviderHell;
+import net.minecraft.client.audio.MusicTicker.MusicType;
 
-import mod.acgaming.universaltweaks.UniversalTweaks;
-import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
-import mod.acgaming.universaltweaks.tweaks.misc.music.UTMusicType;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+// Courtesy of Apis035, jchung01
 @Mixin(Minecraft.class)
 public class UTAmbientMusicMixin
 {
-    @Shadow
-    public WorldClient world;
-
-    @Shadow
-    public EntityPlayerSP player;
-
-    @Shadow
-    @Nullable
-    public GuiScreen currentScreen;
-
-    @Shadow
-    public GuiIngame ingameGUI;
-
-    @Inject(method = "getAmbientMusicType", at = @At(value = "HEAD"), cancellable = true)
-    public void getAmbientMusicType(CallbackInfoReturnable<MusicTicker.MusicType> cir)
+    @ModifyReturnValue(method = "getAmbientMusicType", at = @At(value = "RETURN"))
+    private MusicType utGetAmbientMusicType(MusicType originalType)
     {
-        UTMusicType musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlMenu;
-
-        if (currentScreen instanceof GuiWinGame) musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlCredits;
-        else if (player != null)
+        switch (originalType)
         {
-            MusicTicker.MusicType worldMusicType = world.provider.getMusicType();
-            if (worldMusicType != null)
-            {
-                cir.setReturnValue(worldMusicType);
-                return;
-            }
-            else if (player.world.provider instanceof WorldProviderHell) musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlNether;
-            else if (player.world.provider instanceof WorldProviderEnd)
-            {
-                if (ingameGUI.getBossOverlay().shouldPlayEndBossMusic()) musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlEndBoss;
-                else musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlEnd;
-            }
-            else if (player.capabilities.isCreativeMode && player.capabilities.allowFlying) musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlCreative;
-            else musicType = UTConfigTweaks.MISC.MUSIC.utMusicControlOverworld;
+            case MENU:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlMenu.getMusicTickerType().get();
+            case GAME:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlOverworld.getMusicTickerType().get();
+            case CREATIVE:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlCreative.getMusicTickerType().get();
+            case CREDITS:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlCredits.getMusicTickerType().get();
+            case NETHER:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlNether.getMusicTickerType().get();
+            case END_BOSS:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlEndBoss.getMusicTickerType().get();
+            case END:
+                return UTConfigTweaks.MISC.MUSIC.utMusicControlEnd.getMusicTickerType().get();
+            default:
+                return originalType;
         }
-
-        if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMusicControl ::: Playing ambient music " + musicType);
-
-        cir.setReturnValue(musicType.getMusicTickerType().get());
     }
+
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTAmbientMusicMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTAmbientMusicMixin.java
@@ -64,6 +64,6 @@ public class UTAmbientMusicMixin
 
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTMusicControl ::: Playing ambient music " + musicType);
 
-        cir.setReturnValue(musicType.getMusicTickerType());
+        cir.setReturnValue(musicType.getMusicTickerType().get());
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTNoMusicPauseMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTNoMusicPauseMixin.java
@@ -1,35 +1,24 @@
 package mod.acgaming.universaltweaks.tweaks.misc.music.mixin;
 
-import java.util.Map.Entry;
+import java.util.Map;
 
 import net.minecraft.client.audio.ISound;
 import net.minecraft.client.audio.SoundManager;
 import net.minecraft.util.SoundCategory;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
+// Courtesy of Apis035, jchung01
 @Mixin(SoundManager.class)
 public class UTNoMusicPauseMixin
 {
-    private Entry<String, ISound> localEntry;
-
-    @ModifyVariable(method = "pauseAllSounds", at = @At(value = "STORE"))
-    private Entry<String, ISound> entryStore(Entry<String, ISound> entry)
+    @ModifyExpressionValue(method = "pauseAllSounds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/audio/SoundManager;isSoundPlaying(Lnet/minecraft/client/audio/ISound;)Z"))
+    private boolean utKeepPlayingMusic(boolean shouldPause, @Local Map.Entry<String, ISound> entry)
     {
-        this.localEntry = entry;
-        return entry;
-    }
-
-    @ModifyVariable(method = "pauseAllSounds", at = @At(value = "STORE"))
-    private boolean flagStore(boolean flag)
-    {
-        ISound value = this.localEntry.getValue();
-        boolean isMusic = value.getCategory() == SoundCategory.MUSIC;
-        boolean isPlaying = ((SoundManager) (Object)this).isSoundPlaying(value);
-        if (UTConfigTweaks.MISC.MUSIC.utKeepMusicOnPause) return !isMusic && isPlaying;
-        else return isPlaying;
+        return shouldPause && !(UTConfigTweaks.MISC.MUSIC.utKeepMusicOnPause && entry.getValue().getCategory() == SoundCategory.MUSIC);
     }
 }


### PR DESCRIPTION
The music control tweak was causing a crash due to loading a Minecraft class in core-mod phase.
- Lazy init music type in `UTMusicType` to fix crash
- Only reference `MusicType` in client environment so dedicated server won't crash
- Simplify `UTNoMusicPauseMixin`
- Simplify/make `UTAmbientMusicMixin` more compatible
- Add credits