### PR TITLE
Implement player death attribute persistence tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All changes are toggleable via config files.
 * **Armor Curve:** Adjusts the armor scaling and degradation formulae for mobs and players
 * **Armor Swap:** Enable the ability to swap equipped armor when right-clicking armor, instead of only being able to equip armor when the slot is empty. Also applies to Elytra
 * **Attributes:** Sets custom ranges for entity attributes
+* **Attribute Keeper:** Specify attributes that will persist through player death
 * **Auto Jump Replacement:** Replaces auto jump with an increased step height (singleplayer only)
 * **Auto Save Interval:** Configurable interval in ticks between world auto saves
 * **Auto Switch Tools:** Switches the selected hotbar slot to a proper tool if required

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,5 +1,7 @@
 package mod.acgaming.universaltweaks;
 
+import mod.acgaming.universaltweaks.tweaks.entities.attributes.UTAttributeKeeper;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.common.MinecraftForge;
@@ -202,6 +204,7 @@ public class UniversalTweaks
         if (UTConfigGeneral.MASTER_SWITCHES.utMasterSwitchTweaks)
         {
             if (UTConfigTweaks.ENTITIES.ATTRIBUTES.utAttributesToggle) UTAttributes.utSetAttributes();
+            if (UTConfigTweaks.ENTITIES.ATTRIBUTES.utAttributesToggle) MinecraftForge.EVENT_BUS.register(UTAttributeKeeper.class);
             if (UTConfigTweaks.MISC.utSkipRegistryScreenToggle) System.setProperty("fml.queryResult", "confirm");
         }
 

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -835,6 +835,17 @@ public class UTConfigTweaks
 
             @Config.Name("[21] Luck Max")
             public double utAttributeLuckMax = 65536;
+
+            @Config.Name("[22] Attribute Keeper")
+            @Config.Comment
+                ({
+                    "A list of attributes that will persist after player death. Only the base attribute value will be kept",
+                    "such as those increased through the Player Attribute Commands mod.",
+                    " Examples:",
+                    "  generic.maxHealth",
+                    "  generic.attackDamage"
+                })
+            public String[] utAttributeLock = new String[] {};
         }
 
         public static class BetterBurningCategory

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/attributes/UTAttributeKeeper.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/attributes/UTAttributeKeeper.java
@@ -1,0 +1,57 @@
+package mod.acgaming.universaltweaks.tweaks.entities.attributes;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.entity.ai.attributes.AbstractAttributeMap;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Allows persistence for configured attribute values after player death. Player death normally resets all
+ * attributes, undoing any changes done by mods such as <a href="https://www.curseforge.com/minecraft/mc-mods/player-attribute-commands">Player Attribute Command</a>.
+ * <p>
+ * Only the base attribute value is persistent, so any modifiers, such as those gained with potions, will
+ * not be included.
+ */
+public class UTAttributeKeeper
+{
+    @SubscribeEvent
+    public static void utAttributeKeeper(PlayerEvent.Clone event) {
+        if(event.isWasDeath() && !event.isCanceled())
+        {
+            EntityPlayer original = event.getOriginal();
+            AbstractAttributeMap originalAttributes = original.getAttributeMap();
+            if(originalAttributes != null)
+            {
+                for(IAttributeInstance instance : originalAttributes.getAllAttributes())
+                {
+                    for(String configStr : UTConfigTweaks.ENTITIES.ATTRIBUTES.utAttributeLock)
+                    {
+                        if (instance.getAttribute().getName().equals(configStr))
+                        {
+                            transferAttribute(event.getEntityPlayer(), instance);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void transferAttribute(EntityPlayer player, @NotNull IAttributeInstance attributeValue)
+    {
+        IAttributeInstance instance = player.getEntityAttribute(attributeValue.getAttribute());
+        if(instance != null)
+        {
+            instance.setBaseValue(attributeValue.getBaseValue());
+        }
+        else
+        {
+            player.getAttributeMap().registerAttribute(attributeValue.getAttribute()).setBaseValue(attributeValue.getBaseValue());
+        }
+    }
+}


### PR DESCRIPTION
Player attributes are reset on player death. This causes changes to base attribute values, such as those modified with the [Player Attribute Commands](https://www.curseforge.com/minecraft/mc-mods/player-attribute-commands) mod, to return to their default values.

Attribute modifiers, such as those applied through potions, are not copied during this process.

By default, this tweak does not cause any attributes to be persistent and will require setup by any users wishing to utilize this feature.