### PR TITLE
Fix CaveGenMixin not preserving vanilla behavior

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/world/cavegen/mixin/UTCaveGenMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/world/cavegen/mixin/UTCaveGenMixin.java
@@ -5,19 +5,23 @@ import net.minecraft.world.gen.MapGenCaves;
 import mod.acgaming.universaltweaks.config.UTConfigTweaks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
 // Courtesy of brunnh1lde
 @Mixin(MapGenCaves.class)
 public abstract class UTCaveGenMixin
 {
-    @ModifyArg(method = "recursiveGenerate", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 2))
+    @ModifyExpressionValue(
+        method = "recursiveGenerate",
+        at = @At(value = "CONSTANT", args = "intValue=15", ordinal = 0))
     public int utCaveGenSize(int bound)
     {
         return UTConfigTweaks.WORLD.CAVE_GEN.utCaveGenSize;
     }
 
-    @ModifyArg(method = "recursiveGenerate", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 3))
+    @ModifyExpressionValue(
+        method = "recursiveGenerate",
+        at = @At(value = "CONSTANT", args = "intValue=7", ordinal = 0))
     public int utCaveGenRarity(int bound)
     {
         return UTConfigTweaks.WORLD.CAVE_GEN.utCaveGenRarity;


### PR DESCRIPTION
Enabling the cave generation toggle made caves spawn differently from vanilla even without changing values from their vanilla defaults. It also didn't replicate r1.6 caves when changing the size to 40 and rarity to 15.