### PR TITLE
Fix Industrial Foregoing Black Hole Tank voiding items

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ All changes are toggleable via config files.
     * **Duplication Fixes:** Fixes various duplication exploits
 * **Industrial Foregoing**
     * **Duplication Fixes:** Fixes various duplication exploits
+    * **Fix Black Hole Tank Bucket Voiding:** Fix the Black Hole Tank voiding buckets if the player inventory is full by dropping the buckets on the ground
     * **Machines Max Range Off-By-One Fix:** Fixes an off-by-one error where IF Machines would display the max tier of range addon as one less than the actual maximum
 * **Infernal Mobs**
     * **Better Entity Names:** Gets the actual display names of entities for improved naming

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1086,6 +1086,11 @@ public class UTConfigMods
         public boolean utDuplicationFixesToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Fix Black Hole Tank Bucket Voiding")
+        @Config.Comment("Fix the Black Hole Tank voiding buckets if the player inventory is full by dropping the buckets on the ground")
+        public boolean utFixBlackHoleTankVoiding = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Machines Max Range Off-By-One Fix")
         @Config.Comment("Fixes an off-by-one error where IF Machines would display the max tier of range addon as one less than the actual maximum")
         public boolean utRangeAddonNumberFix = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -149,6 +149,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.incontrol.rule.json", c -> regularInControlLoaded() && UTConfigMods.INCONTROL.utStatsFixToggle);
                 put("mixins/mods/mixins.incontrol.handler_crash.json", c -> regularInControlLoaded() && UTConfigMods.INCONTROL.utClientCrash);
                 put("mixins/mods/mixins.industrialcraft.dupes.json", c -> c.isModPresent("ic2") && UTConfigMods.INDUSTRIALCRAFT.utDuplicationFixesToggle);
+                put("mixins/mods/mixins.industrialforegoing.blackholetank.json", c -> c.isModPresent("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utFixBlackHoleTankVoiding);
                 put("mixins/mods/mixins.industrialforegoing.dupes.json", c -> c.isModPresent("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utDuplicationFixesToggle);
                 put("mixins/mods/mixins.industrialforegoing.rangeaddon.json", c -> c.isModPresent("industrialforegoing") && UTConfigMods.INDUSTRIAL_FOREGOING.utRangeAddonNumberFix);
                 put("mixins/mods/mixins.infernalmobs.json", c -> c.isModPresent("infernalmobs"));

--- a/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/blackholetank/mixin/UTBlackHoleTankBlockMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/industrialforegoing/blackholetank/mixin/UTBlackHoleTankBlockMixin.java
@@ -1,0 +1,31 @@
+package mod.acgaming.universaltweaks.mods.industrialforegoing.blackholetank.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import com.buuz135.industrial.tile.block.BlackHoleTankBlock;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Courtesy of WaitingIdly
+@Mixin(value = BlackHoleTankBlock.class, remap = false)
+public class UTBlackHoleTankBlockMixin
+{
+    /**
+     * @author WaitingIdly
+     * @reason If the player inventory is full, {@link EntityPlayer#addItemStackToInventory(ItemStack)} will return false.
+     * In that situation, the item is supposed to be dropped onto the ground.
+     * The current code voids buckets if the inventory is full.
+     */
+    @WrapOperation(method = "onBlockActivated", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;addItemStackToInventory(Lnet/minecraft/item/ItemStack;)Z"))
+    private boolean utDropFallback(EntityPlayer instance, ItemStack p_191521_1_, Operation<Boolean> original)
+    {
+        if (!original.call(instance, p_191521_1_))
+        {
+            instance.dropItem(p_191521_1_, false);
+        }
+        return true;
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.industrialforegoing.blackholetank.json
+++ b/src/main/resources/mixins/mods/mixins.industrialforegoing.blackholetank.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.industrialforegoing.blackholetank.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTBlackHoleTankBlockMixin"]
+}


### PR DESCRIPTION
changes in this PR:
- make the black hole tank drop items in the ground instead of voiding them when the player inventory is full (default: `true`)

resolves #848