### PR TITLE
Persistent Bed Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ All changes are toggleable via config files.
     * **Chat Lines:** Sets the maximum number of chat lines to display
     * **Compact Messages:** Removes duplicate messages and instead put a number behind the message how often it was repeated
     * **Keep Sent Messages:** Don't clear sent message history on leaving the world
+    * **Keep Chat Active on waking:** When waking up from bed, if the chat had text keep the chat window open
 * **Check Animated Models:** Improves model load times by checking if an animated model exists before trying to load it
 * **Chicken Shedding:** Allows chickens to have a chance to shed feathers (similarly to laying eggs)
 * **Chunk Gen Limit:** Limits maximum chunk generation per tick for improved server performance

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -80,6 +80,7 @@ import mod.acgaming.universaltweaks.tweaks.items.useduration.UTCustomUseDuration
 import mod.acgaming.universaltweaks.tweaks.misc.advancements.screenshot.UTAdvancementScreenshot;
 import mod.acgaming.universaltweaks.tweaks.misc.armorcurve.UTArmorCurve;
 import mod.acgaming.universaltweaks.tweaks.misc.buttons.cheats.UTToggleCheats;
+import mod.acgaming.universaltweaks.tweaks.misc.chat.bed.UTKeepChatOpen;
 import mod.acgaming.universaltweaks.tweaks.misc.damagetilt.UTDamageTilt;
 import mod.acgaming.universaltweaks.tweaks.misc.endportal.UTEndPortalParallax;
 import mod.acgaming.universaltweaks.tweaks.misc.gui.lanserverproperties.UTLanServerProperties;
@@ -249,6 +250,7 @@ public class UniversalTweaks
             if (UTConfigTweaks.ENTITIES.utCoyoteTimeJumpingToggle) MinecraftForge.EVENT_BUS.register(UTCoyoteTimeJumping.class);
             if (UTConfigTweaks.ITEMS.utAutoSwitchToggle) MinecraftForge.EVENT_BUS.register(UTAutoSwitch.class);
             if (UTConfigTweaks.MISC.ADVANCEMENT_SCREENSHOT.utAdvancementScreenshotToggle) MinecraftForge.EVENT_BUS.register(UTAdvancementScreenshot.class);
+            if (UTConfigTweaks.MISC.CHAT.utKeepChatOpen) MinecraftForge.EVENT_BUS.register(UTKeepChatOpen.class);
             if (UTConfigTweaks.MISC.LOAD_SOUNDS.utLoadSoundMode != UTConfigTweaks.MiscCategory.LoadSoundsCategory.EnumSoundModes.NOTHING) MinecraftForge.EVENT_BUS.register(UTLoadSound.class);
             if (UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) UTPickupNotificationOverlay.init();
             if (UTConfigTweaks.MISC.utEndPortalParallaxToggle) UTEndPortalParallax.initRenderer();

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -2056,6 +2056,11 @@ public class UTConfigTweaks
             @Config.Name("[3] Compact Messages")
             @Config.Comment("Removes duplicate messages and instead put a number behind the message how often it was repeated")
             public boolean utCompactMessagesToggle = false;
+
+            @Config.RequiresMcRestart
+            @Config.Name("[4] Keep Chat Active on waking")
+            @Config.Comment("When waking up from bed, if the chat had text keep the chat window open")
+            public boolean utKeepChatOpen = true;
         }
 
         public static class GameWindowCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -227,6 +227,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins.tweaks.misc.buttons.anaglyph.optifine.json", () -> UTConfigTweaks.MISC.ut3DAnaglyphButtonToggle && Coremods.OPTIFINE.isLoaded());
                 put("mixins.tweaks.misc.buttons.realms.json", () -> SystemUtils.IS_JAVA_1_8 && UTConfigTweaks.MISC.utRealmsButtonToggle && !Coremods.RANDOM_PATCHES.isLoaded());
                 put("mixins.tweaks.misc.buttons.snooper.client.json", () -> SystemUtils.IS_JAVA_1_8 && UTConfigTweaks.MISC.utSnooperToggle);
+                put("mixins.tweaks.misc.chat.bed.json", () -> UTConfigTweaks.MISC.CHAT.utKeepChatOpen);
                 put("mixins.tweaks.misc.chat.compactmessage.json", () -> UTConfigTweaks.MISC.CHAT.utCompactMessagesToggle);
                 put("mixins.tweaks.misc.chat.keepsentmessages.json", () -> UTConfigTweaks.MISC.CHAT.utKeepSentMessageHistory);
                 put("mixins.tweaks.misc.chat.maximumlines.json", () -> UTConfigTweaks.MISC.CHAT.utChatLines != 100);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/chat/bed/UTKeepChatOpen.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/chat/bed/UTKeepChatOpen.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.tweaks.misc.chat.bed;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
+import net.minecraft.client.gui.GuiSleepMP;
+import net.minecraftforge.client.event.GuiOpenEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import mod.acgaming.universaltweaks.tweaks.misc.chat.bed.mixin.UTGuiChatAccessor;
+
+// Courtesy of WaitingIdly
+public class UTKeepChatOpen
+{
+    @SubscribeEvent
+    public static void utKeepChatOpenOnWake(GuiOpenEvent event)
+    {
+        if (!UTConfigTweaks.MISC.CHAT.utKeepChatOpen) return;
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.currentScreen instanceof GuiSleepMP && event.getGui() == null)
+        {
+            String text = ((UTGuiChatAccessor) mc.currentScreen).getInputField().getText();
+            if (!text.isEmpty())
+            {
+                event.setGui(new GuiChat(text));
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/chat/bed/mixin/UTGuiChatAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/chat/bed/mixin/UTGuiChatAccessor.java
@@ -1,0 +1,14 @@
+package mod.acgaming.universaltweaks.tweaks.misc.chat.bed.mixin;
+
+import net.minecraft.client.gui.GuiChat;
+import net.minecraft.client.gui.GuiTextField;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(GuiChat.class)
+public interface UTGuiChatAccessor
+{
+    @Accessor("inputField")
+    GuiTextField getInputField();
+}

--- a/src/main/resources/mixins.tweaks.misc.chat.bed.json
+++ b/src/main/resources/mixins.tweaks.misc.chat.bed.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.chat.bed.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiChatAccessor"]
+}


### PR DESCRIPTION
changes in this PR:
- add a tweak to allow keeping the chat open when waking up if the chat has text in it (default: `false`).

this is a feature from [Bed Bugs](https://www.curseforge.com/minecraft/mc-mods/bed-bugs), although implemented rather differently. i think theres a potential argument to mark `bedbugs` as obsolete because its main features are this and the addition of a button+command to kick the player while in bed. the reason for the latter seems to be the same as `bedpatch`, which was fixed in forge.