### PR TITLE
Fixes and features related to Astral Sorcery Fluid Veins

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ All changes are toggleable via config files.
     * **Sooty Marble Rendering:** Fixes Sooty Marble Pillar blocking the proper rendering of adjacent fluids due to inverted logic
     * **Clear Particle Effects:** Fixes a bug where particle effects would continue to render after changing dimensions
     * **Fix Division By Zero Crystal Tool:** Fixes a bug where merging Crystal Tool Properties could result in a division by zero
+    * **Fix Fluid Vein Overflow:** Fixes a bug where the fluid veins could overflow, resulting in empty veins (just water)
+    * **Allow Unlimited Fluid Veins:** Make it so max size fluid veins never run out
+    * **Allow to change the Neromantic Prime Extraction Quantity:** Allows configuring the amount extracted from the fluid vein per Neromantic Prime operation
+    * **Allow to specify dimensions for fluid veins:** Extends the fluid vein configuration to allow specifying in which dimensions a fluid can generate
 * **Advent of Ascension**
     * **Improved Player Tick:** Improves AoA player ticking by only sending inventory changes when necessary
 * **Arcane Archives**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -392,6 +392,27 @@ public class UTConfigMods
         @Config.Name("Fix Division By Zero Crystal Tool")
         @Config.Comment("Fixes a bug where merging Crystal Tool Properties could result in a division by zero")
         public boolean utEmptyPropertiesZero = true;
+
+        @Config.Name("Fix Neromantic Prime Fluid Overflow")
+        @Config.Comment("Fixes a bug where the fluid veins for Neromantic Prime could overflow, resulting in empty veins (just water)")
+        public boolean utNeromanticPrimeFluidOverflow = true;
+
+        @Config.Name("Allow Unlimited Fluid Veins")
+        @Config.Comment("Make it so max size fluid veins never run out")
+        public boolean utNeromanticPrimeUnlimitedVeins = true;
+
+        @Config.Name("Neromantic Prime Extraction Quantity")
+        @Config.Comment("Amount of fluid extracted per Neromantic Prime operation (in mB per 20-30 ticks)")
+        public int utNeromanticPrimeExtractionQuantity = 300;
+
+        @Config.Name("Neromantic Prime Fluid Vein Dimensions")
+        @Config.Comment({
+            "Extends the fluid vein configuration to allow specifying in which dimensions a fluid can generate",
+            "This should be done as a list of comma-separated dimension IDs at the 5th field. Leave blank to allow all dimensions.",
+            "Example: 'lava;100000;200000;50;0,-1,7' allows lava veins to spawn in the Overworld (0) and Nether (-1)",
+            "Example: 'essence;50000;150000;30' allows essence veins to spawn in all dimensions"
+        })
+        public boolean utNeromanticPrimeFluidVeinDimensions = true;
     }
 
     public static class AOACategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -65,6 +65,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.aoa3.json", () -> loaded("aoa3") && UTConfigMods.AOA.utImprovedPlayerTickToggle);
                 put("mixins.mods.arcanearchives.dupes.json", () -> loaded("arcanearchives") && UTConfigMods.ARCANE_ARCHIVES.utDuplicationFixesToggle);
                 put("mixins.mods.astralsorcery.json", () -> loaded("astralsorcery"));
