### PR TITLE
Add hoe harvesting backport

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Unlimited Sound Pitch Range:** Removes the hardcoded range for sound pitches (0.5-2.0)
 * **Use Separate Dismount Key:** Makes the dismount keybind separate from LSHIFT, allowing it to be rebound independently
 * **Use Separate Narrator Key:** Allows using a custom Narrator key, instead of being stuck with CTRL+B
+* **Useful Hoes:** Backports faster Hoe block harvesting for hay bales and sponges, includes configurable whitelist
 * **Village Distance:** Sets the village generation distance in chunks
 * **Villager Harvesting:** Fixes Villagers being unable to replant modded crops and allows villagers to breed using modded foods.
 * **Villager Profession Biome Restriction:** Controls villager professions in specified biomes

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
 
+import mod.acgaming.universaltweaks.tweaks.items.usefulhoes.UTUsefulHoes;
+
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
@@ -1442,6 +1444,10 @@ public class UTConfigTweaks
         @Config.Name("Shield Parry")
         public final ParryCategory PARRY = new ParryCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.items.usefulhoes")
+        @Config.Name("Useful Hoes")
+        public final UsefulHoesCategory USEFUL_HOES = new UsefulHoesCategory();
+
         @Config.Name("Always Eat")
         @Config.Comment("Allows the consumption of food at any time, regardless of the hunger bar")
         public boolean utAlwaysEatToggle = false;
@@ -1788,6 +1794,26 @@ public class UTConfigTweaks
             @Config.Name("[12] Require Rebound Enchantment")
             @Config.Comment("Requires the rebound enchantment for parrying")
             public boolean utParryReboundRequire = false;
+        }
+
+        public static class UsefulHoesCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[1] Useful Hoes")
+            @Config.Comment("Enables the Useful Hoes feature, allowing hoes to harvest whitelisted blocks faster")
+            public boolean utUsefulHoesToggle = true;
+
+            @Config.Name("[2] Hoe Harvestable Blocks")
+            @Config.Comment
+                ({
+                    "Blocks that have faster break speed when harvested with a hoe",
+                    "Example -> minecraft:hay_bale"
+                })
+            public String[] utHoeHarvestableBlocks = new String[] {
+                "minecraft:nether_wart_block",
+                "minecraft:hay_block",
+                "minecraft:sponge"
+            };
         }
     }
 
@@ -3199,6 +3225,7 @@ public class UTConfigTweaks
                 if (ITEMS.utCustomRarities.length > 0) UTCustomRarity.initItemRarityMap();
                 if (ITEMS.utCustomUseDurations.length > 0) UTCustomUseDuration.initItemUseMaps();
                 if (ITEMS.PARRY.utParryToggle) UTParry.initProjectileList();
+                if (ITEMS.USEFUL_HOES.utUsefulHoesToggle) UTUsefulHoes.initLists();
                 if (WORLD.CHUNK_GEN_LIMIT.utChunkGenLimitToggle) UTChunkGenLimit.initDimensionList();
                 if (WORLD.FLAT_BEDROCK.utFlatBedrockToggle) UTFlatBedrockList.initHeightWhitelist();
                 if (WORLD.VOID_FOG.utVoidFogToggle) UTVoidFog.initDimensionList();

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -164,6 +164,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.items.infinitymending.json", c -> UTConfigTweaks.ITEMS.INFINITY.utInfinityEnchantmentConflicts);
                 put("mixins/tweaks/mixins.items.itementities.server.json", c -> UTConfigTweaks.ITEMS.ITEM_ENTITIES.utItemEntitiesToggle);
                 put("mixins/tweaks/mixins.items.mobegg.json", c -> UTConfigTweaks.ITEMS.utPreventMobEggsFromChangingSpawner);
+                put("mixins/tweaks/mixins.items.usefulhoes.json", c -> UTConfigTweaks.ITEMS.USEFUL_HOES.utUsefulHoesToggle);
                 put("mixins/tweaks/mixins.items.rarity.json", c -> UTConfigTweaks.ITEMS.utCustomRarities.length > 0);
                 put("mixins/tweaks/mixins.items.repairing.json", c -> UTConfigTweaks.ITEMS.utCraftingRepairToggle);
                 put("mixins/tweaks/mixins.items.xpbottle.json", c -> UTConfigTweaks.ITEMS.utXPBottleAmount != -1);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/usefulhoes/UTUsefulHoes.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/usefulhoes/UTUsefulHoes.java
