### PR TITLE
Fix Quark Untranslated Link Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ All changes are toggleable via config files.
     * **Facing Crash Fix:** Fixes a bug where converting a pumpkin from a non-horizontal face would crash
 * **Quark**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Fix Untranslated Link Items:** When using the Link Items feature, if playing on a server, items that are not localized serverside will display the lang code in chat. This only impacts servers.
 * **Random Things**
     * **Anvil Crafting Fix:** Fixes a bug where crafting the output of an Anvil recipe would modify the recipe, preventing crafts until restart
     * **Fix Spectre Dimension Teleport Stall:** Fix a bug where teleporting to the Spectre dimension on servers can leave the player stalled out in the void

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1033,6 +1033,11 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Fix Untranslated Link Items")
+        @Config.Comment("When using the Link Items feature, if playing on a server, items that are not localized serverside will display the lang code in chat. This causes it to be translated.")
+        public boolean utLinkItemsServer = true;
     }
 
     public static class RailcraftCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -22,6 +22,7 @@ public class UTMixinLoader implements ILateMixinLoader
     {
         {
             put("mixins.mods.randomthings.teleport.json", () -> loaded("randomthings") && UTConfigMods.RANDOM_THINGS.utTeleportStall);
+            put("mixins.mods.quark.linkitems.json", () -> loaded("quark") && UTConfigMods.QUARK.utLinkItemsServer);
         }
     });
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/quark/linkitems/mixin/UTLinkItemsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/quark/linkitems/mixin/UTLinkItemsMixin.java
@@ -1,0 +1,82 @@
+package mod.acgaming.universaltweaks.mods.quark.linkitems.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.event.HoverEvent;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import vazkii.quark.management.feature.LinkItems;
+
+@Mixin(value = LinkItems.class, remap = false)
+public class UTLinkItemsMixin
+{
+    /**
+     * This code is just a glommed together combination of two ItemStack methods, with the instances
+     * where {@link TextComponentString} was called inside of {@link ItemStack#getDisplayName()} replaced
+     * with {@link TextComponentTranslation}.
+     * <p>
+     * This cannot simply call {@link ItemStack#getDisplayName()} because one of the possible outputs is a raw String.
+     *
+     * @see ItemStack#getTextComponent()
+     * @see ItemStack#getDisplayName()
+     */
+    @Unique
+    private static ITextComponent universalTweaks$getTextComponent(ItemStack stack)
+    {
+        ITextComponent stackName = null;
+        NBTTagCompound display = stack.getSubCompound("display");
+
+        if (display != null)
+        {
+            if (display.hasKey("Name", 8))
+            {
+                stackName = new TextComponentString(display.getString("Name"));
+            }
+
+            if (display.hasKey("LocName", 8))
+            {
+                stackName = new TextComponentTranslation(display.getString("LocName"));
+            }
+        }
+        if (stackName == null) stackName = new TextComponentTranslation(stack.getItem().getItemStackDisplayName(stack));
+
+        if (stack.hasDisplayName())
+        {
+            stackName.getStyle().setItalic(Boolean.TRUE);
+        }
+
+        ITextComponent component = (new TextComponentString("[")).appendSibling(stackName).appendText("]");
+
+        if (!stack.isEmpty())
+        {
+            NBTTagCompound tag = stack.writeToNBT(new NBTTagCompound());
+            component.getStyle().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_ITEM, new TextComponentString(tag.toString())));
+            component.getStyle().setColor(stack.getItem().getForgeRarity(stack).getColor());
+        }
+
+        return component;
+    }
+
+    /**
+     * @reason Since this can run on the server, if it is run on the server send a {@link TextComponentTranslation} for the name
+     * instead of a {@link TextComponentString} of the untranslated name.
+     * @author WaitingIdly
+     */
+    @WrapOperation(method = "linkItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getTextComponent()Lnet/minecraft/util/text/ITextComponent;"))
+    private static ITextComponent useItemStackTranslation(ItemStack instance, Operation<ITextComponent> original, @Local(argsOnly = true) EntityPlayer player)
+    {
+        if (UTConfigMods.QUARK.utLinkItemsServer && player.isServerWorld()) return universalTweaks$getTextComponent(instance);
+        return original.call(instance);
+    }
+
+}

--- a/src/main/resources/mixins.mods.quark.linkitems.json
+++ b/src/main/resources/mixins.mods.quark.linkitems.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.quark.linkitems.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTLinkItemsMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- adds a serverside fix for Quark's Link Items feature (default: `true`).

the bug here is that, when sharing an item in chat (default: `ctrl+t`), the item is localized on the server. this works for vanilla and many mods, but doesnt work with mods where the localization is added by a resource loader. this means that when playing on a server, all items from contenttweaker that are shared are shared as `[item.contenttweaker.item.name]` instead of `[ItemName]`.
to test this you need a script with
```java
#loader contenttweaker
mods.contenttweaker.VanillaFactory.createItem("test").register();
```
and `resources/contenttweaker/lang/en_us.lang` with `item.contenttweaker.test.name=Test Lang`