### PR TITLE
Fix Witches Altar IBlockState Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ All changes are toggleable via config files.
 * **Backpacks**
     * **No Offhand Interaction:** Prevents unintended offhand right-click behavior when opening backpacks
 * **Bewitchment**
+    * **Fix Altar IBlockState Check:** Fix the Witches Altar checking blocks causing crashes when scanning blocks that do not have the expected properties, primarily TerraFirmaCraft leaves
     * **Witches' Oven Fix:** Fixes Witches' Oven consuming container fuel items
 * **Bibliocraft**
     * **Allow Any Black Dye for Printing Press:** Allow the Printing Press to properly work with any itemstack with the dyeBlack oredict, instead of only processing with Ink Sacs

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -446,6 +446,11 @@ public class UTConfigMods
     public static class BewitchmentCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("Fix Altar IBlockState Check")
+        @Config.Comment("Fix the Witches Altar checking blocks causing crashes when scanning blocks that do not have the expected properties, primarily TerraFirmaCraft leaves")
+        public boolean utLeavesChechFix = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Witches' Oven Fix")
         @Config.Comment("Fixes Witches' Oven consuming container fuel items")
         public boolean utWitchesOvenFixToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -75,6 +75,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.astralsorcery.tool.json", c -> c.isModPresent("astralsorcery") && UTConfigMods.ASTRAL_SORCERY.utEmptyPropertiesZero);
                 put("mixins/mods/mixins.backpack.json", c -> c.isModPresent("backpack") && UTConfigMods.BACKPACKS.utBPNoOffhandInteractionToggle);
                 put("mixins/mods/mixins.bewitchment.json", c -> c.isModPresent("bewitchment") && UTConfigMods.BEWITCHMENT.utWitchesOvenFixToggle);
+                put("mixins/mods/mixins.bewitchment.leaves.json", c -> c.isModPresent("bewitchment") && UTConfigMods.BEWITCHMENT.utLeavesChechFix);
                 put("mixins/mods/mixins.bibliocraft.armor.json", c -> c.isModPresent("bibliocraft") && UTConfigMods.BIBLIOCRAFT.utArmorStandSlotFixToggle);
                 put("mixins/mods/mixins.bibliocraft.armorbinding.json", c -> c.isModPresent("bibliocraft") && UTConfigMods.BIBLIOCRAFT.utArmorStandBindingCurseToggle);
                 put("mixins/mods/mixins.bibliocraft.hand.json", c -> c.isModPresent("bibliocraft") && UTConfigMods.BIBLIOCRAFT.utFixHandConsumption);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/bewitchment/mixin/UTTileEntityWitchesAltarMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bewitchment/mixin/UTTileEntityWitchesAltarMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.mods.bewitchment.mixin;
+
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.IBlockState;
+
+import com.bewitchment.common.block.tile.entity.TileEntityWitchesAltar;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = TileEntityWitchesAltar.class, remap = false)
+public class UTTileEntityWitchesAltarMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason Ensure the property exists before attempting to set the blockstate with it,
+     * as not all classes that extend the class.
+     * Primarily for TerraFirmaCraft leaves, as they do not have the {@link net.minecraft.block.BlockLeaves#CHECK_DECAY BlockLeaves.CHECK_DECAY}
+     * property, which causes the altar to crash when checking them.
+     * See <a href="https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.12.x/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLeavesTFC.java#L59">BlockLeavesTFC.java</a>
+     */
+    @SuppressWarnings("MixinExtrasOperationParameters")
+    @WrapOperation(method = "convert", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/IBlockState;withProperty(Lnet/minecraft/block/properties/IProperty;Ljava/lang/Comparable;)Lnet/minecraft/block/state/IBlockState;"))
+    private <T extends Comparable<T>, V extends T> IBlockState utCheckPropertyExists(IBlockState instance, IProperty<T> property, V value, Operation<IBlockState> original)
+    {
+        if (instance.getPropertyKeys().contains(property)) return original.call(instance, property, value);
+        return instance;
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.bewitchment.leaves.json
+++ b/src/main/resources/mixins/mods/mixins.bewitchment.leaves.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.bewitchment.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTTileEntityWitchesAltarMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- fix bewitchment altar iblockstate checks checking invalid properties, which causes crashes with mods like TerraFirmaCraft due to their leaves not having the `CHECK_DECAY` property (default: `true`).

requested by https://github.com/ACGaming/UniversalTweaks/discussions/637, https://github.com/ACGaming/UniversalTweaks/discussions/570
related to https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues/1602