@@ -1,0 +1,40 @@
+package mod.acgaming.universaltweaks.tweaks.items.usefulhoes;
+
+import mod.acgaming.universaltweaks.UniversalTweaks;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class UTUsefulHoes
+{
+    private static final Set<Block> HARVESTABLE_BLOCKS = new HashSet<>();
+
+    public static boolean canHarvestBlock(IBlockState state)
+    {
+        return HARVESTABLE_BLOCKS.contains(state.getBlock());
+    }
+
+    public static void initLists() {
+        HARVESTABLE_BLOCKS.clear();
+        for(String str : UTConfigTweaks.ITEMS.USEFUL_HOES.utHoeHarvestableBlocks)
+        {
+            Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(str));
+            if(block != null && block != Blocks.AIR)
+            {
+                HARVESTABLE_BLOCKS.add(block);
+            }
+            else
+            {
+                UniversalTweaks.LOGGER.error("No registered block found for {}", str);
+            }
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/items/usefulhoes/mixin/UTUsefulHoesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/items/usefulhoes/mixin/UTUsefulHoesMixin.java
@@ -1,0 +1,55 @@
+package mod.acgaming.universaltweaks.tweaks.items.usefulhoes.mixin;
+
+import mod.acgaming.universaltweaks.tweaks.items.usefulhoes.UTUsefulHoes;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemHoe;
+
+import net.minecraft.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ItemHoe.class)
+public class UTUsefulHoesMixin extends Item
+{
+    @Shadow protected ToolMaterial toolMaterial;
+
+    /**
+     * @author Invadermonky
+     * Allows hoes to have faster harvesting speed for whitelisted blocks.
+     */
+    @Override
+    public boolean canHarvestBlock(@NotNull IBlockState blockIn)
+    {
+        return super.canHarvestBlock(blockIn) || UTUsefulHoes.canHarvestBlock(blockIn);
+    }
+
+    /**
+     * @author Invadermonky
+     * Allows hoes to have faster harvesting speed for whitelisted blocks.
+     */
+    @Override
+    public float getDestroySpeed(@NotNull ItemStack stack, @NotNull IBlockState state)
+    {
+        if(UTUsefulHoes.canHarvestBlock(state))
+        {
+            return toolMaterial.getEfficiency();
+        }
+        return super.getDestroySpeed(stack, state);
+    }
+
+    /**
+     * @author Invadermonky
+     * Allows hoes to be enchanted with Efficiency to increase their harvest speed for whitelisted blocks.
+     */
+    @Override
+    public boolean canApplyAtEnchantingTable(@NotNull ItemStack stack, @NotNull Enchantment enchantment)
+    {
+        return enchantment == Enchantments.EFFICIENCY || super.canApplyAtEnchantingTable(stack, enchantment);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -211,6 +211,7 @@ cfg.universaltweaks.tweaks.items.infinity=Infinity
 cfg.universaltweaks.tweaks.items.itementities=Item Entities
 cfg.universaltweaks.tweaks.items.mending=Mending
 cfg.universaltweaks.tweaks.items.parry=Shield Parry
+cfg.universaltweaks.tweaks.items.usefulhoes=Useful Hoes
 cfg.universaltweaks.tweaks.misc.advancements=Advancements
 cfg.universaltweaks.tweaks.misc.advancementscreenshot=Advancement Screenshot
 cfg.universaltweaks.tweaks.misc.armorcurve=Armor Curve

--- a/src/main/resources/mixins/tweaks/mixins.items.usefulhoes.json
+++ b/src/main/resources/mixins/tweaks/mixins.items.usefulhoes.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.items.usefulhoes.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTUsefulHoesMixin"]
+}


### PR DESCRIPTION
Adds Hoe harvesting support for configurable blocks, a backported feature from Minecraft 1.16+. By default, this includes Hay Bales, Nether Wart Blocks, and Sponges.

Also adds support for enchanting Hoes with the Efficiency enchant, again backported from Minecraft 1.16+.