### PR TITLE
Add Cyclic memory leak fix tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ All changes are toggleable via config files.
     * **Oven Fix:** Fixes CFB Oven consuming container fuel items
 * **Corpse**
     * **Opening GUIs Off-thread Fix:** Fixes opening up GUIs on a non-client thread
+* **Cyclic**
+    * **Memory Leak Fix:** Fixes memory leak associated with advancements when creating FakePlayers
 * **Divine RPG**
     * **Change Water Mob Creature Type:** Changes the creature type for DivineRPG Water Mobs to be WATER_CREATURE, fixing issues with hostile mob spawn caps and infinite water mob spawning
     * **Fix Aquamarine Stack Size:** Aquamarine has durability, yet doesn't have a max stack size of 1

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -85,6 +85,7 @@ final def mod_dependencies = [
     'curse.maven:corpse-316582:3010808'                               : [debug_corpse],
     'curse.maven:cqrepoured-303422:3953103'                           : [debug_cqrepoured],
     'curse.maven:ctm-267602:2915363'                                  : [debug_chisel],
+    'curse.maven:cyclic-239286:4075832'                               : [debug_cyclic],
     'curse.maven:cyclops-core-232758:3159497'                         : [debug_evilcraft],
     'curse.maven:dankkstorage-335673:2787318'                         : [debug_dankstorage],
     'curse.maven:effortlessbuilding-302113:2847346'                   : [debug_effortless_building],

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,7 @@ debug_cooking_for_blockheads = false
 debug_corpse = false
 debug_cqrepoured = false
 debug_crafttweaker = false
+debug_cyclic = false
 debug_dankstorage = false
 debug_divinerpg = false
 debug_effortless_building = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -107,6 +107,10 @@ public class UTConfigMods
     @Config.Name("Corpse")
     public static final CorpseCategory CORPSE = new CorpseCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.cyclic")
+    @Config.Name("Cyclic")
+    public static final CyclicCategory CYCLIC = new CyclicCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.dankstorage")
     @Config.Name("Dank Storage")
     public static final DankStorageCategory DANK_STORAGE = new DankStorageCategory();
@@ -621,6 +625,14 @@ public class UTConfigMods
         @Config.Name("Opening GUIs Off-thread Fix")
         @Config.Comment("Fixes opening up GUIs on a non-client thread")
         public boolean utOpeningGuisOffThreadFixToggle = true;
+    }
+
+    public static class CyclicCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Memory Leak Fix")
+        @Config.Comment("Fixes memory leak associated with advancements when creating FakePlayers")
+        public boolean utMemoryLeakFixToggle = true;
     }
 
     public static class DankStorageCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -90,6 +90,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins.mods.compactmachines.spawns.json", () -> loaded("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utAllowedSpawnsImprovementToggle);
                 put("mixins.mods.cookingforblockheads.json", () -> loaded("cookingforblockheads") && UTConfigMods.COOKING_FOR_BLOCKHEADS.utOvenFixToggle);
                 put("mixins.mods.cqrepoured.json", () -> loaded("cqrepoured"));
+                put("mixins.mods.cyclic.json", () -> loaded("cyclicmagic") && UTConfigMods.CYCLIC.utMemoryLeakFixToggle);
                 put("mixins.mods.dankstorage.json", () -> loaded("dankstorage"));
                 put("mixins.mods.divinerpg.aquamarine.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
                 put("mixins.mods.divinerpg.armorset.json", () -> loaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixArmorSetCleanup);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/mixin/UTUtilFakePlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/mixin/UTUtilFakePlayerMixin.java
@@ -1,0 +1,25 @@
+package mod.acgaming.universaltweaks.mods.cyclic.mixin;
+
+import java.util.UUID;
+
+import com.lothrazar.cyclicmagic.util.Const;
+import com.lothrazar.cyclicmagic.util.UtilFakePlayer;
+import com.mojang.authlib.GameProfile;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// Courtesy of jchung01
+@Mixin(value = UtilFakePlayer.class, remap = false)
+public class UTUtilFakePlayerMixin
+{
+    // Shared profile so new PlayerAdvancements aren't created for every fake player
+    @Unique
+    private static final GameProfile ut$CYCLIC_PROFILE = new GameProfile(UUID.nameUUIDFromBytes(Const.MODID.getBytes()), "[Cyclic]");
+
+    @Redirect(method = "initFakePlayer", at = @At(value = "NEW", target = "(Ljava/util/UUID;Ljava/lang/String;)Lcom/mojang/authlib/GameProfile;"))
+    private static GameProfile utUseSharedProfile(UUID id, String name) {
+        return ut$CYCLIC_PROFILE;
+    }
+}

--- a/src/main/resources/mixins.mods.cyclic.json
+++ b/src/main/resources/mixins.mods.cyclic.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.cyclic.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTUtilFakePlayerMixin"]
+}


### PR DESCRIPTION
Fixes a FakePlayer-related memory leak from Cyclic. Cyclic uses `FakePlayerFactory` to get fake players for its various tile entities that need it, but it generated a new GameProfile with different UUIDs everytime. This is a problem as the tiles store weak references to their FakePlayer, so when the fake players would get cleaned up by the GC, `PlayerAdvancements` associated with their unique GameProfile would not be cleaned up. This caused advancement-related data to infinitely grow in memory usage the longer a server ran.
The fix just uses a shared `GameProfile` like other mods do for their fake players.