### PR TITLE
Add Villager Harvesting Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Use Separate Dismount Key:** Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently
 * **Use Separate Narrator Key:** Allows using a custom Narrator key, instead of being stuck with CTRL+B
 * **Village Distance:** Sets the village generation distance in chunks
+* **Villager Harvesting:** Fixes Villagers being unable to replant modded crops and allows villagers to breed using modded foods.
 * **Villager Profession Biome Restriction:** Controls villager professions in specified biomes
 * **Void Fog:** Re-implements pre-1.8 void fog and void particles
 * **Water Fall Damage:** Re-implements an improved version of pre-1.4 fall damage in water

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,5 +1,7 @@
 package mod.acgaming.universaltweaks;
 
+import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.common.MinecraftForge;
@@ -388,6 +390,7 @@ public class UniversalTweaks
             if (UTConfigTweaks.BLOCKS.END_CRYSTAL_PLACEMENT.utEndCrystalPlacementToggle) UTEndCrystalPlacement.initBlockList();
             if (UTConfigTweaks.BLOCKS.PISTON.utPistonBlockBlacklistToggle) UTPistonBlockBlacklist.initBlockBlacklist();
             if (UTConfigTweaks.ENTITIES.utVillagerProfessionBiomeRestriction.length > 0) UTVillagerProfessionRestriction.initBiomeRestrictions();
+            if (UTConfigTweaks.ENTITIES.VILLAGER_HARVEST.utVillagerHarvestToggle) UTVillagerHarvestUtils.initLists();
             if (UTConfigTweaks.MISC.ADVANCEMENT_SCREENSHOT.utAdvancementScreenshotToggle) UTAdvancementScreenshot.initAdvancementList();
             if (UTConfigTweaks.MISC.SWING_THROUGH_GRASS.utSwingThroughGrassToggle) UTSwingThroughGrassLists.initLists();
             if (UTConfigTweaks.MISC.INCURABLE_POTIONS.utIncurablePotionsToggle) UTIncurablePotions.initPotionList();

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -3,6 +3,8 @@ package mod.acgaming.universaltweaks.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
+
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
@@ -573,6 +575,10 @@ public class UTConfigTweaks
         @Config.LangKey("cfg.universaltweaks.tweaks.entities.waterfalldamage")
         @Config.Name("Water Fall Damage")
         public final WaterFallDamageCategory WATER_FALL_DAMAGE = new WaterFallDamageCategory();
+
+        @Config.LangKey("cfg.universaltweaks.tweaks.entities.villagerharvest")
+        @Config.Name("Villager Harvesting")
+        public final VillagerHarvestCategory VILLAGER_HARVEST = new VillagerHarvestCategory();
 
         @Config.LangKey("cfg.universaltweaks.tweaks.entities.voidteleport")
         @Config.Name("Void Teleport")
@@ -1247,6 +1253,39 @@ public class UTConfigTweaks
             @Config.Name("[2] Damage Reduction")
             @Config.Comment("How much fall damage gets reduced by water per tick")
             public double utFallDamageValue = 2.0D;
+        }
+
+        public static class VillagerHarvestCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[01] Villager Harvest Tweak Toggle")
+            @Config.Comment
+                ({
+                    "Enables Villager Harvest tweak, allowing villagers to harvest and replant modded crops.",
+                    "This tweak also allows villagers to breed with modded crops."
+                })
+            public boolean utVillagerHarvestToggle = true;
+
+            @Config.Name("[02] Food Whitelist")
+            @Config.Comment
+                ({
+                    "A list of foods that villagers can pick up and use to breed. Minecraft uses 'count' values",
+                    "of 12 for Potatoes and Carrots, and a value of 3 for bread. Adding different values to this",
+                    "list for those foods will override vanilla behavior.",
+                    "  Syntax: modid:itemid=count",
+                    "  Example -> minecraft:steak=2"
+                })
+            public String[] utFoodWhitelist = new String[] {};
+
+            @Config.Name("[03] Harvest Blacklist")
+            @Config.Comment
+                ({
+                    "A list of crops that villagers will not harvest. This is used to prevent villagers from",
+                    "breaking crops that have custom harvest logic.",
+                    "  Syntax: modid:blockid",
+                    "  Example -> minecraft:wheat"
+                })
+            public String[] utHarvestBlacklist = new String[] {};
         }
 
         public static class VoidTeleportCategory
@@ -3108,6 +3147,7 @@ public class UTConfigTweaks
                 if (BLOCKS.END_CRYSTAL_PLACEMENT.utEndCrystalPlacementToggle) UTEndCrystalPlacement.initBlockList();
                 if (BLOCKS.PISTON.utPistonBlockBlacklistToggle) UTPistonBlockBlacklist.initBlockBlacklist();
                 if (ENTITIES.utVillagerProfessionBiomeRestriction.length > 0) UTVillagerProfessionRestriction.initBiomeRestrictions();
