### PR TITLE
Fix Further AA Breaker Dupes

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/dupes/mixin/StackUtilMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/actuallyadditions/dupes/mixin/StackUtilMixin.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.mods.actuallyadditions.dupes.mixin;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import de.ellpeck.actuallyadditions.mod.util.ItemStackHandlerAA;
+import de.ellpeck.actuallyadditions.mod.util.StackUtil;
+
+/**
+ * Fixes `canAddAll` function increasing stack counts in stack list;
+ * under specific edge cases (e.g. inventory is empty)
+ */
+@Mixin(value = StackUtil.class, remap = false)
+public class StackUtilMixin {
+
+    @WrapOperation(method = "canAddAll(Lde/ellpeck/actuallyadditions/mod/util/ItemStackHandlerAA;Ljava/util/List;Z)Z",
+                   at = @At(value = "INVOKE",
+                            target = "Lde/ellpeck/actuallyadditions/mod/util/ItemStackHandlerAA;insertItem(ILnet/minecraft/item/ItemStack;ZZ)Lnet/minecraft/item/ItemStack;"),
+                   require = 1)
+    private static ItemStack copyStack1(ItemStackHandlerAA instance, int slot, ItemStack stack, boolean simulate,
+                                        boolean fromAutomation,
+                                        Operation<ItemStack> original) {
+        return original.call(instance, slot, stack.copy(), simulate, fromAutomation);
+    }
+
+    @WrapOperation(method = "canAddAll(Lde/ellpeck/actuallyadditions/mod/util/ItemStackHandlerAA;Ljava/util/List;IIZ)Z",
+                   at = @At(value = "INVOKE",
+                            target = "Lde/ellpeck/actuallyadditions/mod/util/ItemStackHandlerAA;insertItem(ILnet/minecraft/item/ItemStack;ZZ)Lnet/minecraft/item/ItemStack;"),
+                   require = 1)
+    private static ItemStack copyStack2(ItemStackHandlerAA instance, int slot, ItemStack stack, boolean simulate,
+                                        boolean fromAutomation,
+                                        Operation<ItemStack> original) {
+        return original.call(instance, slot, stack.copy(), simulate, fromAutomation);
+    }
+}

--- a/src/main/resources/mixins.mods.actuallyadditions.dupes.json
+++ b/src/main/resources/mixins.mods.actuallyadditions.dupes.json
@@ -3,5 +3,10 @@
   "refmap": "universaltweaks.refmap.json",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTTileEntityBreakerMixin", "UTTileEntityDirectionalBreakerMixin", "UTTileEntityPhantomPlacerMixin"]
+  "mixins": [
+    "StackUtilMixin",
+    "UTTileEntityBreakerMixin",
+    "UTTileEntityDirectionalBreakerMixin",
+    "UTTileEntityPhantomPlacerMixin"
+  ]
 }


### PR DESCRIPTION
This PR fixes further AA dupes caused by stack modification in its `StackUtil.canAddAll` function.

This can be observed with a breaker and clay blocks:
- When the breaker's inventory is empty, 7 clay balls are outputted
- When its not empty (and clay balls are in inventory, and no new slot needs to be filled), 4 clay balls are outputted (as expected)

The reason the dupe only occurs where a new slot needs to be filled is that one of the stacks in the list is placed into the dummy inv; which then has its count incremented, resulting in more drops than actual. This doesn't happen if slots are already filled as then the dummy inv's existing stack has its count incremented.