### PR TITLE
Add Ender Dragon Kill Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Disable Villager Trade Restock:** Disables restocking of villager trades, only allowing one trade per offer
 * **Disable Wither Targeting AI:** Disables withers targeting animals
 * **Display Title:** Determines the title of the game window
+* **Dragon Kill:** Allows setting dragon kill experience drops and egg spawn after first kill
 * **Easy Breeding:** Enables easy breeding of animals by tossing food on the ground
 * **End Crystal Placement:** Allows placing end crystals on more blocks than obsidian or bedrock below
 * **End Portal Parallax:** Re-implements parallax rendering of the end portal from 1.11 and older

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -545,6 +545,10 @@ public class UTConfigTweaks
         @Config.Name("Damage Velocity")
         public final DamageVelocityCategory DAMAGE_VELOCITY = new DamageVelocityCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.entities.dragonkill")
+        @Config.Name("Dragon Kill")
+        public final DragonKillCategory DRAGON_KILL = new DragonKillCategory();
+
         @Config.LangKey("cfg.universaltweaks.tweaks.entities.easybreeding")
         @Config.Name("Easy Breeding")
         public final EasyBreedingCategory EASY_BREEDING = new EasyBreedingCategory();
@@ -952,6 +956,26 @@ public class UTConfigTweaks
             @Config.Name("[3] Baby Chickens Shed Feathers")
             @Config.Comment("Allows baby chickens to also shed feathers")
             public boolean utChickenSheddingBabyToggle = false;
+        }
+
+        public static class DragonKillCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[1] Dragon Kill Toggle")
+            @Config.Comment("Enables the dragon kill tweaks")
+            public boolean utDragonKillToggle = true;
+
+            @Config.Name("[2] First Kill Xp")
+            @Config.Comment("The amount of experience dropped on the first dragon kill")
+            public int utFirstKillXp = 12000;
+
+            @Config.Name("[3] Second+ Kill Xp")
+            @Config.Comment("The amount of experience dropped on dragon kills after the first")
+            public int utSecondKillXp = 500;
+
+            @Config.Name("[4] Second+ Kill Egg")
+            @Config.Comment("Enables a dragon egg spawning on dragon kills after the first")
+            public boolean utSecondKillEgg = false;
         }
 
         public static class EasyBreedingCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -130,6 +130,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.entities.damage.velocity.json", c -> UTConfigTweaks.ENTITIES.DAMAGE_VELOCITY.utDamageVelocityToggle);
                 put("mixins/tweaks/mixins.entities.despawning.horse.json", c -> UTConfigTweaks.ENTITIES.UNDEAD_HORSES.utDespawningUndeadHorsesToggle);
                 put("mixins/tweaks/mixins.entities.despawning.mobs.json", c -> UTConfigTweaks.ENTITIES.utMobDespawningToggle != UTConfigTweaks.EnumMobDespawning.DEFAULT);
+                put("mixins/tweaks/mixins.entities.dragonkill.json", c -> UTConfigTweaks.ENTITIES.DRAGON_KILL.utDragonKillToggle);
                 put("mixins/tweaks/mixins.entities.loot.json", c -> UTConfigTweaks.ENTITIES.utCreeperMusicDiscsToggle);
                 put("mixins/tweaks/mixins.entities.minecart.json", c -> UTConfigTweaks.ENTITIES.utMinecartDropsType);
                 put("mixins/tweaks/mixins.entities.exhaustion.regen.json", c -> UTConfigTweaks.ENTITIES.utRegenExhaustion != 6.0D);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/dragonkill/mixin/UTDragonFightManagerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/dragonkill/mixin/UTDragonFightManagerMixin.java
@@ -1,0 +1,30 @@
+package mod.acgaming.universaltweaks.tweaks.entities.dragonkill.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.world.end.DragonFightManager;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(DragonFightManager.class)
+public class UTDragonFightManagerMixin
+{
+    /**
+     * @author Invadermonky
+     * @reason Allows dragon egg spawning on Ender Dragon kills following the first kill.
+     */
+    @ModifyExpressionValue(
+        method = "processDragonDeath",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/world/end/DragonFightManager;previouslyKilled:Z",
+            opcode = Opcodes.GETFIELD
+        )
+    )
+    private boolean utSpawnEggOnDeath(boolean previouslyKilled)
+    {
+        //The egg spawn check inverts this logic
+        return previouslyKilled && !UTConfigTweaks.ENTITIES.DRAGON_KILL.utSecondKillEgg;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/dragonkill/mixin/UTEntityDragonDropsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/dragonkill/mixin/UTEntityDragonDropsMixin.java
@@ -1,0 +1,33 @@
+package mod.acgaming.universaltweaks.tweaks.entities.dragonkill.mixin;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import net.minecraft.entity.boss.EntityDragon;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(EntityDragon.class)
+public class UTEntityDragonDropsMixin
+{
+    /**
+     * @author Invadermonky
+     * @reason Modifying the hardcoded experience drop when the Ender Dragon is killed
+     *          for the second time.
+     */
+    @ModifyConstant(method = "onDeathUpdate", constant = @Constant(intValue = 500))
+    private int utModifySecondKillXp(int original)
+    {
+        return UTConfigTweaks.ENTITIES.DRAGON_KILL.utSecondKillXp;
+    }
+
+    /**
+     * @author Invadermonky
+     * @reason Modifying the hardcoded experience drop when the Ender Dragon is killed
+     *          for the first time.
+     */
+    @ModifyConstant(method = "onDeathUpdate", constant = @Constant(intValue = 12000))
+    private int utModifyFirstKillXp(int original)
+    {
+        return UTConfigTweaks.ENTITIES.DRAGON_KILL.utFirstKillXp;
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -190,6 +190,7 @@ cfg.universaltweaks.tweaks.entities.chickenshedding=Chicken Shedding
 cfg.universaltweaks.tweaks.entities.cobwebslowness=Cobweb Slowness
 cfg.universaltweaks.tweaks.entities.creeperconfetti=Creeper Confetti
 cfg.universaltweaks.tweaks.entities.damagevelocity=Damage Velocity
+cfg.universaltweaks.tweaks.entities.dragonkill=Dragon Kill
 cfg.universaltweaks.tweaks.entities.easybreeding=Easy Breeding
 cfg.universaltweaks.tweaks.entities.mobgriefing=Mob Griefing
 cfg.universaltweaks.tweaks.entities.nogolems=No Golems

--- a/src/main/resources/mixins/tweaks/mixins.entities.dragonkill.json
+++ b/src/main/resources/mixins/tweaks/mixins.entities.dragonkill.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.dragonkill.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTDragonFightManagerMixin", "UTEntityDragonDropsMixin"]
+}


### PR DESCRIPTION
Add tweaks for hardcoded features of the Ender Dragon boss kill.
- Change first kill experience drop amount
- Change second+ kill experience drop amount
- Spawn Dragon Egg on second+ kill

These tweaks deprecate [EqualDragons](https://www.curseforge.com/minecraft/mc-mods/equaldragons).