### PR TITLE
Add localization for Tweaked Excavation

### DIFF
--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -45,6 +45,9 @@ entity.Villager.alchemist=Alchemist
 # Cyclic
 gui.universaltweaks.cyclic.ender_book.page=Page %s / %s
 
+# Tweaked Excavation
+tweakedexcavation.jei.mineral.average.Infinite=Average Mineral yield: Infinite
+
 # TIME COMMAND
 cmd.universaltweaks.time.set=Set time to %s in dimension %s
 


### PR DESCRIPTION
(also PR'ed for faulting mod, but might be dead. so figured such a small fix would go live pretty fast in UT)
https://github.com/Srdjan-V/TweakedExcavation/pull/6

# Added CORRECT localization for Tweaked Excavation - Infinite Yield.

all references to this langentry uses uppercase "I" (i) .. but mods own langfile
```tweakedexcavation.jei.mineral.average.infinite=Average Mineral yield: Infinite```

all references are here:
```
ExcavatorWrapper.java
TopCompat.java
WailaCompat.java
```

Result: (hovering output-ore in jei)
<img width="459" height="62" alt="image" src="https://github.com/user-attachments/assets/c057d2da-ed11-49c2-8565-83fed6a9ee98" />



fixed example: 
<img width="336" height="216" alt="image" src="https://github.com/user-attachments/assets/0925999d-94dd-49ce-9e11-862d2058b513" />