### PR TITLE
Smooth scrolling improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.0'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.4.9'
     id 'net.darkhax.curseforgegradle' version '1.1.24' apply false
     id 'com.modrinth.minotaur' version '2.8.7' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiScrollingListMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiScrollingListMixin.java
@@ -94,15 +94,17 @@ public abstract class UTGuiScrollingListMixin
     @Redirect(method = "drawScreen(IIF)V", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/client/GuiScrollingList;applyScrollLimits()V"))
     public void utBindScrollDistance(GuiScrollingList guiSlot)
     {
-        if (Mouse.isButtonDown(0)) target = scrollDistance = UTSmoothScrolling.clamp(scrollDistance, getMaxScroll(), 0);
+        if (Mouse.isButtonDown(0)) target = scrollDistance = UTSmoothScrolling.clamp(scrollDistance, getMaxScroll());
     }
 
     @Inject(method = "drawScreen(IIF)V", at = @At("HEAD"))
     public void utRender(int int_1, int int_2, float delta, CallbackInfo callbackInfo)
     {
-        float[] target = new float[] {this.target};
-        this.scrollDistance = UTSmoothScrolling.handleScrollingPosition(target, this.scrollDistance, this.getMaxScroll(), 20f / Minecraft.getDebugFPS(), (double) this.start, (double) this.duration);
-        this.target = target[0];
+        if (!Mouse.isButtonDown(0)) {
+            float[] target = new float[] {this.target};
+            this.scrollDistance = UTSmoothScrolling.handleScrollingPosition(target, this.scrollDistance, this.getMaxScroll(), 20f / Minecraft.getDebugFPS(), (double) this.start, (double) this.duration);
+            this.target = target[0];
+        }
         if (lastContentHeight != getContentHeight())
         {
             if (lastContentHeight != -1) scrollDistance = this.target = UTSmoothScrolling.clamp(this.target, getMaxScroll(), 0);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiScrollingListMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiScrollingListMixin.java
@@ -162,8 +162,6 @@ public abstract class UTGuiScrollingListMixin
     @Unique
     private int getMaxScroll()
     {
-        int max = this.getContentHeight() - (this.bottom - this.top) + 4;
-        if (max < 0) max /= 2;
-        return max;
+        return Math.max(0, this.getContentHeight() - (this.bottom - this.top - 4));
     }
 }

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiSlotMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiSlotMixin.java
@@ -67,7 +67,7 @@ public abstract class UTGuiSlotMixin
     @Inject(method = "handleMouseInput", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;getEventDWheel()I", remap = false), cancellable = true)
     public void utHandleMouseScroll(CallbackInfo callbackInfo)
     {
-        if (Mouse.isButtonDown(0) && this.getEnabled()) target = amountScrolled = UTSmoothScrolling.clamp(amountScrolled, getMaxScroll(), 0);
+        if (Mouse.isButtonDown(0) && this.getEnabled()) target = amountScrolled = UTSmoothScrolling.clamp(amountScrolled, getMaxScroll());
         else
         {
             int wheel = Mouse.getEventDWheel();
@@ -108,9 +108,12 @@ public abstract class UTGuiSlotMixin
     @Inject(method = "drawScreen", at = @At("HEAD"))
     public void utRender(int int_1, int int_2, float delta, CallbackInfo callbackInfo)
     {
-        float[] target = new float[] {this.target};
-        this.amountScrolled = UTSmoothScrolling.handleScrollingPosition(target, this.amountScrolled, this.getMaxScroll(), 20f / Minecraft.getDebugFPS(), (double) this.start, (double) this.duration);
-        this.target = target[0];
+        if (!Mouse.isButtonDown(0))
+        {
+            float[] target = new float[] {this.target};
+            this.amountScrolled = UTSmoothScrolling.handleScrollingPosition(target, this.amountScrolled, this.getMaxScroll(), 20f / Minecraft.getDebugFPS(), (double) this.start, (double) this.duration);
+            this.target = target[0];
+        }
         if (lastContentHeight != getContentHeight())
         {
             if (lastContentHeight != -1) amountScrolled = this.target = UTSmoothScrolling.clamp(this.target, getMaxScroll(), 0);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiSlotMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/smoothscrolling/mixin/UTGuiSlotMixin.java
@@ -113,7 +113,7 @@ public abstract class UTGuiSlotMixin
         this.target = target[0];
         if (lastContentHeight != getContentHeight())
         {
-            if (lastContentHeight != -1) amountScrolled = this.target = UTSmoothScrolling.clamp(this.target, getContentHeight(), 0);
+            if (lastContentHeight != -1) amountScrolled = this.target = UTSmoothScrolling.clamp(this.target, getMaxScroll(), 0);
             lastContentHeight = getContentHeight();
         }
     }


### PR DESCRIPTION
This PR:

- bumps RetroFuturaGradle to `1.4.9`. The original version, `1.4.0`, no longer exists on the GTNH maven, making it impossible to build the mod.
- fixes the issue where, when the content height becomes smaller, the scrolling position would become negative, creating a visual artifact [0]
- fixes the issue where, if the user clicks the left mouse button while the scroll position is negative, the position jumps to zero instead of properly stopping at the current point [1]

|    | Before    | After  |
|---|----------|--------|
|[0]|<img width="852" height="480" alt="Scroll1_WO" src="https://github.com/user-attachments/assets/547ad70a-d42b-41eb-8b6d-7e9b2806183e"/>|<img width="852" height="480" alt="Scroll1_W" src="https://github.com/user-attachments/assets/781ebc7f-4bdf-4e20-a874-e14d9b0378ab"/>|
|[1]|<img width="852" height="480" alt="Scroll2_WO" src="https://github.com/user-attachments/assets/05e46a3a-8af5-4966-ae4e-7e701945ec38"/>|<img width="852" height="480" alt="Scroll2_W" src="https://github.com/user-attachments/assets/fabe383a-8529-4f50-ab5a-94aa605f5068"/>|