### PR TITLE
Fix possible crash with advancement trigger tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryPlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryPlayerMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.Unique;
 public class UTInventoryPlayerMixin implements ISlotContext
 {
     @Unique
-    private ItemStack ut$changedStack;
+    private ItemStack ut$changedStack = ItemStack.EMPTY;
 
     @Unique
     private SlotCounts ut$slotCounts;


### PR DESCRIPTION
The tweak may cause a crash if `InventoryChangeTrigger#trigger()` is called from a method other than where expected (`EntityPlayerMP#sendSlotContents()`).