### PR TITLE
Fix compat with Alfheim v1.6 for Compact Machines memory tweak

### DIFF
--- a/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
+++ b/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
@@ -1,0 +1,5 @@
+package dev.redstudio.alfheim.lighting;
+
+// stub class for Alfheim v1.6+
+public class LightingEngine {
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/memory/mixin/UTProxyWorldMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/compactmachines/memory/mixin/UTProxyWorldMixin.java
@@ -21,6 +21,7 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 
+import dev.redstudio.alfheim.lighting.LightingEngine;
 import mod.acgaming.universaltweaks.mods.compactmachines.memory.DummyWorld;
 import org.dave.compactmachines3.world.ProxyWorld;
 import org.spongepowered.asm.mixin.*;
@@ -166,10 +167,9 @@ public abstract class UTProxyWorldMixin extends World
         return this;
     }
 
-    @SuppressWarnings("NullableProblems")
     @Override
     @Optional.Method(modid = "alfheim")
-    public int getLightFromNeighborsFor(EnumSkyBlock type, BlockPos pos)
+    public int getLightFromNeighborsFor(@Nonnull EnumSkyBlock type, @Nonnull BlockPos pos)
     {
         return 15;
     }
@@ -179,5 +179,11 @@ public abstract class UTProxyWorldMixin extends World
     public int alfheim$getLight(BlockPos pos, boolean checkNeighbors)
     {
         return 15;
+    }
+
+    @SuppressWarnings({"MissingUnique", "unused"})
+    @Optional.Method(modid = "alfheim")
+    public LightingEngine getAlfheim$lightingEngine() {
+        return null;
     }
 }


### PR DESCRIPTION
Fixes/adds compatibility with Alfheim v1.6 for the Compact Machines memory tweak. The tweak would cause an NPE since v1.6 due to a difference in how the lighting engine is initialized (see GregTechCEu/GregTech#2838).