### PR TITLE
Add Disable FOV Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Disable Audio Debug:** Improves loading times by removing debug code for missing sounds and subtitles
 * **Disable Creeper Music Discs:** Disables creepers dropping music discs when slain by skeletons
 * **Disable Fancy Missing Model:** Improves rendering performance by removing the resource location text on missing models
+* **Disable FOV:** Disables FOV changes caused by sprinting, potions, or armor attributes
 * **Disable Hotbar Scroll Wrapping:** Disables using the scroll wheel to change hotbar slots wrapping
 * **Disable Mob Spawner Entity Render:** Disables rendering an entity inside of Mob Spawners
 * **Disable Narrator:** Disables the narrator functionality entirely

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -2,6 +2,8 @@ package mod.acgaming.universaltweaks;
 
 import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
 
+import mod.acgaming.universaltweaks.tweaks.misc.fov.UTFovHandler;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.common.MinecraftForge;
@@ -338,6 +340,7 @@ public class UniversalTweaks
             if (UTConfigTweaks.MISC.LOAD_SOUNDS.utLoadSoundMode != UTConfigTweaks.MiscCategory.LoadSoundsCategory.EnumSoundModes.NOTHING) MinecraftForge.EVENT_BUS.register(UTLoadSound.class);
             if (UTConfigTweaks.MISC.PICKUP_NOTIFICATION.utPickupNotificationToggle) UTPickupNotificationOverlay.init();
             if (UTConfigTweaks.MISC.SOUND_CHANNELS.utSoundChannelsNormal != 28 || UTConfigTweaks.MISC.SOUND_CHANNELS.utSoundChannelsStreaming != 4) MinecraftForge.EVENT_BUS.register(UTSoundChannels.class);
+            if (UTConfigTweaks.MISC.utDisableFov) MinecraftForge.EVENT_BUS.register(UTFovHandler.class);
             if (UTConfigTweaks.MISC.utEndPortalParallaxToggle) UTEndPortalParallax.initRenderer();
             if (UTConfigTweaks.MISC.utLANServerProperties) MinecraftForge.EVENT_BUS.register(UTLanServerProperties.class);
             if (UTConfigTweaks.MISC.utPotionShiftToggle) MinecraftForge.EVENT_BUS.register(UTPotionShift.class);

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1876,6 +1876,11 @@ public class UTConfigTweaks
         public boolean utDisableAdvancementsToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Disable FOV")
+        @Config.Comment("Disables FOV changes caused by sprinting, potions, or armor attributes")
+        public boolean utDisableFov = false;
+
+        @Config.RequiresMcRestart
         @Config.Name("Disable Narrator")
         @Config.Comment("Disables the narrator functionality entirely")
         public boolean utDisableNarratorToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fov/UTFovHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fov/UTFovHandler.java
@@ -4,6 +4,7 @@ import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBow;
 import net.minecraftforge.client.event.FOVUpdateEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -11,7 +12,11 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class UTFovHandler
 {
-    @SubscribeEvent
+    /**
+     * Priority is {@link EventPriority#HIGH} for this event to fire early so mods with custom FOV
+     * handling can modify this value without being overwritten.
+     */
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void utOnFovUpdate(FOVUpdateEvent event) {
         event.setNewfov(getBowFov(event.getEntity()));
     }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fov/UTFovHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fov/UTFovHandler.java
@@ -1,0 +1,42 @@
+package mod.acgaming.universaltweaks.tweaks.misc.fov;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBow;
+import net.minecraftforge.client.event.FOVUpdateEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class UTFovHandler
+{
+    @SubscribeEvent
+    public static void utOnFovUpdate(FOVUpdateEvent event) {
+        event.setNewfov(getBowFov(event.getEntity()));
+    }
+
+    /**
+     * A copy of the FOV logic from {@link AbstractClientPlayer#getFovModifier()}, bypassing movement
+     * speed modifiers and only applying bow aiming adjustments.
+     */
+    private static float getBowFov(EntityPlayer player) {
+        if (player.isHandActive() && player.getActiveItemStack().getItem() instanceof ItemBow)
+        {
+            int useMaxCount = player.getItemInUseMaxCount();
+            float useSeconds = (float)useMaxCount / 20.0F;
+
+            if (useSeconds > 1.0F)
+            {
+                useSeconds = 1.0F;
+            }
+            else
+            {
+                useSeconds = useSeconds * useSeconds;
+            }
+
+            return 1.0F - useSeconds * 0.15F;
+        }
+        return 1.0f;
+    }
+}


### PR DESCRIPTION
Adds a tweak disabling FOV changes caused by sprinting, potions, or armor attributes. Bow pulling FOV remains unchanged.

This new tweak deprecates [NoFoV](https://www.curseforge.com/minecraft/mc-mods/nofov).