### PR TITLE
Improve forge mod list tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/modlist/mixin/UTGuiModListMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/gui/modlist/mixin/UTGuiModListMixin.java
@@ -7,6 +7,7 @@ import net.minecraftforge.fml.client.GuiModList;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -21,6 +22,7 @@ public abstract class UTGuiModListMixin
     @Shadow(remap = false)
     private String lastFilterText;
 
+    @Unique
     private static String savedFilterText = "";
 
     @Inject(method = "initGui", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiTextField;setCanLoseFocus(Z)V", shift = At.Shift.AFTER))


### PR DESCRIPTION
- Fix the search to actually remember last searches
- Trim whitespace between pipes so searching like `univer | just` gives better result