### PR TITLE
Rewrite DivineRPG armor set cleanup tweak

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -35,6 +35,7 @@ import mod.acgaming.universaltweaks.mods.bloodmagic.UTBloodMagicEvents;
 import mod.acgaming.universaltweaks.mods.botania.UTBotaniaFancySkybox;
 import mod.acgaming.universaltweaks.mods.collective.UTCollectiveEvents;
 import mod.acgaming.universaltweaks.mods.cqrepoured.UTGoldenFeatherEvent;
+import mod.acgaming.universaltweaks.mods.divinerpg.armorset.ArmorPowerHandler;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Burning;
 import mod.acgaming.universaltweaks.mods.elenaidodge2.UTED2Sprinting;
 import mod.acgaming.universaltweaks.mods.mekanism.dupes.UTMekanismFixes;
@@ -233,6 +234,7 @@ public class UniversalTweaks
             if (Loader.isModLoaded("bloodmagic") && UTConfigMods.BLOOD_MAGIC.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTBloodMagicEvents());
             if (Loader.isModLoaded("collective") && UTConfigMods.COLLECTIVE.utMemoryLeakFixToggle) MinecraftForge.EVENT_BUS.register(new UTCollectiveEvents());
             if (Loader.isModLoaded("cqrepoured") && UTConfigMods.CHOCOLATE_QUEST.utCQRGoldenFeatherToggle) MinecraftForge.EVENT_BUS.register(new UTGoldenFeatherEvent());
