### PR TITLE
Optimize HammerLib ItemColorHelper rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
     * **Correct FPS Display:** Fixes incorrect FPS number being displayed on the HUD
 * **Gaia Dimension**
     * **Fix Restructurer Crash:** Safely access a nullable value when checking recipes in the Restructurer
+* **HammerLib**
+    * **Optimized ItemColorHelper Rendering**  Optimizes HammerLib's item color rendering performance, increasing FPS when rendering ItemStacks
 * **HWYLA**
     * **Keybindings Fix:** Fixes crashes in all menus when changing HWYLA keybindings to unsupported values
 * **Immersive Engineering**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -109,6 +109,7 @@ final def mod_dependencies = [
     'curse.maven:gaiadimension-302529:2724738'                        : [debug_gaiadimension],
     'curse.maven:geckolib-388172:4020277'                             : [debug_cqrepoured],
     'curse.maven:guideapi-228832:2645992'                             : [debug_blood_magic],
+    'curse.maven:hammerlib-247401:6348753'                            : [debug_hammerlib],
     'curse.maven:hwyla-253449:2568751'                                : [debug_hwyla],
     'curse.maven:immersive_engineering-231951:2974106'                : [debug_immersive_engineering],
     'curse.maven:incontrol-257356:3101719'                            : [debug_incontrol],

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,6 +55,7 @@ debug_forestry = false
 debug_forgemultipartcbe = false
 debug_fps_reducer = false
 debug_gaiadimension = false
+debug_hammerlib = false
 debug_hwyla = false
 debug_immersive_engineering = false
 debug_incontrol = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -191,6 +191,10 @@ public class UTConfigMods
     @Config.Name("Gaia Dimension")
     public static final GaiaDimensionCategory GAIA_DIMENSION = new GaiaDimensionCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.hammerlib")
+    @Config.Name("HammerLib")
+    public static final HammerLibCategory HAMMER_LIB = new HammerLibCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.immersiveengineering")
     @Config.Name("Immersive Engineering")
     public static final ImmersiveEngineeringCategory IMMERSIVE_ENGINEERING = new ImmersiveEngineeringCategory();
@@ -1056,6 +1060,14 @@ public class UTConfigMods
         @Config.Name("Fix Restructurer Crash")
         @Config.Comment("Safely access a nullable array when checking recipes in the Restructurer")
         public boolean utFixNPERestructurerRecipe = true;
+    }
+
+    public static class HammerLibCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Optimized ItemColorHelper Rendering")
+        @Config.Comment("Optimizes HammerLib's item color rendering performance, increasing FPS when rendering ItemStacks")
+        public boolean utOptimizeItemColorHelper = true;
     }
 
     public static class ImmersiveEngineeringCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -45,6 +45,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.electroblobswizardry.json", c -> c.isModPresent("ebwizardry") && c.isModPresent("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);
                 put("mixins/mods/mixins.enderio.itemrender.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
                 put("mixins/mods/mixins.fpsreducer.json", c -> c.isModPresent("fpsreducer") && UTConfigMods.FPS_REDUCER.utCorrectFpsValue);
+                put("mixins/mods/mixins.hammerlib.json", c -> c.isModPresent("hammercore") && UTConfigMods.HAMMER_LIB.utOptimizeItemColorHelper);
                 put("mixins/mods/mixins.hwyla.json", c -> c.isModPresent("waila"));
                 put("mixins/mods/mixins.ironchests.json", c -> c.isModPresent("ironchest") && UTConfigMods.IRON_CHESTS.utReplaceItemRenderer);
                 put("mixins/mods/mixins.modularmagic.nullingredient.json", c -> c.isModPresent("modularmagic") && UTConfigMods.MODULAR_MAGIC.utEnsureIngredientNotNull);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/hammerlib/QuarkCompat.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/hammerlib/QuarkCompat.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.hammerlib;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
+
+import com.zeitheron.hammercore.client.utils.ItemColorHelper;
+import vazkii.quark.misc.feature.ColorRunes;
+
+public class QuarkCompat
+{
+    private static final boolean isQuarkLoaded = Loader.isModLoaded("quark");
+
+    public static int getRuneColor(ItemStack target)
+    {
+        if (!isQuarkLoaded)
+        {
+            return ItemColorHelper.DEFAULT_GLINT_COLOR;
+        }
+        ColorRunes.setTargetStack(target);
+        return ColorRunes.getColor(ItemColorHelper.DEFAULT_GLINT_COLOR);
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/hammerlib/mixin/UTItemColorHelperMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/hammerlib/mixin/UTItemColorHelperMixin.java
@@ -1,0 +1,63 @@
+package mod.acgaming.universaltweaks.mods.hammerlib.mixin;
+
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.item.ItemStack;
+
+import com.zeitheron.hammercore.api.items.IRenderAwareItem;
+import com.zeitheron.hammercore.client.render.item.ItemRenderingHandler;
+import com.zeitheron.hammercore.client.render.shader.GlShaderStack;
+import com.zeitheron.hammercore.client.utils.ItemColorHelper;
+import mod.acgaming.universaltweaks.mods.hammerlib.QuarkCompat;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// Courtesy of jchung01
+@Mixin(value = ItemColorHelper.class, remap = false)
+public abstract class UTItemColorHelperMixin
+{
+    @Shadow
+    @Final
+    public static int DEFAULT_GLINT_COLOR;
+    @Shadow
+    static ItemStack target;
+
+    @Shadow
+    public static int getColorFromStack(ItemStack stack, int prev) {
+        return 0;
+    }
+
+    /**
+     * @reason The current shader program is queried by {@link GlShaderStack} for EVERY ItemStack on screen, EVERY frame, which is super slow.
+     */
+    @Inject(method = "renderItemModelIntoGUIPre", at = @At("HEAD"), cancellable = true)
+    private static void utSkipPushShader(ItemStack stack, int x, int y, IBakedModel bakedmodel, CallbackInfo ci)
+    {
+        if ((stack.isEmpty() || ItemRenderingHandler.INSTANCE.getRenderHooks(stack.getItem()).isEmpty())
+                && IRenderAwareItem.get(stack) == null) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "renderItemModelIntoGUIPost", at = @At("HEAD"), cancellable = true)
+    private static void utSkipPopShader(ItemStack stack, int x, int y, IBakedModel bakedmodel, CallbackInfo ci)
+    {
+        if ((stack.isEmpty() || ItemRenderingHandler.INSTANCE.getRenderHooks(stack.getItem()).isEmpty())
+                && IRenderAwareItem.get(stack) == null) {
+            ci.cancel();
+        }
+    }
+
+    /**
+     * @reason Get Quark rune color without expensive reflection.
+     */
+    @Inject(method = "getCustomColor", at = @At(value = "INVOKE", target = "Ljava/lang/Class;forName(Ljava/lang/String;)Ljava/lang/Class;"), cancellable = true)
+    private static void utGetQuarkRuneColor(int prev, CallbackInfoReturnable<Integer> cir) {
+        int runeColor = QuarkCompat.getRuneColor(target);
+        cir.setReturnValue(runeColor != DEFAULT_GLINT_COLOR ? runeColor : getColorFromStack(target, prev));
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -124,6 +124,7 @@ cfg.universaltweaks.modintegration.extreme_reactors=Extreme Reactors
 cfg.universaltweaks.modintegration.forestry=Forestry
 cfg.universaltweaks.modintegration.fpsreducer=FPS Reducer
 cfg.universaltweaks.modintegration.gaia_dimension=Gaia Dimension
+cfg.universaltweaks.modintegration.hammerlib=HammerLib
 cfg.universaltweaks.modintegration.immersiveengineering=Immersive Engineering
 cfg.universaltweaks.modintegration.incontrol=In Control!
 cfg.universaltweaks.modintegration.industrialcraft=IndustrialCraft 2

--- a/src/main/resources/mixins/mods/mixins.hammerlib.json
+++ b/src/main/resources/mixins/mods/mixins.hammerlib.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.hammerlib.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTItemColorHelperMixin"]
+}


### PR DESCRIPTION
Adds a tweak to optimize HammerLib's `ItemColorHelper`, as it causes a very noticeable FPS impact when rendering many items on the screen.
- Skip push/pop shader calls for items that don't need HammerLib's custom coloring/rendering. Hotpath `GLShaderStack#glsActiveProgram` was being called for EVERY item on screen, EVERY frame.
- Handles Quark compat for rune colors without using reflection for every call.

Simple test with a very populated BQu quest book open -
[Before](https://spark.lucko.me/ppn8zZV9og?hl=673,87):
<img width="904" height="1071" alt="hammerlib_before" src="https://github.com/user-attachments/assets/83e539df-b251-4528-996c-8c1fccc2d96d" />
[After](https://spark.lucko.me/vUswIjkgkd?hl=105):
<img width="825" height="1075" alt="hammerlib_after" src="https://github.com/user-attachments/assets/0f7c4ad2-3687-4873-965e-8928afdc6c17" />
