### PR TITLE
Add dirt to path tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Default Difficulty:** Sets the default difficulty for newly generated worlds
 * **Default GUI Text Color:** Sets the default GUI text color (HEX RGB code) which can improve readability in dark mode resource packs
 * **Dimension Unload:** Unloads dimensions not in use to free up resources
+* **Dirt To Path:** Dirt can be shoveled into grass paths and grass paths can be shoveled into dirt
 * **Disable Advancements:** Prevents the advancement system from loading entirely
 * **Disable Audio Debug:** Improves loading times by removing debug code for missing sounds and subtitles
 * **Disable Creeper Music Discs:** Disables creepers dropping music discs when slain by skeletons

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,5 +1,6 @@
 package mod.acgaming.universaltweaks;
 
+import mod.acgaming.universaltweaks.tweaks.blocks.paths.UTDirtToPath;
 import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
 
 import mod.acgaming.universaltweaks.tweaks.misc.fov.UTFovHandler;
@@ -276,6 +277,7 @@ public class UniversalTweaks
             if (UTConfigTweaks.BLOCKS.BREAKABLE_BEDROCK.utBreakableBedrockToggle) MinecraftForge.EVENT_BUS.register(UTBreakableBedrock.class);
             if (UTConfigTweaks.BLOCKS.FINITE_WATER.utFiniteWaterToggle) MinecraftForge.EVENT_BUS.register(UTFiniteWater.class);
             if (UTConfigTweaks.BLOCKS.utBetterHarvestToggle) MinecraftForge.EVENT_BUS.register(UTBetterHarvest.class);
+            if (UTConfigTweaks.BLOCKS.utDirtToPath) MinecraftForge.EVENT_BUS.register(UTDirtToPath.class);
             if (UTConfigTweaks.BLOCKS.utSlimeBlockProjectiles) MinecraftForge.EVENT_BUS.register(UTSlimeBlockProjectiles.class);
             if (UTConfigTweaks.ENTITIES.CHICKEN_SHEDDING.utChickenSheddingToggle) MinecraftForge.EVENT_BUS.register(UTChickenShedding.class);
             if (UTConfigTweaks.ENTITIES.EASY_BREEDING.utEasyBreedingToggle) MinecraftForge.EVENT_BUS.register(UTEasyBreeding.class);

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -243,6 +243,15 @@ public class UTConfigTweaks
         public boolean utEnchantmentTableObstructionToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Dirt to Path")
+        @Config.Comment
+            ({
+                "Allows converting dirt blocks to grass path by clicking them with a shovel. Grass paths can",
+                "be reverted to dirt with shift right-click."
+            })
+        public boolean utDirtToPath = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Lenient Paths")
         @Config.Comment("Allows the creation of grass paths everywhere (beneath fence gates, trapdoors, ...)")
         public boolean utLenientPathsToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/paths/UTDirtToPath.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/paths/UTDirtToPath.java
@@ -1,0 +1,62 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.paths;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.block.BlockDirt;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemSpade;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class UTDirtToPath
+{
+    @SubscribeEvent
+    public static void utOnDirtInteract(PlayerInteractEvent.RightClickBlock event)
+    {
+        ItemStack stack = event.getItemStack();
+        if(!stack.isEmpty() && stack.getItem() instanceof ItemSpade || stack.getItem().getToolClasses(stack).contains("shovel"))
+        {
+            EntityPlayer player = event.getEntityPlayer();
+            World world = event.getWorld();
+            BlockPos pos = event.getPos();
+            IBlockState state = world.getBlockState(event.getPos());
+            //Reverting grass path to dirt
+            if(state.getBlock() == Blocks.GRASS_PATH && player.isSneaking())
+            {
+                world.playSound(player, pos, SoundEvents.ITEM_SHOVEL_FLATTEN, SoundCategory.BLOCKS, 1.0F, 1.0F);
+                if(!world.isRemote)
+                {
+                    world.setBlockState(pos, Blocks.DIRT.getDefaultState().withProperty(BlockDirt.VARIANT, BlockDirt.DirtType.DIRT).withProperty(BlockDirt.SNOWY, false), 11);
+                    stack.damageItem(1, player);
+                }
+                event.setCancellationResult(EnumActionResult.SUCCESS);
+                event.setCanceled(true);
+            }
+            //Converting Dirt into Grass Paths
+            else if(state.getBlock() == Blocks.DIRT && state.getValue(BlockDirt.VARIANT) == BlockDirt.DirtType.DIRT)
+            {
+                if(event.getFace() != EnumFacing.DOWN && (world.getBlockState(pos).getMaterial() == Material.AIR || UTConfigTweaks.BLOCKS.utLenientPathsToggle))
+                {
+                    world.playSound(player, pos, SoundEvents.ITEM_SHOVEL_FLATTEN, SoundCategory.BLOCKS, 1.0F, 1.0F);
+                    if(!world.isRemote)
+                    {
+                        world.setBlockState(pos, Blocks.GRASS_PATH.getDefaultState(), 11);
+                        stack.damageItem(1, player);
+                    }
+                    event.setCancellationResult(EnumActionResult.SUCCESS);
+                    event.setCanceled(true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a tweak allowing players to convert dirt blocks to grass paths using shovels. This tweak also allows sneak interacting with grass paths to convert them back into dirt blocks, which previously required breaking and replacing the block.

This tweak deprecates [Dirt2Path \[FORGE\]](https://www.curseforge.com/minecraft/mc-mods/dirt2path).