+                if (ENTITIES.VILLAGER_HARVEST.utVillagerHarvestToggle) UTVillagerHarvestUtils.initLists();
                 if (MISC.ADVANCEMENT_SCREENSHOT.utAdvancementScreenshotToggle) UTAdvancementScreenshot.initAdvancementList();
                 if (MISC.ARMOR_CURVE.utArmorCurveToggle) UTArmorCurve.initExpressions();
                 if (MISC.INCURABLE_POTIONS.utIncurablePotionsToggle) UTIncurablePotions.initPotionList();

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -148,6 +148,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.entities.speed.player.json", c -> UTConfigTweaks.ENTITIES.PLAYER_SPEED.utPlayerSpeedToggle);
                 put("mixins/tweaks/mixins.entities.taming.horse.json", c -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utTamingUndeadHorsesToggle);
                 put("mixins/tweaks/mixins.entities.trading.json", c -> UTConfigTweaks.ENTITIES.utVillagerTradeLevelingToggle || UTConfigTweaks.ENTITIES.utVillagerTradeRestockToggle);
+                put("mixins/tweaks/mixins.entities.villagerharvest.json", c -> UTConfigTweaks.ENTITIES.VILLAGER_HARVEST.utVillagerHarvestToggle);
                 put("mixins/tweaks/mixins.entities.unsafesleeping.json", c -> UTConfigTweaks.ENTITIES.UNSAFE_SLEEPING.utUnsafeSleepingToggle);
                 put("mixins/tweaks/mixins.entities.villagerprofessions.json", c -> UTConfigTweaks.ENTITIES.utVillagerProfessionBiomeRestriction.length > 0);
                 put("mixins/tweaks/mixins.entities.voidteleport.json", c -> UTConfigTweaks.ENTITIES.VOID_TELEPORT.utVoidTeleportToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/attributes/UTAttributeKeeper.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/attributes/UTAttributeKeeper.java
@@ -21,7 +21,7 @@ public class UTAttributeKeeper
 {
     @SubscribeEvent
     public static void utAttributeKeeper(PlayerEvent.Clone event) {
-        if(event.isWasDeath() && !event.isCanceled())
+        if(!event.isCanceled())
         {
             EntityPlayer original = event.getOriginal();
             AbstractAttributeMap originalAttributes = original.getAttributeMap();

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/UTVillagerHarvestUtils.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/UTVillagerHarvestUtils.java
@@ -1,0 +1,119 @@
+package mod.acgaming.universaltweaks.tweaks.entities.villagerharvest;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemSeedFood;
+import net.minecraft.item.ItemSeeds;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A helper class to assist with configuration parsing for fast villager harvest checks.
+ */
+public class UTVillagerHarvestUtils
+{
+    private static final Map<Item, Integer> FOOD_WHITELIST = new HashMap<>();
+    private static final Set<Block> HARVEST_BLACKLIST = new HashSet<>();
+
+    /**
+     * Returns true if the passed ItemStack item extends either {@link ItemSeeds} or {@link ItemSeedFood}.
+     */
+    public static boolean isSeedItem(ItemStack stack) {
+        return !stack.isEmpty() && isSeedItem(stack.getItem());
+    }
+
+    /**
+     * Returns true if the passed Item extends either {@link ItemSeeds} or {@link ItemSeedFood}.
+     */
+    public static boolean isSeedItem(Item item) {
+        return item instanceof ItemSeeds || item instanceof ItemSeedFood;
+    }
+
+    /**
+     * Returns true if the passed ItemStack is a valid food item used for villager breeding.
+     */
+    public static boolean isWhiteListedFood(ItemStack stack) {
+        return !stack.isEmpty() && isWhiteListedFood(stack.getItem());
+    }
+
+    /**
+     * Returns true if the passed item is a valid food item used for villager breeding.
+     */
+    public static boolean isWhiteListedFood(Item item) {
+        return getRequiredFoodCount(item) > 0;
+    }
+
+    /**
+     * Returns the item count required for this food ItemStack. If this ItemStack is not valid food, this
+     * method will return 0.
+     */
+    public static int getRequiredFoodCount(ItemStack stack) {
+        return !stack.isEmpty() ? getRequiredFoodCount(stack.getItem()) : 0;
+    }
+
+    /**
+     * Returns the item count required for this food item. If this item is not valid food, this
+     * method will return 0.
+     */
+    public static int getRequiredFoodCount(Item item) {
+        return FOOD_WHITELIST.containsKey(item) ? FOOD_WHITELIST.get(item) : (item instanceof ItemSeedFood ? 12 : 0);
+    }
+
+    /**
+     * Returns true if the block is not eligible for Villager harvesting.
+     */
+    public static boolean isBlacklistedCrop(Block block) {
+        return HARVEST_BLACKLIST.contains(block);
+    }
+
+    public static void initLists() {
+        FOOD_WHITELIST.clear();
+        HARVEST_BLACKLIST.clear();
+
+        Pattern pattern = Pattern.compile("^([^:]+:[^:=]+)=(\\d+)$");
+        for(String str : UTConfigTweaks.ENTITIES.VILLAGER_HARVEST.utFoodWhitelist) {
+            try {
+                Matcher matcher = pattern.matcher(str);
+                if(matcher.find()) {
+                    ResourceLocation loc = new ResourceLocation(matcher.group(1));
+                    Item item = ForgeRegistries.ITEMS.getValue(loc);
+                    int count = Integer.parseInt(matcher.group(2));
+                    if(item == null || item == Items.AIR) {
+                        UniversalTweaks.LOGGER.error("Error parsing [02] Crop Food Whitelist. No valid item found for {}", str);
+                    } else if(count <= 0) {
+                        UniversalTweaks.LOGGER.error("Error parsing [02] Crop Food Whitelist. Count must be greater than 0 {}", str);
+                    } else {
+                        FOOD_WHITELIST.put(item, count);
+                    }
+                } else {
+                    UniversalTweaks.LOGGER.error("Error parsing [02] Crop Food Whitelist. Invalid configuration string {}", str);
+                }
+            } catch (Exception e) {
+                UniversalTweaks.LOGGER.error("Error parsing [02] Crop Food Whitelist. Error parsing {}", str);
+            }
+        }
+
+        for(String str : UTConfigTweaks.ENTITIES.VILLAGER_HARVEST.utHarvestBlacklist) {
+            ResourceLocation loc = new ResourceLocation(str);
+            Block block = ForgeRegistries.BLOCKS.getValue(loc);
+            if (block == null || block == Blocks.AIR) {
+                UniversalTweaks.LOGGER.error("Error parsing [03] Harvest Blacklist. No valid block found for {}", str);
+            } else {
+                HARVEST_BLACKLIST.add(block);
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityAIVillagerHarvestMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityAIVillagerHarvestMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.ai.EntityAIHarvestFarmland;
+import net.minecraftforge.common.EnumPlantType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(EntityAIHarvestFarmland.class)
+public class UTEntityAIVillagerHarvestMixin
+{
+    @ModifyExpressionValue(
+        method = "updateTask",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraftforge/common/IPlantable;getPlantType(Lnet/minecraft/world/IBlockAccess;Lnet/minecraft/util/math/BlockPos;)Lnet/minecraftforge/common/EnumPlantType;",
+            remap = false
+        )
+    )
+    private EnumPlantType utBlacklistPlantHarvest(EnumPlantType original, @Local Block block) {
+        if(original == EnumPlantType.Crop && UTVillagerHarvestUtils.isBlacklistedCrop(block)) {
+            return null;
+        }
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityAIVillagerInteractMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityAIVillagerInteractMixin.java
@@ -1,0 +1,49 @@
+package mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
+import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
+
+import net.minecraft.entity.ai.EntityAIVillagerInteract;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.item.ItemSeedFood;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityAIVillagerInteract.class)
+public class UTEntityAIVillagerInteractMixin
+{
+    @Shadow EntityVillager villager;
+
+    /**
+     * @author Invadermonky
+     * @reason Allows villagers to drop modded {@link ItemSeedFood} when other nearby villagers want
+     *          additional food. This logic is usually used for villager breeding.
+     */
+    @Inject(
+        method = "updateTask",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"
+        )
+    )
+    private void utDropModdedSeedFood(CallbackInfo ci, @Local int index, @Local(ordinal = 0)LocalRef<ItemStack> slotStackRef, @Local(ordinal = 1) LocalRef<ItemStack> dropStackRef)
+    {
+        ItemStack slotStack = slotStackRef.get();
+        if(!slotStack.isEmpty() && UTVillagerHarvestUtils.isWhiteListedFood(slotStack) && slotStack.getCount() > 3)
+        {
+            int toDrop = slotStack.getCount() / 2;
+            dropStackRef.set(slotStack.splitStack(toDrop));
+            if(slotStack.isEmpty()) {
+                this.villager.getVillagerInventory().setInventorySlotContents(index, ItemStack.EMPTY);
+            }
+            //Setting the ItemStack to EMPTY to bypass vanilla logic in the case of overwrites.
+            slotStackRef.set(ItemStack.EMPTY);
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityVillagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/villagerharvest/mixin/UTEntityVillagerMixin.java
@@ -1,0 +1,119 @@
+package mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.mixin;
+
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
+import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
+
+import net.minecraft.entity.EntityAgeable;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemSeedFood;
+import net.minecraft.item.ItemSeeds;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityVillager.class)
+public abstract class UTEntityVillagerMixin extends EntityAgeable
+{
+    @Shadow public InventoryBasic villagerInventory;
+
+    public UTEntityVillagerMixin(World worldIn)
+    {
+        super(worldIn);
+    }
+
+    /**
+     * @author Invadermonky
+     * @reason Allows villagers to mate with modded food items. This method extends the
+     *          previously hardcoded checks for potatoes and carrots.
+     */
+    @Inject(
+        method = "getIsWillingToMate",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"
+        )
+    )
+    private void utMateWithModdedFood(boolean updateFirst, CallbackInfoReturnable<Boolean> cir,
+                                      @Local(ordinal = 1) LocalBooleanRef booleanRef,
+                                      @Local int index,
+                                      @Local LocalRef<ItemStack> stackRef)
+    {
+        int requiredCount = UTVillagerHarvestUtils.getRequiredFoodCount(stackRef.get());
+        if(requiredCount > 0) {
+            booleanRef.set(true);
+            this.villagerInventory.decrStackSize(index, requiredCount);
+            //Setting the ItemStack to EMPTY to bypass vanilla logic in the case of overwrites.
+            stackRef.set(ItemStack.EMPTY);
+        }
+    }
+
+    /**
+     * @author Invadermonky
+     * @reason Allows villagers to pick up modded items that can either be replanted or used
+     *          as food for breeding.
+     */
+    @ModifyReturnValue(method = "canVillagerPickupItem", at = @At("RETURN"))
+    private boolean utPickupModdedItems(boolean original, @Local(argsOnly = true)Item itemIn)
+    {
+        return original || UTVillagerHarvestUtils.isSeedItem(itemIn) || UTVillagerHarvestUtils.isWhiteListedFood(itemIn);
+    }
+
+    /**
+     * @author Invadermonky
+     * @reason Expands the hardcoded food item count check to include configured items. This
+     *          check is generally used when determining if a villager can breed using items
+     *          in its inventory.
+     */
+    @Inject(
+        method = "hasEnoughItems",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"
+        ),
+        cancellable = true
+    )
+    private void utHasEnoughFoodItems(int multiplier, CallbackInfoReturnable<Boolean> cir, @Local ItemStack stack)
+    {
+        if(!stack.isEmpty())
+        {
+            int requiredAmount = UTVillagerHarvestUtils.getRequiredFoodCount(stack) * multiplier;
+            if (requiredAmount > 0 && stack.getCount() >= requiredAmount)
+            {
+                cir.setReturnValue(true);
+                cir.cancel();
+            }
+        }
+    }
+
+    /**
+     * @author Invadermonky
+     * @reason Expands the hardcoded seed check to include modded items that extend the {@link ItemSeeds} or
+     *          {@link ItemSeedFood} classes when determining if a villager can replant a crop during the
+     *          {@link net.minecraft.entity.ai.EntityAIHarvestFarmland} update.
+     */
+    @Inject(
+        method = "isFarmItemInInventory",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"
+        ),
+        cancellable = true
+    )
+    private void utIsSeedItemInInventory(CallbackInfoReturnable<Boolean> cir, @Local ItemStack stack)
+    {
+        if(UTVillagerHarvestUtils.isSeedItem(stack)) {
+            cir.setReturnValue(true);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -193,6 +193,7 @@ cfg.universaltweaks.tweaks.entities.spawncaps=Spawn Caps
 cfg.universaltweaks.tweaks.entities.undeadhorses=Undead Horses
 cfg.universaltweaks.tweaks.entities.unsafesleeping=Unsafe Sleeping
 cfg.universaltweaks.tweaks.entities.waterfalldamage=Water Fall Damage
+cfg.universaltweaks.tweaks.entities.villagerharvest=Villager Harvesting
 cfg.universaltweaks.tweaks.entities.voidteleport=Void Teleport
 cfg.universaltweaks.tweaks.items.attackcooldown=Attack Cooldown
 cfg.universaltweaks.tweaks.items.infinity=Infinity

--- a/src/main/resources/mixins/tweaks/mixins.entities.villagerharvest.json
+++ b/src/main/resources/mixins/tweaks/mixins.entities.villagerharvest.json
@@ -1,0 +1,11 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "UTEntityAIVillagerHarvestMixin",
+    "UTEntityAIVillagerInteractMixin",
+    "UTEntityVillagerMixin"
+  ]
+}


### PR DESCRIPTION
Adds a rewritten and improved implementation of the [Villager Replant](https://www.curseforge.com/minecraft/mc-mods/villager-replant) mod.

In addition to the improved harvesting logic, this tweak also allows villagers to breed using modded foods, extending the previously hardcoded food checks for Bread, Carrots and Potatoes.