### PR TITLE
Add DivineRPG fix for armor set handler cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ All changes are toggleable via config files.
 * **Divine RPG**
     * **Change Water Mob Creature Type:** Changes the creature type for DivineRPG Water Mobs to be WATER_CREATURE, fixing issues with hostile mob spawn caps and infinite water mob spawning
     * **Fix Aquamarine Stack Size:** Aquamarine has durability, yet doesn't have a max stack size of 1
+    * **Fix Armor Set Effect Cleanup:** Fixes issues with armor set effects being cleaned up under the wrong conditions that caused crashes
     * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
 * **Effortless Building**
     * **Block Transmutation Fix:** Fixes Effortless Building ignoring Metadata when checking for items in inventory

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -628,6 +628,11 @@ public class UTConfigMods
         public boolean utFixAquamarineStackSize = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fix Armor Set Effect Cleanup")
+        @Config.Comment("Fixes issues with armor set effects being cleaned up under the wrong conditions that caused crashes")
+        public boolean utFixArmorSetCleanup = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Consuming Incorrect Hand")
         @Config.Comment("Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used")
         public boolean utFixHandConsumption = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -91,6 +91,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.corpse.json", () -> loaded("corpse") && UTConfigMods.CORPSE.utOpeningGuisOffThreadFixToggle);
                 put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
                 put("mixins.mods.divinerpg.aquamarine.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
+                put("mixins.mods.divinerpg.armorset.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixArmorSetCleanup);
                 put("mixins.mods.divinerpg.hand.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixHandConsumption);
                 put("mixins.mods.divinerpg.waterspawning.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utChangeWaterMobCreatureType);
                 put("mixins.mods.effortlessbuilding.json", () -> loaded("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersMixin.java
@@ -1,0 +1,41 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
+
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import divinerpg.capabilities.armor.ArmorPowers;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = ArmorPowers.class, remap = false)
+public class UTArmorPowersMixin
+{
+    @Shadow
+    @Final
+    private WeakReference<EntityLivingBase> player;
+
+    /**
+     * @reason The UUID check is inverted; unsubscribe() must only be called when the UUID is the same (the same player),
+     * but EntityPlayer object is different (the entity of the player was recreated), not on ANY entity join
+     * <br>
+     * Also only cleanup on the matching side, fixing possible ConcurrentModificationException and corrupting the EventBus.
+     * @see <a href="https://github.com/DivineRPG/DivineRPG/commit/a1429c46a2bb5edad4979b5854b57c64b7a5e7b6?diff=split#diff-ada324cf157705224cfc240578dfdf6ff491085063010e5440de9f00c5a881baL53">the originally correct condition</a>
+     */
+    @Definition(id = "equals", method = "Ljava/util/Objects;equals(Ljava/lang/Object;Ljava/lang/Object;)Z")
+    @Expression("equals(?, ?) == false")
+    @ModifyExpressionValue(method = "onCleanUp", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private boolean utOnlyCleanupRecreatedPlayer(boolean notEqual, EntityJoinWorldEvent event)
+    {
+        EntityLivingBase oldPlayer = Objects.requireNonNull(player.get());
+        // !(!equals) -> equals
+        return !notEqual && event.getWorld().isRemote == oldPlayer.world.isRemote;
+    }
+}

--- a/src/main/resources/mixins.mods.divinerpg.armorset.json
+++ b/src/main/resources/mixins.mods.divinerpg.armorset.json
@@ -1,0 +1,10 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "mixinextras": {
+    "minVersion": "0.5.0-beta.5"
+  },
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTArmorPowersMixin"]
+}


### PR DESCRIPTION
Fixes incorrect condition for DivineRPG's armor set handler when unregistering itself. Random crashes like [this](https://mclo.gs/XIxdSQp) and [this](https://mclo.gs/ipercFZ) would occur due to unregistering on any entity spawn, including ones on a different thread (in singleplayer). 