+                put("mixins.mods.astralsorcery.neromanticprime.json", () -> loaded("astralsorcery"));
                 put("mixins.mods.astralsorcery.tool.json", () -> loaded("astralsorcery") && UTConfigMods.ASTRAL_SORCERY.utEmptyPropertiesZero);
                 put("mixins.mods.backpack.json", () -> loaded("backpack") && UTConfigMods.BACKPACKS.utBPNoOffhandInteractionToggle);
                 put("mixins.mods.bewitchment.json", () -> loaded("bewitchment") && UTConfigMods.BEWITCHMENT.utWitchesOvenFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/duck/UTFluidRarityEntryExt.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/duck/UTFluidRarityEntryExt.java
@@ -1,0 +1,8 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.duck;
+
+// Accessor interface to interact with fields added via mixin to FluidRarityEntry
+public interface UTFluidRarityEntryExt {
+    int[] ut$getAllowedDims();
+
+    void ut$setAllowedDims(int[] dims);
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/FluidRarityEntryMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/FluidRarityEntryMixin.java
@@ -1,0 +1,70 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin;
+
+import hellfirepvp.astralsorcery.AstralSorcery;
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry.FluidRarityEntry;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.duck.UTFluidRarityEntryExt;
+
+@Mixin(value = FluidRarityEntry.class, remap = false)
+public abstract class FluidRarityEntryMixin implements UTFluidRarityEntryExt {
+    @Unique
+    private int[] allowedDims = null;
+
+    @Unique
+    @Override
+    public int[] ut$getAllowedDims() {
+        return allowedDims;
+    }
+
+    @Unique
+    @Override
+    public void ut$setAllowedDims(int[] dims) {
+        this.allowedDims = dims;
+    }
+
+    // Wrap the deserialize method to handle the extra dimension field - FluidRarityEntry deserialize(String str)
+    @WrapMethod(method = "deserialize")
+    private static FluidRarityEntry deserializeWithDims(String str, Operation<FluidRarityEntry> original) {
+        if (str == null) return null;
+
+        String[] split = str.split(";");
+        if (split.length != 5) return original.call(str); // let original handle non-5-field cases
+
+        String withoutDim = split[0] + ";" + split[1] + ";" + split[2] + ";" + split[3];
+        String dimField = split[4];
+
+        // Let original method create the instance first
+        FluidRarityEntry entry = original.call(withoutDim);
+        if (entry == null) {
+            AstralSorcery.log.warn("Failed to deserialize FluidRarityEntry from string: " + str);
+            return null;
+        }
+
+        // Parse dimensions
+        String[] parts = dimField.split(",");
+        List<Integer> dims = new ArrayList<>();
+        for (String p : parts) {
+            try {
+                dims.add(Integer.parseInt(p.trim()));
+            } catch (NumberFormatException ignored) {
+                AstralSorcery.log.warn("Invalid dimension id in FluidRarityEntry deserialization: " + p);
+            }
+        }
+
+        if (!dims.isEmpty()) {
+            int[] arr = new int[dims.size()];
+            for (int i = 0; i < dims.size(); i++) arr[i] = dims.get(i);
+            ((UTFluidRarityEntryExt) entry).ut$setAllowedDims(arr);
+        }
+
+        return entry;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTConfigurableFluidVeinDimensionsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTConfigurableFluidVeinDimensionsMixin.java
@@ -1,0 +1,70 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin;
+
+import hellfirepvp.astralsorcery.AstralSorcery;
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry;
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry.FluidRarityEntry;
+import net.minecraft.util.WeightedRandom;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidRegistry;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.duck.UTFluidRarityEntryExt;
+
+
+@Mixin(value = FluidRarityRegistry.class, remap = false)
+public abstract class UTConfigurableFluidVeinDimensionsMixin {
+    @Shadow
+    private static List<FluidRarityEntry> rarityList;
+
+    // Replaces "FluidRarityEntry sample = selectFluidEntry(r); "to add dimension id via w.provider.getDimension()
+	@WrapOperation(
+        method = "onChLoad",
+        at = @At(
+            value ="INVOKE",
+            target = "Lhellfirepvp/astralsorcery/common/base/FluidRarityRegistry;selectFluidEntry(Ljava/util/Random;)Lhellfirepvp/astralsorcery/common/base/FluidRarityRegistry$FluidRarityEntry;"
+        ),
+        remap = false
+    )
+	private FluidRarityEntry GenerateWrap(Random random, Operation<FluidRarityEntry> original, @Local World w) {
+        return ut$selectFluidEntryByDim(random, w.provider.getDimension());
+	}
+
+    // New method to select FluidRarityEntry based on dimension filtering
+	@Unique
+	private static FluidRarityEntry ut$selectFluidEntryByDim(Random random, int dimId) {
+		// Build filtered list based on optional allowedDims
+		List<FluidRarityEntry> filtered = new ArrayList<>();
+		for (FluidRarityEntry e : rarityList) {
+			if (e.fluid == null || e.fluid.equals(FluidRegistry.WATER)) {
+				continue; // mirror original selectFluidEntry behavior that can return null for WATER
+			}
+
+            int[] allowed = ((UTFluidRarityEntryExt) e).ut$getAllowedDims();
+			if (allowed == null || allowed.length == 0) {
+				filtered.add(e);
+			} else {
+				for (int d : allowed) {
+					if (d == dimId) {
+						filtered.add(e);
+						break;
+					}
+				}
+			}
+		}
+
+        if (filtered.isEmpty()) return null;
+
+        return (FluidRarityEntry) WeightedRandom.getRandomItem(random, filtered);
+	}
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTConfigurableFluidVeinExtractionQuantityMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTConfigurableFluidVeinExtractionQuantityMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin;
+
+import hellfirepvp.astralsorcery.common.tile.TileBore;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(value = TileBore.class, remap = false)
+public abstract class UTConfigurableFluidVeinExtractionQuantityMixin {
+
+    // Change both occurrences of 300 in rand.nextInt(300) + 300
+    @ModifyConstant(
+        method = "playBoreLiquidEffect",
+        constant = @Constant(intValue = 300),
+        remap = false
+    )
+    private int changeDrainConstant(int original) {
+        return UTConfigMods.ASTRAL_SORCERY.utNeromanticPrimeExtractionQuantity;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTFixNeromanticPrimeFluidOverflowMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTFixNeromanticPrimeFluidOverflowMixin.java
@@ -1,0 +1,56 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin;
+
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry;
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry.ChunkFluidEntry;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraftforge.fluids.Fluid;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+import java.lang.reflect.Method;
+
+@Mixin(value = FluidRarityRegistry.class, remap = false)
+public abstract class UTFixNeromanticPrimeFluidOverflowMixin {
+    // FIXME: MofifyArg does not seem to work properly here
+
+    /**
+     * If the amount set in config is large enough, guaranteed + random additional can overflow, resulting in negative amounts.
+     * This creates in a valid but empty entry, defaulting to only water generation.
+     * This change ensures that the overflow is converted back to Integer.MAX_VALUE to allow full generation.
+     */
+    @ModifyArg(
+        method = "onChLoad",
+        at = @At(value = "INVOKE",
+                 target = "Lhellfirepvp/astralsorcery/common/base/FluidRarityRegistry$ChunkFluidEntry;generate(Lnet/minecraftforge/fluids/Fluid;I)V"),
+        index = 1,
+        remap = false
+    )
+    private int convertOverflowedAmount(int amount) {
+        // guaranteed >= 0 and nextInt >= 0, so negative here implies overflow
+        return UTConfigMods.ASTRAL_SORCERY.utNeromanticPrimeFluidOverflow && amount < 0 ? Integer.MAX_VALUE : amount;
+    }
+
+    // Redirect fallback: replace the generate(...) invocation if we cannot modify the argument properly
+    @Redirect(
+        method = "onChLoad",
+        at = @At(value = "INVOKE",
+                 target = "Lhellfirepvp/astralsorcery/common/base/FluidRarityRegistry$ChunkFluidEntry;generate(Lnet/minecraftforge/fluids/Fluid;I)V"),
+        remap = false
+    )
+    private void redirectGenerate(ChunkFluidEntry entry, Fluid fluid, int amount) {
+        if (UTConfigMods.ASTRAL_SORCERY.utNeromanticPrimeFluidOverflow && amount < 0) {
+            // entry.generate(fluid, Integer.MAX_VALUE); -- cannot call directly due to private visibility
+            try {
+                Method m = entry.getClass().getDeclaredMethod("generate", Fluid.class, int.class);
+                m.setAccessible(true);
+                m.invoke(entry, fluid, Integer.MAX_VALUE);
+            } catch (Exception e) {
+                UniversalTweaks.LOGGER.error("Failed to invoke generate method via reflection", e);
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTUnlimitedFluidVeinMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/astralsorcery/neromanticprime/mixin/UTUnlimitedFluidVeinMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin;
+
+import hellfirepvp.astralsorcery.common.base.FluidRarityRegistry.ChunkFluidEntry;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ChunkFluidEntry.class, remap = false)
+public abstract class UTUnlimitedFluidVeinMixin {
+    @Shadow
+    private int mbRemaining;
+
+    @Shadow
+    private Fluid chunkFluid;
+
+    @Inject(method = "tryDrain", at = @At("HEAD"), cancellable = true, remap = false)
+    private void shortcutInfiniteDrain(int mbRequested, boolean consume, CallbackInfoReturnable<FluidStack> cir) {
+        // use shadowed fields directly to avoid illegal direct access to the target's private fields
+        if (UTConfigMods.ASTRAL_SORCERY.utNeromanticPrimeUnlimitedVeins && this.mbRemaining == Integer.MAX_VALUE && ((ChunkFluidEntry) (Object) this).isValid())
+            cir.setReturnValue(new FluidStack(this.chunkFluid, mbRequested));
+    }
+}

--- a/src/main/resources/mixins.mods.astralsorcery.neromanticprime.json
+++ b/src/main/resources/mixins.mods.astralsorcery.neromanticprime.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.astralsorcery.neromanticprime.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTFixNeromanticPrimeFluidOverflowMixin", "UTUnlimitedFluidVeinMixin", "UTConfigurableFluidVeinDimensionsMixin", "UTConfigurableFluidVeinExtractionQuantityMixin", "FluidRarityEntryMixin"]
+}


### PR DESCRIPTION
Fix Neromantic Prime Fluid Overflow due to addition of max int numbers
Allow Unlimited Fluid Veins if they are max size
Allow tweakking the amount extacted per operation
Allow filtering which dimension each vein appars in