### PR TITLE
Add Cape Angle Clamp tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Burning Baby Zombies:** Lets baby zombies burn in daylight as in Minecraft 1.13+
 * **Burning Skeletons:** Prevents skeletons burning in daylight
 * **Burning Zombies:** Prevents zombies burning in daylight
+* **Cape Angle Clamp:** Limits player cape rotation to modern behavior at high movement speeds
 * **Cave Generation:** Sets custom values for the vanilla cave generation
 * **Charged Creeper Spawning:** Sets the chance for creepers to spawn charged
 * **Chat:**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -639,6 +639,11 @@ public class UTConfigTweaks
         public boolean utBurningZombiesToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Cape Angle Clamp")
+        @Config.Comment("Limits player cape rotation to modern behavior at high movement speeds")
+        public boolean utCapeAngleClamp = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Coyote Time Jumping")
         @Config.Comment("Lets the player jump a couple frames after stepping off a ledge, similar to jumping in many platformers")
         public boolean utCoyoteTimeJumpingToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -246,6 +246,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.blocks.hitdelay.json", c -> UTConfigTweaks.BLOCKS.utBlockHitDelay != 5);
                 put("mixins/tweaks/mixins.blocks.rotation.json", c -> UTConfigTweaks.BLOCKS.utUnlimitedBlockModelRotations);
                 put("mixins/tweaks/mixins.entities.burning.player.json", c -> UTConfigTweaks.ENTITIES.utFirstPersonBurningOverlay != -0.3D);
+                put("mixins/tweaks/mixins.entities.cape.json", c -> UTConfigTweaks.ENTITIES.utCapeAngleClamp);
                 put("mixins/tweaks/mixins.entities.jumping.autojump.json", c -> UTConfigTweaks.ENTITIES.utAutoJumpToggle);
                 put("mixins/tweaks/mixins.entities.playerdismount.json", c -> UTConfigTweaks.MISC.utUseSeparateDismountKey);
                 put("mixins/tweaks/mixins.entities.playerf5.json", c -> UTConfigTweaks.ENTITIES.utThirdPersonIgnoresNonSolidBlocks);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/cape/mixin/UTCapeAngleClampMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/entities/cape/mixin/UTCapeAngleClampMixin.java
@@ -1,0 +1,47 @@
+package mod.acgaming.universaltweaks.tweaks.entities.cape.mixin;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.renderer.entity.layers.LayerCape;
+import net.minecraft.util.math.MathHelper;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(LayerCape.class)
+public class UTCapeAngleClampMixin
+{
+    @ModifyVariable(
+        method = "doRenderLayer(Lnet/minecraft/client/entity/AbstractClientPlayer;FFFFFFF)V",
+        at = @At(value = "STORE", ordinal = 0),
+        ordinal = 9 // f2
+    )
+    private float utClampCapeLean(
+        float capeLean,
+        AbstractClientPlayer player,
+        float limbSwing,
+        float limbSwingAmount,
+        float partialTicks
+    )
+    {
+        if (!UTConfigTweaks.ENTITIES.utCapeAngleClamp) return capeLean;
+
+        float ticks = player.getTicksElytraFlying() + partialTicks;
+        float fallFlyingScale = MathHelper.clamp(ticks * ticks / 100.0F, 0.0F, 1.0F);
+        capeLean *= 1.0F - fallFlyingScale;
+        return MathHelper.clamp(capeLean, 0.0F, 150.0F);
+    }
+
+    @ModifyVariable(
+        method = "doRenderLayer(Lnet/minecraft/client/entity/AbstractClientPlayer;FFFFFFF)V",
+        at = @At(value = "STORE", ordinal = 0),
+        ordinal = 10 // f3
+    )
+    private float utClampCapeLean2(float capeLean2)
+    {
+        if (!UTConfigTweaks.ENTITIES.utCapeAngleClamp) return capeLean2;
+
+        return MathHelper.clamp(capeLean2, -20.0F, 20.0F);
+    }
+}

--- a/src/main/resources/mixins/tweaks/mixins.entities.cape.json
+++ b/src/main/resources/mixins/tweaks/mixins.entities.cape.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.entities.cape.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTCapeAngleClampMixin"]
+}


### PR DESCRIPTION
Improves visuals by limiting player cape rotation, matching modern Minecraft behavior.

Not tested yet in Universal Tweaks because the build script is broken, but I verified the mixin class separately in a small test mod and confirmed it works in both development and production environments.