### PR TITLE
Fix Item Favorites using the wrong path on Unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Iron Chests**
     * **Replace Crystal Chest/Shulker Renderer:** Fixes client-side memory leak by replacing the crystal chest/shulker box renderer with a simpler one (Note: Disables stack size rendering)
+* **Item Favorites**
+    * **Linux Saving/Loading**: Fixes saving and loading of favorite items on Unix systems
 * **Item Stages**
     * **Ingredient Matching:** Changes item matching code to CraftTweaker's ingredient matching system, fixes item NBT issues
 * **Jurassic Reborn**

--- a/build.gradle
+++ b/build.gradle
@@ -440,7 +440,8 @@ repositories {
                 //noinspection ForeignDelegate
                 maven {
                     name = 'Curse Maven'
-                    url = 'https://www.cursemaven.com'
+                    url = 'https://curse.cleanroommc.com'
+                    // url = 'https://www.cursemaven.com'
                     // url = 'https://beta.cursemaven.com'
                 }
             }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -109,6 +109,7 @@ final def mod_dependencies = [
     'curse.maven:infinitylib-251396:3317119'                          : [debug_agricraft],
     'curse.maven:ironbackpacks-227049:2564573'                        : [debug_iron_backpacks],
     'curse.maven:ironchests-228756:2747935'                           : [debug_iron_chests],
+    'curse.maven:item-favorites-358194:3177845'                       : [debug_itemfavorites],
     'curse.maven:jurassic-reborn-359537:4574634'                      : [debug_jurassic_reborn],
     'curse.maven:mantle-74924:2713386'                                : [debug_tinkers_construct, debug_moartinkers],
     'curse.maven:mcjtylib-233105:2745846'                             : [debug_rftools],

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,6 +55,7 @@ debug_industrial_foregoing = false
 debug_industrialcraft = false
 debug_iron_backpacks = false
 debug_iron_chests = false
+debug_itemfavorites = false
 debug_jurassic_reborn = false
 debug_mekanism = false
 debug_moartinkers = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -191,6 +191,10 @@ public class UTConfigMods
     @Config.Name("Iron Chests")
     public static final IronChestsCategory IRON_CHESTS = new IronChestsCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.itemfavorites")
+    @Config.Name("Item Favorites")
+    public static final ItemFavoritesCategory ITEM_FAVORITES = new ItemFavoritesCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.itemstages")
     @Config.Name("Item Stages")
     public static final ItemStagesCategory ITEM_STAGES = new ItemStagesCategory();
@@ -888,6 +892,14 @@ public class UTConfigMods
                 "Note: Stack sizes are not rendered, similar to modern versions of this mod"
             })
         public boolean utReplaceItemRenderer = true;
+    }
+
+    public static class ItemFavoritesCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Path correction")
+        @Config.Comment("Fixes issues with favorite items not being saved/loaded correctly on Unix-based systems")
+        public boolean utUnixPathFix = true;
     }
 
     public static class ItemStagesCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -122,6 +122,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.industrialforegoing.rangeaddon.json", () -> loaded("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utRangeAddonNumberFix);
                 put("mixins.mods.infernalmobs.json", () -> loaded("infernalmobs"));
                 put("mixins.mods.ironbackpacks.dupes.json", () -> loaded("ironbackpacks") && UTConfigMods.IRON_BACKPACKS.utDuplicationFixesToggle);
+                put("mixins.mods.itemfavorites.unixfix.json", () -> loaded("itemfav") && UTConfigMods.ITEM_FAVORITES.utUnixPathFix);
                 put("mixins.mods.itemstages.json", () -> loaded("itemstages"));
                 put("mixins.mods.jurassicreborn.json", () -> loaded("rebornmod"));
                 put("mixins.mods.mekanism.dupes.json", () -> loaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/itemfavorites/mixin/UTItemFavoritesUnixMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/itemfavorites/mixin/UTItemFavoritesUnixMixin.java
@@ -1,0 +1,26 @@
+package mod.acgaming.universaltweaks.mods.itemfavorites.mixin;
+
+import mrunknown404.itemfav.utils.LockHandler;
+
+import java.io.File;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(value = LockHandler.class, remap = false)
+public abstract class UTItemFavoritesUnixMixin
+{
+    // Replaces "\\" (char 92) with system file separator to fix Unix compatibility
+    @ModifyConstant(method = "saveToFile", constant = @Constant(intValue = 92))
+    private static int replaceBackslashInSave(int constant)
+    {
+        return File.separatorChar;
+    }
+
+    @ModifyConstant(method = "readFromFile", constant = @Constant(intValue = 92))
+    private static int replaceBackslashInRead(int constant)
+    {
+        return File.separatorChar;
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -95,6 +95,7 @@ cfg.universaltweaks.modintegration.industrialforegoing=Industrial Foregoing
 cfg.universaltweaks.modintegration.infernalmobs=Infernal Mobs
 cfg.universaltweaks.modintegration.ironbackpacks=Iron Backpacks
 cfg.universaltweaks.modintegration.ironchests=Iron Chests
+cfg.universaltweaks.modintegration.itemfavorites=Item Favorites
 cfg.universaltweaks.modintegration.itemstages=Item Stages
 cfg.universaltweaks.modintegration.jurassicreborn=Jurassic Reborn
 cfg.universaltweaks.modintegration.mekanism=Mekanism

--- a/src/main/resources/mixins.mods.itemfavorites.unixfix.json
+++ b/src/main/resources/mixins.mods.itemfavorites.unixfix.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.itemfavorites.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTItemFavoritesUnixMixin"]
+}


### PR DESCRIPTION
Fixes https://github.com/MrUnknown404/ItemFavorites/blob/1.12.2/ItemFavorites/src/main/java/mrunknown404/itemfav/utils/LockHandler.java#L40 using "\\" instead of `java.io.File.separatorChar`, which caused the saving/loading of favorites to fail every time.

:warning: Do note that, due to this mod disabling download by 3rd party, the cursemaven repository had to be replaced by curse.cleanroommc. This affects all other mods included in dependencies.gradle.