### PR TITLE
Follow-up to advancement trigger tweak bugfix

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/ISlotContext.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/ISlotContext.java
@@ -1,5 +1,7 @@
 package mod.acgaming.universaltweaks.tweaks.performance.advancements.triggers;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.item.ItemStack;
 
@@ -20,7 +22,11 @@ public interface ISlotContext
 
     /**
      * Get the stack that was changed.
+     * <br>
+     * An empty ItemStack means the context was passed an empty stack.
+     * A null stack means the context was never passed stack info.
      */
+    @Nullable
     ItemStack ut$getStack();
 
     /**
@@ -28,6 +34,9 @@ public interface ISlotContext
      */
     void ut$setStack(ItemStack stack);
 
+    /**
+     * Reset stack info and slot counts.
+     */
     void ut$resetContext();
 
     class SlotCounts

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryChangeTriggerInstanceMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryChangeTriggerInstanceMixin.java
@@ -56,6 +56,10 @@ public class UTInventoryChangeTriggerInstanceMixin
         }
 
         ItemStack changedStack = ((ISlotContext) inventory).ut$getStack();
+        // Ignore optimization if stack info is unavailable.
+        if (changedStack == null) {
+            return;
+        }
         int numPredicates = items.length;
         if (numPredicates == 0)
         {

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryChangeTriggerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryChangeTriggerMixin.java
@@ -36,14 +36,22 @@ public class UTInventoryChangeTriggerMixin
     private void utOnlyTriggerForIncreasedStacks(EntityPlayerMP player, InventoryPlayer inventory, CallbackInfo ci)
     {
         ItemStack stack = ((ISlotContext) inventory).ut$getStack();
-        if ((stack.isEmpty() && UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utIgnoreEmptiedStackTriggers)
-            || (UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utIgnoreDecreasedStackTriggers
-            && stack.getCount() < ((IPrevSizeTracker) (Object) stack).ut$getPreviousStackSize())
-            || (UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utOptimizeIncreasedStackTriggers
-            && !StackSizeThresholdManager.doesStackPassThreshold(stack)))
+        // Ignore optimization for triggers where stack info is unavailable.
+        if (stack == null)
         {
-            ci.cancel();
+            if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInventoryChangeTrigger ::: Allowing trigger from unknown source");
+            ut$prepareSlotCounts(inventory);
+            return;
+        }
+        if ((UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utIgnoreEmptiedStackTriggers
+                && stack.isEmpty())
+            || (UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utIgnoreDecreasedStackTriggers
+                && stack.getCount() < ((IPrevSizeTracker) (Object) stack).ut$getPreviousStackSize())
+            || (UTConfigTweaks.PERFORMANCE.ADVANCEMENT_TRIGGERS.utOptimizeIncreasedStackTriggers
+                && !StackSizeThresholdManager.doesStackPassThreshold(stack)))
+        {
             if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInventoryChangeTrigger ::: Cancelling trigger for {} with previous size {}", stack, ((IPrevSizeTracker) (Object) stack).ut$getPreviousStackSize());
+            ci.cancel();
             return;
         }
         if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTInventoryChangeTrigger ::: Allowing trigger for {} with previous size {}", stack, ((IPrevSizeTracker) (Object) stack).ut$getPreviousStackSize());

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryPlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/performance/advancements/triggers/mixin/UTInventoryPlayerMixin.java
@@ -1,6 +1,7 @@
 package mod.acgaming.universaltweaks.tweaks.performance.advancements.triggers.mixin;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -13,8 +14,9 @@ import org.spongepowered.asm.mixin.Unique;
 @Mixin(value = InventoryPlayer.class)
 public class UTInventoryPlayerMixin implements ISlotContext
 {
+    @Nullable
     @Unique
-    private ItemStack ut$changedStack = ItemStack.EMPTY;
+    private ItemStack ut$changedStack = null;
 
     @Unique
     private SlotCounts ut$slotCounts;
@@ -31,6 +33,7 @@ public class UTInventoryPlayerMixin implements ISlotContext
         ut$slotCounts = new SlotCounts(numFull, numEmpty, numOccupied);
     }
 
+    @Nullable
     @Override
     public ItemStack ut$getStack()
     {
@@ -46,7 +49,7 @@ public class UTInventoryPlayerMixin implements ISlotContext
     @Override
     public void ut$resetContext()
     {
-        ut$changedStack = ItemStack.EMPTY;
+        ut$changedStack = null;
         ut$slotCounts = null;
     }
 }


### PR DESCRIPTION
A follow-up to the previous fix to more properly handle advancement triggers in unexpected contexts. Now actually skips the optimizations if `CriteriaTriggers.INVENTORY_CHANGED.trigger()` is called from a method other than where expected.