### PR TITLE
Impulse Hopper NBT

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ All changes are toggleable via config files.
 * **Ender IO**
     * **Clear Outdated Redstone Conduit:** When changing colors in the Redstone Conduit GUI, remove the signal from the old color
     * **Fix Chorus Farming StackOverflow:** Fixes the Farming Station Chorus Walker being able to loop though and check the same positions endlessly, causing a StackOverflow
+    * **Fix Impulse Hopper NBT Inputs:** Makes inserting into the Impulse Hopper filter by NBT of the relevant ghost item, which is required for actually moving the item
     * **Fix Soul Binder JEI Appearance:** Fixes the Soul Binder having empty ingredients or displaying filled soul vials in the output slot incorrectly
     * **Replace Obelisk Renderer:** Fixes client-side memory leak by replacing obelisk renderer with a simpler one
     * **Save Filter Cycle Buttons Properly:** Fixes an issue where Cycle Buttons for Damage do not report being clicked when in the Picker Overlay, preventing changing Damage values until clicked again

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -864,6 +864,11 @@ public class UTConfigMods
         public boolean utChorusStackOverflow = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fix Impulse Hopper NBT Inputs")
+        @Config.Comment("Makes inserting into the Impulse Hopper filter by NBT of the relevant ghost item, which is required for actually moving the item")
+        public boolean utImpulseHopperInsert = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Soul Binder JEI Appearance")
         @Config.Comment("Fix the Soul Binder having empty ingredients or displaying filled soul vials in the output slot incorrectly")
         public boolean utFixSoulBinderJEI = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -118,6 +118,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.elenaidodge2.json", c -> c.isModPresent("elenaidodge2"));
                 put("mixins/mods/mixins.enderio.chorus.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utChorusStackOverflow);
                 put("mixins/mods/mixins.enderio.cyclebutton.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utSaveFilterCycleButtonProperly);
+                put("mixins/mods/mixins.enderio.impulsehopper.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utImpulseHopperInsert);
                 put("mixins/mods/mixins.enderio.redstoneconduit.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utClearRedstoneConduitChange);
                 put("mixins/mods/mixins.enderio.soulbinderjei.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utFixSoulBinderJEI);
                 put("mixins/mods/mixins.enderstorage.json", c -> c.isModPresent("enderstorage") && UTConfigMods.ENDER_STORAGE.utFrequencyTrackFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderio/impulsehopper/mixin/UTPredicateItemStackMatchMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderio/impulsehopper/mixin/UTPredicateItemStackMatchMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.enderio.impulsehopper.mixin;
+
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(targets = "crazypants.enderio.machines.machine.ihopper.TileImpulseHopper$PredicateItemStackMatch", remap = false)
+public abstract class UTPredicateItemStackMatchMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason The Impulse Hopper filters its inputs by each slot's "ghost item",
+     * and does so via checking {@link ItemStack#isItemEqual}.
+     * However, actually moving the items also checks {@link ItemStack#areItemStackTagsEqual},
+     * which means that items with different nbt value can be inserted, but will never be moved.
+     */
+    @WrapOperation(method = "doApply", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isItemEqual(Lnet/minecraft/item/ItemStack;)Z"))
+    private boolean utCheckNBTTag(ItemStack instance, ItemStack other, Operation<Boolean> original)
+    {
+        return original.call(instance, other) && ItemStack.areItemStackTagsEqual(instance, other);
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.enderio.impulsehopper.json
+++ b/src/main/resources/mixins/mods/mixins.enderio.impulsehopper.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderio.impulsehopper.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTPredicateItemStackMatchMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- make impulse hopper filter nbt on insertion instead of only checking when moving items (default: `true`)
