### PR TITLE
Make music delay configurable

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -2180,9 +2180,29 @@ public class UTConfigTweaks
             @Config.Comment("Don't pause music when game is paused")
             public boolean utKeepMusicOnPause = false;
 
-            @Config.Name("[10] Infinite Music")
-            @Config.Comment("Lets background music play continuously without delays")
-            public boolean utInfiniteMusicToggle = false;
+            @Config.Name("[10] Custom Music Delay")
+            @Config.Comment("Enable custom delay for next music to play")
+            public boolean utCustomMusicDelay = false;
+
+            @Config.Name("[11] Min Music Delay")
+            @Config.Comment
+                ({
+                    "Minimum delay before next music plays (in minutes)",
+                    "A value of 0 will set the delay to 1 second"
+                })
+            @Config.RangeInt(min = 0, max = 20)
+            @Config.SlidingOption
+            public int utMusicDelayMin = 0;
+
+            @Config.Name("[12] Max Music Delay")
+            @Config.Comment
+                ({
+                    "Maximum delay before next music plays (in minutes)",
+                    "A value of 0 will set the delay to 1 second"
+                })
+            @Config.RangeInt(min = 0, max = 20)
+            @Config.SlidingOption
+            public int utMusicDelayMax = 0;
         }
 
         public static class PickupNotificationCategory

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTMusicDelayMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/music/mixin/UTMusicDelayMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(MusicTicker.class)
-public class UTInfiniteMusicMixin
+public class UTMusicDelayMixin
 {
     @Shadow
     @Final
@@ -22,16 +22,16 @@ public class UTInfiniteMusicMixin
     @Redirect(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/audio/MusicTicker$MusicType;getMinDelay()I"))
     public int utInfiniteMusicMinDelay(MusicTicker.MusicType instance)
     {
-        if (!UTConfigTweaks.MISC.MUSIC.utInfiniteMusicToggle) return this.mc.getAmbientMusicType().getMinDelay();
+        if (!UTConfigTweaks.MISC.MUSIC.utCustomMusicDelay) return this.mc.getAmbientMusicType().getMinDelay();
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInfiniteMusic ::: Set min delay");
-        return 20;
+        return Math.max(20, Math.min(UTConfigTweaks.MISC.MUSIC.utMusicDelayMin, UTConfigTweaks.MISC.MUSIC.utMusicDelayMax) * 20);
     }
 
     @Redirect(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/audio/MusicTicker$MusicType;getMaxDelay()I"))
     public int utInfiniteMusicMaxDelay(MusicTicker.MusicType instance)
     {
-        if (!UTConfigTweaks.MISC.MUSIC.utInfiniteMusicToggle) return this.mc.getAmbientMusicType().getMaxDelay();
+        if (!UTConfigTweaks.MISC.MUSIC.utCustomMusicDelay) return this.mc.getAmbientMusicType().getMaxDelay();
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInfiniteMusic ::: Set max delay");
-        return 20;
+        return Math.max(20, UTConfigTweaks.MISC.MUSIC.utMusicDelayMax * 20);
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -81,7 +81,7 @@ public class UTObsoleteModsHandler
                 put("cleardespawn", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utIEClearDespawnToggle);
                 put("configurablecane", () -> UTConfigTweaks.BLOCKS.utSugarCaneSize != 3);
                 put("configurabledespawntimer", () -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
-                put("continousmusic", () -> UTConfigTweaks.MISC.MUSIC.utInfiniteMusicToggle);
+                put("continousmusic", () -> UTConfigTweaks.MISC.MUSIC.utCustomMusicDelay);
                 put("creeperconfetti", () -> UTConfigTweaks.ENTITIES.CREEPER_CONFETTI.utCreeperConfettiChance > 0);
                 put("damagetilt", () -> UTConfigTweaks.MISC.utDamageTiltToggle);
                 put("darkstone", () -> UTConfigTweaks.PERFORMANCE.utRedstoneLightingToggle);


### PR DESCRIPTION
Replaces infinite music toggle with custom music delay option.

Setting music delay min and max to 0 (adjusts to 20 ticks) will retain infinite music tweak behavior.
The max 20 minutes delay limit is determined from vanilla behavior of longest music delay (24000 ticks).