### PR TITLE
Add mouse keybind fix

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/mousekeybind/mixin/UTMinecraftMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/bugfixes/misc/mousekeybind/mixin/UTMinecraftMixin.java
@@ -1,0 +1,27 @@
+package mod.acgaming.universaltweaks.bugfixes.misc.mousekeybind.mixin;
+
+import net.minecraft.client.Minecraft;
+
+import net.minecraftforge.fml.common.FMLCommonHandler;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public class UTMinecraftMixin
+{
+    /**
+     * @author decce6
+     * @reason Mods usually handle keybinds by listening to the {@link net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent} event.
+     * This event, however, is normally only fired on <b>keyboard</b> input. This means if a keybind is bound to a mouse button, the input
+     * won't be detected by mods when user presses the button, until they subsequently press a key on the keyboard.
+     * </p>
+     * This mixin fixes the issue by firing an additional {@link net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent} event on mouse input.
+     */
+    @Inject(method = "runTickMouse", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/FMLCommonHandler;fireMouseInput()V", remap = false))
+    private void utFireKeyboardInputOnMouseInput(CallbackInfo ci) {
+        FMLCommonHandler.instance().fireKeyInput();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigBugfixes.java
@@ -394,6 +394,11 @@ public class UTConfigBugfixes
         public boolean utLocaleToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Mouse Keybind Fix")
+        @Config.Comment("Fixes keybinds not triggering when bound to a mouse button")
+        public boolean utMouseKeybindFix = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Overlay Message Fade Out")
         @Config.Comment("Fixes Forge's overlay message (action bar) fade out regression")
         public boolean utOverlayMessageFadeOut = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -229,6 +229,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/bugfixes/mixins.misc.camera.json", c -> UTConfigBugfixes.MISC.utCameraOrientation);
                 put("mixins/bugfixes/mixins.misc.depthmask.entity.json", c -> UTConfigBugfixes.MISC.utEntityDepthMaskToggle);
                 put("mixins/bugfixes/mixins.misc.depthmask.particle.json", c -> UTConfigBugfixes.MISC.utParticleDepthMaskToggle);
+                put("mixins/bugfixes/mixins.misc.mousekeybind.json", c -> UTConfigBugfixes.MISC.utMouseKeybindFix);
                 put("mixins/bugfixes/mixins.misc.potionamplifier.json", c -> UTConfigBugfixes.MISC.utPotionAmplifierVisibilityToggle);
                 put("mixins/bugfixes/mixins.misc.smoothlighting.json", c -> UTConfigBugfixes.MISC.utAccurateSmoothLighting);
                 put("mixins/bugfixes/mixins.misc.spectatormenu.json", c -> UTConfigBugfixes.MISC.utSpectatorMenuToggle);

--- a/src/main/resources/mixins/bugfixes/mixins.misc.mousekeybind.json
+++ b/src/main/resources/mixins/bugfixes/mixins.misc.mousekeybind.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.bugfixes.misc.mousekeybind.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTMinecraftMixin"]
+}


### PR DESCRIPTION
Previously, if a keybind is bound to a mouse button, the keybind is not triggered *until the next keyboard input*. This was a flaw in Forge's design in 1.12.2. This PR resolves this issue by firing an additional `InputEvent.KeyInputEvent` event on mouse input.

Vanilla: 
<img width="852" height="480" alt="Mouse_WO" src="https://github.com/user-attachments/assets/a30ddb1e-72a2-4712-a781-e30951941f16" />

PR: 
<img width="852" height="480" alt="Mouse_W" src="https://github.com/user-attachments/assets/3635341c-d58c-4d83-b14c-35c6fcbccbc6" />
