### PR TITLE
Fix Void Island Control Island creation in other dimensions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -176,6 +176,7 @@ final def mod_dependencies = [
     'curse.maven:wanionlib-253043:4623135'                            : [debug_avaritiaaddons],
     'curse.maven:xnet-260912:2745852'                                 : [debug_xnet],
     'curse.maven:tomb-many-graves-2-262823:2619249'                   : [debug_tomb_many_graves],
+    'curse.maven:void-island-control-257655:2666967'                  : [debug_void_island_control],
     'curse.maven:woot-244049:2712670'                                 : [debug_woot],
     'curse.maven:wopper-269377:2456802'                               : [debug_wopper],
     'curse.maven:zerocore-247921:3194743'                             : [debug_extreme_reactors],

--- a/gradle.properties
+++ b/gradle.properties
@@ -99,6 +99,7 @@ debug_thermal_expansion = false
 debug_tinkers_construct = false
 debug_tiny_progressions = false
 debug_tomb_many_graves = false
+debug_void_island_control = false
 debug_woot = false
 debug_wopper = false
 debug_xnet = false

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,6 +1,7 @@
 package mod.acgaming.universaltweaks;
 
 import mod.acgaming.universaltweaks.mods.simpledifficulty.UTCanteenCauldron;
+import mod.acgaming.universaltweaks.mods.voidislandcontrol.UTVoidIslandControlEvents;
 import mod.acgaming.universaltweaks.tweaks.entities.attributes.UTAttributeKeeper;
 
 import mod.acgaming.universaltweaks.tweaks.entities.damage.arrow.layers.UTArrowLayers;
@@ -260,6 +261,7 @@ public class UniversalTweaks
             if (Loader.isModLoaded("tardis") && UTConfigMods.TARDIS.utMemoryLeakFixToggle) MinecraftForge.EVENT_BUS.unregister(ClientProxy.class);
             if (UTMixinLoader.regularTConLoaded() && UTConfigMods.TINKERS_CONSTRUCT.utDuplicationFixesToggle) MinecraftForge.EVENT_BUS.register(new UTTConstructEvents());
             if (Loader.isModLoaded("woot") && UTConfigMods.WOOT.utCleanupSimulatedKillsToggle) UTWootTicketManager.init();
+            if (Loader.isModLoaded("voidislandcontrol") && UTConfigMods.VOID_ISLAND_CONTROL.utFixSpawnIslandCreation)  MinecraftForge.EVENT_BUS.register(new UTVoidIslandControlEvents());
         }
 
         if (UTConfigGeneral.MASTER_SWITCHES.utMasterSwitchTweaks)

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -363,6 +363,10 @@ public class UTConfigMods
     @Config.Name("TombManyGraves2")
     public static final TombManyGravesCategory TOMBMANYGRAVES = new TombManyGravesCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.voidislandcontrol")
+    @Config.Name("Void Island Control")
+    public static final VoidIslandControlCategory VOID_ISLAND_CONTROL = new VoidIslandControlCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.woot")
     @Config.Name("Woot")
     public static final WootCategory WOOT = new WootCategory();
@@ -1695,6 +1699,13 @@ public class UTConfigMods
         @Config.Name("Proper World Size Check")
         @Config.Comment("Fix TombManyGraves not spawning the grave due to incorrectly checking world height")
         public boolean utProperWorldSizeCheck = true;
+    }
+
+    public static class VoidIslandControlCategory
+    {
+        @Config.Name("Fix spawn island creation")
+        @Config.Comment("Fixes islands not being able to be created if the dimension is not the overworld when visiting the dimension for the first time due to the spawn island not being created.")
+        public boolean utFixSpawnIslandCreation = true;
     }
 
     public static class WootCategory

