### PR TITLE
allow placing unsupported fence gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ All changes are toggleable via config files.
 * **Fast Prefix Checking:** Optimizes Forge's ID prefix checking and removes prefix warnings impacting load time
 * **Fast World Loading:** Skips garbage collection to speed up world loading
 * **Faster Advancement Trigger Checking:** Optimizes triggering advancements when obtaining items
+* **Fence Gate Placing:** Allows placing Fence Gates without a supporting block
 * **Fence/Wall Jump:** Allows the player to jump over fences and walls
 * **Finite Water:** Prevents creation of infinite water sources outside of ocean and river biomes
 * **First Person Burning Overlay:** Sets the offset for the fire overlay in first person when the player is burning

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -240,6 +240,10 @@ public class UTConfigTweaks
         @Config.Comment("Allows placing Pumpkins and Jack'O'Lanterns without a supporting block")
         public boolean utUnsupportedPumpkinPlacing = false;
 
+        @Config.Name("Unsupported Fence Gate Placing")
+        @Config.Comment("Allows placing Fence Gates without a supporting block")
+        public boolean utUnsupportedFenceGatePlacing = false;
+
         @Config.RequiresMcRestart
         @Config.Name("Projectiles Bounce Off Slime Blocks")
         @Config.Comment("Lets projectiles like arrows bounce off slime blocks")

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -103,6 +103,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.blocks.endportal.json", c -> UTConfigTweaks.BLOCKS.utRenderEndPortalBottom);
                 put("mixins/tweaks/mixins.blocks.explosion.json", c -> UTConfigTweaks.BLOCKS.utExplosionDropChance != 1.0D);
                 put("mixins/tweaks/mixins.blocks.falling.json", c -> UTConfigTweaks.BLOCKS.utFallingBlockLifespan != 600);
+                put("mixins/tweaks/mixins.blocks.fencegateplacing.json", c -> UTConfigTweaks.BLOCKS.utUnsupportedFenceGatePlacing);
                 put("mixins/tweaks/mixins.blocks.golemstructure.json", c -> UTConfigTweaks.ENTITIES.utGolemPlacement);
                 put("mixins/tweaks/mixins.blocks.growthsize.json", c -> UTConfigTweaks.BLOCKS.utCactusSize != 3 && UTConfigTweaks.BLOCKS.utSugarCaneSize != 3 && UTConfigTweaks.BLOCKS.utVineSize != 0);
                 put("mixins/tweaks/mixins.blocks.leafdecay.json", c -> UTConfigTweaks.BLOCKS.utLeafDecayToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/fencegateplacing/mixin/UTBlockFenceGateMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/fencegateplacing/mixin/UTBlockFenceGateMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.fencegateplacing.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFenceGate;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.block.material.Material;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = BlockFenceGate.class)
+public abstract class UTBlockFenceGateMixin extends Block
+{
+    public UTBlockFenceGateMixin(Material blockMaterialIn, MapColor blockMapColorIn)
+    {
+        super(blockMaterialIn, blockMapColorIn);
+    }
+
+    @Inject(method = "canPlaceBlockAt", at = @At(value = "HEAD"), cancellable = true)
+    public void utUnsupportedPlacingOverride(World worldIn, BlockPos pos, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!UTConfigTweaks.BLOCKS.utUnsupportedFenceGatePlacing) return;
+        cir.setReturnValue(super.canPlaceBlockAt(worldIn, pos));
+    }
+}

--- a/src/main/resources/mixins/tweaks/mixins.blocks.fencegateplacing.json
+++ b/src/main/resources/mixins/tweaks/mixins.blocks.fencegateplacing.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.blocks.fencegateplacing.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBlockFenceGateMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- add a config for allowing fence gates to be placed without a supporting block (default: `false`)

this feature is part of in vanilla for 1.13+, and was added in [17w47a](https://minecraft.wiki/w/Java_Edition_17w47a#:~:text=Fence%20gates%20and%20pumpkins)
related to #425, which did pumpkins