### PR TITLE
Fix Cabbage Seed drop having wrong metadata

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/erebus/cabbage/mixin/UTCabbageMixin.java
@@ -28,7 +28,7 @@ public abstract class UTCabbageMixin extends BlockCrops
     public int damageDropped(IBlockState blockState)
     {
         if (!UTConfigMods.EREBUS.utCabbageDrop) return super.damageDropped(blockState);
-        return ItemErebusFood.EnumFoodType.CABBAGE.ordinal();
+        return isMaxAge(blockState) ? ItemErebusFood.EnumFoodType.CABBAGE.ordinal() : 0;
     }
 
     @Inject(method = "getDrops", at = @At("HEAD"), remap = false, cancellable = true)


### PR DESCRIPTION
changes in this PR:
- check that the crop is `isMaxAge(blockState)` before returning the metadata for the crop, otherwise return metdata `0` for the seed. currently a not-fully-grown cabbage will drop the invalid `seed:15` instead of the valid `seed:0`.

related to #442 