--- a/src/main/java/mod/acgaming/universaltweaks/mods/voidislandcontrol/UTVoidIslandControlEvents.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/voidislandcontrol/UTVoidIslandControlEvents.java
@@ -5,23 +5,25 @@ import com.bartz24.voidislandcontrol.api.IslandManager;
 import com.bartz24.voidislandcontrol.api.IslandPos;
 import com.bartz24.voidislandcontrol.config.ConfigOptions;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 
 public class UTVoidIslandControlEvents
 {
     @SubscribeEvent
-    public void onPlayerChangedDimension(EntityJoinWorldEvent event)
+    public void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event)
     {
-        if (event.getWorld().isRemote && !(event.getEntity() instanceof EntityPlayer)) return;
-
-        if (event.getWorld().provider.getDimension() == ConfigOptions.worldGenSettings.baseDimension && IslandManager.CurrentIslandsList.isEmpty())
+        if (event.toDim == ConfigOptions.worldGenSettings.baseDimension && IslandManager.CurrentIslandsList.isEmpty())
         {
+            World world = DimensionManager.getWorld(event.toDim);
+            BlockPos pos = new BlockPos(0, ConfigOptions.islandSettings.islandYLevel, 0);
             IslandManager.CurrentIslandsList.add(new IslandPos(0, 0));
-            event.getWorld().setSpawnPoint(new BlockPos(0, 91, 0));
-            EventHandler.createSpawn((EntityPlayer) event.getEntity(), event.getWorld(), new BlockPos(0, 88, 0));
+            world.setSpawnPoint(new BlockPos(0, ConfigOptions.islandSettings.islandYLevel, 0));
+            EventHandler.createSpawn(event.player, world, pos);
+            IslandManager.tpPlayerToPos(event.player, pos, IslandManager.CurrentIslandsList.get(0));
         }
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/mods/voidislandcontrol/UTVoidIslandControlEvents.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/voidislandcontrol/UTVoidIslandControlEvents.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.mods.voidislandcontrol;
+
+import com.bartz24.voidislandcontrol.EventHandler;
+import com.bartz24.voidislandcontrol.api.IslandManager;
+import com.bartz24.voidislandcontrol.api.IslandPos;
+import com.bartz24.voidislandcontrol.config.ConfigOptions;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class UTVoidIslandControlEvents
+{
+    @SubscribeEvent
+    public void onPlayerChangedDimension(EntityJoinWorldEvent event)
+    {
+        if (event.getWorld().isRemote && !(event.getEntity() instanceof EntityPlayer)) return;
+
+        if (event.getWorld().provider.getDimension() == ConfigOptions.worldGenSettings.baseDimension && IslandManager.CurrentIslandsList.isEmpty())
+        {
+            IslandManager.CurrentIslandsList.add(new IslandPos(0, 0));
+            event.getWorld().setSpawnPoint(new BlockPos(0, 91, 0));
+            EventHandler.createSpawn((EntityPlayer) event.getEntity(), event.getWorld(), new BlockPos(0, 88, 0));
+        }
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -141,6 +141,7 @@ cfg.universaltweaks.modintegration.tinyprogressions=Tiny Progressions
 cfg.universaltweaks.modintegration.tombmanygraves=TombManyGraves2
 cfg.universaltweaks.modintegration.tr=Tech Reborn
 cfg.universaltweaks.modintegration.woot=Woot
+cfg.universaltweaks.modintegration.voidislandcontrol=Void Island Control
 cfg.universaltweaks.modintegration.xnet=XNet
 cfg.universaltweaks.modintegration=Mod Integration
 


### PR DESCRIPTION
Fixes Void Island Control not being able to create a island in other dimensions if visiting/loading them for the first time due to the spawn island not being created.

Steps to reproduce:
1) Install JED and create a dimension config like this one https://pastebin.com/ckrWGmdc
2) Edit VIC config and  change the base dimension accordingly
3) Create a new world and teleport to that dimension (Via /tpx from CoFH Core or  w/e)
4)  Execute /island spawn (or /island create)  and see the error message