### PR TITLE
DivineRPG Nightmare Bed

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ All changes are toggleable via config files.
     * **Fix Aquamarine Stack Size:** Aquamarine has durability, yet doesn't have a max stack size of 1
     * **Fix Armor Set Effect Cleanup:** Fixes issues with armor set effects being cleaned up under the wrong conditions that caused crashes
     * **Fix Consuming Incorrect Hand:** Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used
+    * **Fix Nightmare Bed Drop:** Fix the Nightmare Bed not dropping when being broken
 * **Dank Storage**
     * **Max Int stack voiding:** Fixes Max Int (2.1B) stacks being voided when right clicking on them in a Dank
 * **Effortless Building**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -758,6 +758,11 @@ public class UTConfigMods
         @Config.Name("Fix Consuming Incorrect Hand")
         @Config.Comment("Fix various DivineRPG items consuming the item in the main hand regardless of the hand actually used")
         public boolean utFixHandConsumption = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Fix Nightmare Bed Drop")
+        @Config.Comment("Fix the Nightmare Bed not dropping when being broken")
+        public boolean utFixNightmareBed = true;
     }
 
     public static class EffortlessBuildingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -110,6 +110,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.divinerpg.aquamarine.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
                 put("mixins/mods/mixins.divinerpg.armorset.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixArmorSetCleanup);
                 put("mixins/mods/mixins.divinerpg.hand.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixHandConsumption);
+                put("mixins/mods/mixins.divinerpg.nightmarebed.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixNightmareBed);
                 put("mixins/mods/mixins.divinerpg.waterspawning.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utChangeWaterMobCreatureType);
                 put("mixins/mods/mixins.effortlessbuilding.json", c -> c.isModPresent("effortlessbuilding") && UTConfigMods.EFFORTLESS_BUILDING.utEFTransmutationFixToggle);
                 put("mixins/mods/mixins.elementarystaffs.json", c -> c.isModPresent("element"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/nightmarebed/mixin/UTBlockNightmareBedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/nightmarebed/mixin/UTBlockNightmareBedMixin.java
@@ -1,0 +1,43 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.nightmarebed.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import divinerpg.objects.blocks.vethea.BlockNightmareBed;
+import divinerpg.registry.ItemRegistry;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlockNightmareBed.class, remap = false)
+public abstract class UTBlockNightmareBedMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason The Nightmare Bed is registered without a corresponding {@link net.minecraft.item.ItemBlock ItemBlock},
+     * so running {@link Item#getItemFromBlock(Block)} always returns {@link net.minecraft.init.Items#AIR AIR}.
+     */
+    @WrapOperation(method = "getItemDropped", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;getItemFromBlock(Lnet/minecraft/block/Block;)Lnet/minecraft/item/Item;"))
+    public Item targetValidItem(Block blockIn, Operation<Item> original)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixNightmareBed) return original.call(blockIn);
+        return ItemRegistry.nightmareBed;
+    }
+
+    /**
+     * @author WaitingIdly
+     * @reason The Nightmare Bed is registered without a corresponding {@link net.minecraft.item.ItemBlock ItemBlock},
+     * so creating a new {@link ItemStack} instance from {@link divinerpg.registry.BlockRegistry#nightmareBed BlockRegistry.nightmareBed} always
+     * creates an empty {@link ItemStack}.
+     */
+    @WrapOperation(method = "dropBlockAsItemWithChance", at = @At(value = "NEW", target = "(Lnet/minecraft/block/Block;I)Lnet/minecraft/item/ItemStack;"))
+    public ItemStack dropValidItemStack(Block blockIn, int amount, Operation<ItemStack> original)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixNightmareBed) return original.call(blockIn, amount);
+        return new ItemStack(ItemRegistry.nightmareBed);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/nightmarebed/mixin/UTTileEntityNightmareBedMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/divinerpg/nightmarebed/mixin/UTTileEntityNightmareBedMixin.java
@@ -1,0 +1,29 @@
+package mod.acgaming.universaltweaks.mods.divinerpg.nightmarebed.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import divinerpg.objects.blocks.tile.entity.TileEntityNightmareBed;
+import divinerpg.registry.ItemRegistry;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = TileEntityNightmareBed.class, remap = false)
+public abstract class UTTileEntityNightmareBedMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason The Nightmare Bed is registered without a corresponding {@link net.minecraft.item.ItemBlock ItemBlock},
+     * so running {@link Item#getItemFromBlock(Block)} always returns {@link net.minecraft.init.Items#AIR AIR}.
+     */
+    @WrapOperation(method = "getItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;getItemFromBlock(Lnet/minecraft/block/Block;)Lnet/minecraft/item/Item;"))
+    public Item targetValidItem(Block blockIn, Operation<Item> original)
+    {
+        if (!UTConfigMods.DIVINE_RPG.utFixNightmareBed) return original.call(blockIn);
+        return ItemRegistry.nightmareBed;
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.divinerpg.nightmarebed.json
+++ b/src/main/resources/mixins/mods/mixins.divinerpg.nightmarebed.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.divinerpg.nightmarebed.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBlockNightmareBedMixin", "UTTileEntityNightmareBedMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- when the nightmare bed is broken, nothing is dropped. this is because the nightmare bed block doesnt have a corresponding item - the item is separate. make the nightmare bed drop the correct item (default: `true`)