### PR TITLE
Fix Outdated Redstone Conduit Signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ All changes are toggleable via config files.
     * **Feathers Helper API Fix:** Fixes server-sided crashes when the Feathers Helper API is utilized
     * **Sprinting Integration:** Configurable consumption of feathers when the player is sprinting
 * **Ender IO**
+    * **Clear Outdated Redstone Conduit:** When changing colors in the Redstone Conduit GUI, remove the signal from the old color
     * **Fix Chorus Farming StackOverflow:** Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow
     * **Fix Soul Binder JEI Appearance:** Fixes the Soul Binder having empty ingredients or displaying filled soul vials in the output slot incorrectly
     * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -785,6 +785,11 @@ public class UTConfigMods
     public static class EnderIOCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Clear Outdated Redstone Conduit")
+        @Config.Comment("When changing colors in the Redstone Conduit GUI, remove the signal from the old color")
+        public boolean utClearRedstoneConduitChange = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Chorus Farming StackOverflow")
         @Config.Comment("Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow")
         public boolean utChorusStackOverflow = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -113,6 +113,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.elenaidodge2.json", c -> c.isModPresent("elenaidodge2"));
                 put("mixins/mods/mixins.enderio.chorus.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);
                 put("mixins/mods/mixins.enderio.cyclebutton.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utSaveFilterCycleButtonProperly);
+                put("mixins/mods/mixins.enderio.redstoneconduit.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utClearRedstoneConduitChange);
                 put("mixins/mods/mixins.enderio.soulbinderjei.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utFixSoulBinderJEI);
                 put("mixins/mods/mixins.enderstorage.json", c -> c.isModPresent("enderstorage") && UTConfigMods.ENDER_STORAGE.utFrequencyTrackFixToggle);
                 put("mixins/mods/mixins.epicsiegemod.json", c -> c.isModPresent("epicsiegemod"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/redstoneconduit/mixin/UTInsulatedRedstoneConduitMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/redstoneconduit/mixin/UTInsulatedRedstoneConduitMixin.java
@@ -1,0 +1,47 @@
+package mod.acgaming.universaltweaks.mods.enderio.redstoneconduit.mixin;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.util.EnumFacing;
+
+import com.enderio.core.common.util.DyeColor;
+import crazypants.enderio.base.conduit.redstone.signals.Signal;
+import crazypants.enderio.conduits.conduit.redstone.InsulatedRedstoneConduit;
+import crazypants.enderio.conduits.conduit.redstone.RedstoneConduitNetwork;
+import crazypants.enderio.util.FuncUtil;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of WaitingIdly
+@Mixin(value = InsulatedRedstoneConduit.class, remap = false)
+public abstract class UTInsulatedRedstoneConduitMixin
+{
+    @Shadow
+    @Nullable
+    public abstract RedstoneConduitNetwork getNetwork();
+
+    @Shadow
+    @Nonnull
+    public abstract Signal getNetworkInput(@NotNull EnumFacing side);
+
+    @Shadow
+    @Nonnull
+    public abstract DyeColor getInputSignalColor(@NotNull EnumFacing dir);
+
+    /**
+     * @author WaitingIdly
+     * @reason When changing color, first set the current color to
+     * have a signal strength of 0. This prevents the signal strength from lingering
+     * in the network.
+     */
+    @Inject(method = "setInputSignalColor", at = @At("HEAD"))
+    private void utRemoveOldSignalStrength(EnumFacing dir, DyeColor col, CallbackInfo ci)
+    {
+        FuncUtil.doIf(getNetwork(), net -> net.getBundledSignal().addSignal(getInputSignalColor(dir), new Signal(0, getNetworkInput(dir).getId())));
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.enderio.redstoneconduit.json
+++ b/src/main/resources/mixins/mods/mixins.enderio.redstoneconduit.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderio.redstoneconduit.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTInsulatedRedstoneConduitMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- when changing Redstone Conduit colors, set the old color to have a signal of 0, which prevents a "ghost signal" from persisting in the conduit network for the old color (default: `true`).

related issues: https://github.com/SleepyTrousers/EnderIO-1.5-1.12/issues/5558