+            if (Loader.isModLoaded("divinerpg") && UTConfigMods.DIVINE_RPG.utFixArmorSetCleanup) MinecraftForge.EVENT_BUS.register(new ArmorPowerHandler());
             if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2ExtinguishingDodgeChance > 0) MinecraftForge.EVENT_BUS.register(new UTED2Burning());
             if (Loader.isModLoaded("elenaidodge2") && UTConfigMods.ELENAI_DODGE_2.utED2SprintingFeatherConsumption > 0) MinecraftForge.EVENT_BUS.register(new UTED2Sprinting());
             if (Loader.isModLoaded("mekanism") && UTConfigMods.MEKANISM.utDuplicationFixesToggle) UTMekanismFixes.fixBinRecipes();

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/ArmorPowerHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/ArmorPowerHandler.java
@@ -1,0 +1,70 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset;
+
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import divinerpg.api.DivineAPI;
+import divinerpg.api.armor.cap.IArmorPowers;
+import divinerpg.events.ArmorWearingEvents;
+import mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin.UTArmorPowersAccessor;
+
+/**
+ * Event handler to properly manage armor powers, because DivineRPG completely disregards thread safety
+ * with their implementation.
+ */
+// Courtesy of jchung01
+public class ArmorPowerHandler
+{
+    @SubscribeEvent
+    public void copyArmorPowers(PlayerEvent.Clone event)
+    {
+        IArmorPowers oldCap = DivineAPI.getArmorPowers(event.getOriginal());
+        IArmorPowers cap = DivineAPI.getArmorPowers(event.getEntityPlayer());
+        if (oldCap == null || cap == null) return;
+
+        Set<ResourceLocation> currentPowers = oldCap.wearing();
+        ((UTArmorPowersAccessor) oldCap).ut$unsubscribe();
+
+        for (ResourceLocation powerKey : currentPowers)
+        {
+            cap.putOn(powerKey);
+        }
+    }
+
+    @SubscribeEvent
+    public void syncArmorPowers(net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent event)
+    {
+        ArmorWearingEvents.recheckAllWearing(event.player, true);
+    }
+
+    @SubscribeEvent
+    public void cleanupArmorPowersServer(net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent event)
+    {
+        IArmorPowers cap = DivineAPI.getArmorPowers(event.player);
+        if (cap == null) return;
+
+        ((UTArmorPowersAccessor) cap).ut$unsubscribe();
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void cleanupArmorPowersClient(FMLNetworkEvent.ClientDisconnectionFromServerEvent event)
+    {
+        EntityPlayerSP player = Minecraft.getMinecraft().player;
+        FMLCommonHandler.instance().getWorldThread(event.getHandler()).addScheduledTask(() -> {
+            IArmorPowers cap = DivineAPI.getArmorPowers(player);
+            if (cap == null) return;
+
+            ((UTArmorPowersAccessor) cap).ut$unsubscribe();
+        });
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersAccessor.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersAccessor.java
@@ -1,0 +1,12 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
+
+import divinerpg.capabilities.armor.ArmorPowers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(value = ArmorPowers.class, remap = false)
+public interface UTArmorPowersAccessor
+{
+    @Invoker("unsubscribe")
+    void ut$unsubscribe();
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorPowersMixin.java
@@ -1,41 +1,33 @@
 package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
 
-import java.lang.ref.WeakReference;
-import java.util.Objects;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
 
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
-
-import com.llamalad7.mixinextras.expression.Definition;
-import com.llamalad7.mixinextras.expression.Expression;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import divinerpg.capabilities.armor.ArmorPowers;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
+// Courtesy of jchung01
 @Mixin(value = ArmorPowers.class, remap = false)
-public class UTArmorPowersMixin
+public abstract class UTArmorPowersMixin
 {
-    @Shadow
-    @Final
-    private WeakReference<EntityLivingBase> player;
+    /**
+     * Don't register the event handler, as it has all sorts of issues.
+     * @see mod.acgaming.universaltweaks.mods.divinerpg.armorset.ArmorPowerHandler#copyArmorPowers(PlayerEvent.Clone) for the fixed handler
+      */
+    @WrapWithCondition(method = "<init>(Lnet/minecraft/entity/EntityLivingBase;)V", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/eventhandler/EventBus;register(Ljava/lang/Object;)V"))
+    private boolean ut$cancelRegister(EventBus instance, Object eventType)
+    {
+        return false;
+    }
 
     /**
-     * @reason The UUID check is inverted; unsubscribe() must only be called when the UUID is the same (the same player),
-     * but EntityPlayer object is different (the entity of the player was recreated), not on ANY entity join
-     * <br>
-     * Also only cleanup on the matching side, fixing possible ConcurrentModificationException and corrupting the EventBus.
-     * @see <a href="https://github.com/DivineRPG/DivineRPG/commit/a1429c46a2bb5edad4979b5854b57c64b7a5e7b6?diff=split#diff-ada324cf157705224cfc240578dfdf6ff491085063010e5440de9f00c5a881baL53">the originally correct condition</a>
+     * @see mod.acgaming.universaltweaks.mods.divinerpg.armorset.ArmorPowerHandler#copyArmorPowers(PlayerEvent.Clone) for the fixed handler
      */
-    @Definition(id = "equals", method = "Ljava/util/Objects;equals(Ljava/lang/Object;Ljava/lang/Object;)Z")
-    @Expression("equals(?, ?) == false")
-    @ModifyExpressionValue(method = "onCleanUp", at = @At("MIXINEXTRAS:EXPRESSION"))
-    private boolean utOnlyCleanupRecreatedPlayer(boolean notEqual, EntityJoinWorldEvent event)
+    @WrapWithCondition(method = "unsubscribe", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/eventhandler/EventBus;unregister(Ljava/lang/Object;)V"))
+    private boolean ut$cancelUnregister(EventBus instance, Object o)
     {
-        EntityLivingBase oldPlayer = Objects.requireNonNull(player.get());
-        // !(!equals) -> equals
-        return !notEqual && event.getWorld().isRemote == oldPlayer.world.isRemote;
+        return false;
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorStatusChangedMessageMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTArmorStatusChangedMessageMixin.java
@@ -1,0 +1,21 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
+
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import divinerpg.networking.message.ArmorStatusChangedMessage;
+import org.spongepowered.asm.mixin.Mixin;
+
+// Courtesy of jchung01
+@Mixin(value = ArmorStatusChangedMessage.Handler.class, remap = false)
+public class UTArmorStatusChangedMessageMixin
+{
+    @WrapMethod(method = "onMessage(Ldivinerpg/networking/message/ArmorStatusChangedMessage;Lnet/minecraftforge/fml/common/network/simpleimpl/MessageContext;)Lnet/minecraftforge/fml/common/network/simpleimpl/IMessage;")
+    private IMessage ut$scheduleChange(ArmorStatusChangedMessage message, MessageContext ctx, Operation<IMessage> original){
+        FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> original.call(message, ctx));
+        return null;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTIPlayerForgeEventMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTIPlayerForgeEventMixin.java
@@ -1,0 +1,34 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
+
+import java.util.Objects;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import divinerpg.api.armor.IPlayerSubscription;
+import divinerpg.api.armor.binded.IPlayerForgeEvent;
+import divinerpg.api.armor.registry.IForgeEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of jchung01
+@Mixin(value = IPlayerForgeEvent.class, remap = false)
+public interface UTIPlayerForgeEventMixin<T extends Event> extends IForgeEvent<T>, IPlayerSubscription
+{
+    /**
+     * Use {@link java.util.Objects#equals(Object, Object)} to handle based on entity id.
+     * The armor set tweak deduplicates event handler registration, so player equality must be based on their id to handle both sides.
+     */
+    @SuppressWarnings("PublicStaticMixinMember")
+    @Definition(id = "player", local = @Local(type = EntityLivingBase.class, name = "player"))
+    @Expression("? == player")
+    @WrapOperation(method = "canHandle", at = @At("MIXINEXTRAS:EXPRESSION"))
+    static boolean ut$handlePlayerById(Object left, Object right, Operation<Boolean> original) {
+        return Objects.equals(left, right);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTPlayerForgeEventMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/armorset/mixin/UTPlayerForgeEventMixin.java
@@ -1,0 +1,46 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.armorset.mixin;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+
+import divinerpg.capabilities.armor.PlayerForgeEvent;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Courtesy of jchung01
+@Mixin(value = PlayerForgeEvent.class, remap = false)
+public abstract class UTPlayerForgeEventMixin
+{
+    @Shadow
+    @Final
+    private WeakReference<EntityLivingBase> player;
+
+    @Inject(method = "subscribe", at = @At("HEAD"), cancellable = true)
+    private void ut$cancelClientRegister(CallbackInfo ci)
+    {
+        if (player == null)
+        {
+            ci.cancel();
+            return;
+        }
+        EntityLivingBase playerObj = player.get();
+        if (playerObj == null)
+        {
+            ci.cancel();
+            return;
+        }
+        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
+        // Prevent registering duplicate handler for integrated servers on client-side
+        if (playerObj.world.isRemote && server != null && !server.isDedicatedServer())
+        {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.divinerpg.armorset.json
+++ b/src/main/resources/mixins/mods/mixins.divinerpg.armorset.json
@@ -6,5 +6,5 @@
     "minVersion": "0.5.0-beta.5"
   },
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTArmorPowersMixin"]
+  "mixins": ["UTArmorPowersAccessor", "UTArmorPowersMixin", "UTArmorStatusChangedMessageMixin", "UTIPlayerForgeEventMixin", "UTPlayerForgeEventMixin"]
 }


### PR DESCRIPTION
After some more testing, it seems that #747 did not fix the thread safety issues with DivineRPG's armor power handler; in fact, the tweak now seems to cause the mod to [leak](https://mclo.gs/4XiRpPt#L20504) event handlers. 
This PR should (hopefully) fix the armor power handling with a better implementation. The event handler in `ArmorPowers` is no longer dynamically registered on player cap init, and `ArmorDescription` event handlers being dynamically registered on equipment change (very hacky) now are only registered once per player, on a consistent logical side. Cleanup and syncing is done by `ArmorPowerHandler`.