### PR TITLE
Fluid transposer unstuck

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1550,6 +1550,11 @@ public class UTConfigMods
         @Config.Name("Duplication Fixes")
         @Config.Comment("Fixes various duplication exploits")
         public boolean utDuplicationFixesToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Fluid Transposer Stuck Fix")
+        @Config.Comment("Fixes the Fluid Transposer rarely getting stuck while auto-processing fluid containers by ejecting spent/unusable containers from the center slot so crafting can resume")
+        public boolean utTransposerStuckFixToggle = true;
     }
 
     public static class TinkersConstructCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -201,6 +201,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.testdummy.copyarmor.json", c -> c.isModPresent("testdummy") && UTConfigMods.TEST_DUMMY.utCopyArmor);
                 put("mixins/mods/mixins.thefarlanders.dupes.json", c -> c.isModPresent("farlanders") && UTConfigMods.THE_FARLANDERS.utDuplicationFixesToggle);
                 put("mixins/mods/mixins.thermalexpansion.dupes.json", c -> c.isModPresent("thermalexpansion") && UTConfigMods.THERMAL_EXPANSION.utDuplicationFixesToggle);
+                put("mixins/mods/mixins.thermalexpansion.transposer.json", c -> c.isModPresent("thermalexpansion") && UTConfigMods.THERMAL_EXPANSION.utTransposerStuckFixToggle);
                 put("mixins/mods/mixins.thermalexpansion.json", c -> c.isModPresent("thermalexpansion"));
                 put("mixins/mods/mixins.tinyprogressions.dupes.json", c -> c.isModPresent("tp") && UTConfigMods.TINY_PROGRESSIONS.utDuplicationFixesToggle);
                 put("mixins/mods/mixins.tombmanygraves.timestamp.json", c -> c.isModPresent("tombmanygraves") && UTConfigMods.TOMBMANYGRAVES.utISOTimestamp);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTTransposerStuckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTTransposerStuckMixin.java
@@ -3,6 +3,8 @@ package mod.acgaming.universaltweaks.mods.thermalexpansion.mixin;
 import cofh.core.fluid.FluidTankCore;
 import cofh.thermalexpansion.block.machine.TileMachineBase;
 import cofh.thermalexpansion.block.machine.TileTransposer;
+import cofh.thermalexpansion.util.managers.machine.TransposerManager;
+import cofh.thermalexpansion.util.managers.machine.TransposerManager.ContainerOverride;
 import mod.acgaming.universaltweaks.config.UTConfigMods;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -15,6 +17,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = TileTransposer.class, remap = false)
 public abstract class UTTransposerStuckMixin extends TileMachineBase {
@@ -57,6 +60,30 @@ public abstract class UTTransposerStuckMixin extends TileMachineBase {
             if (inventory[1] != processStack) {
                 markChunkDirty();
             }
+        }
+    }
+
+    /**
+     * The core problem is that the canStartHandler() checks only that the output slot holds the
+     * right item type, not that it has room. Starting a process whose converted container can no
+     * longer stack (output slot full) is what strands the spent container in the process slot. This
+     * now refuses to start until the output slot has headroom.
+     */
+    @Inject(method = "canStartHandler", at = @At("HEAD"), cancellable = true)
+    private void utTransposerOutputFullGuard(CallbackInfoReturnable<Boolean> cir) {
+        if (!UTConfigMods.THERMAL_EXPANSION.utTransposerStuckFixToggle) {
+            return;
+        }
+        if (inventory[1].isEmpty() || inventory[2].isEmpty()) {
+            return;
+        }
+        ContainerOverride override = TransposerManager.getContainerOverride(inventory[1]);
+        if (override == null) {
+            return;
+        }
+        if (inventory[2].isItemEqual(override.getOutput())
+            && inventory[2].getCount() + 1 > inventory[2].getMaxStackSize()) {
+            cir.setReturnValue(false);
         }
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTTransposerStuckMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/thermalexpansion/mixin/UTTransposerStuckMixin.java
@@ -1,0 +1,82 @@
+package mod.acgaming.universaltweaks.mods.thermalexpansion.mixin;
+
+import cofh.core.fluid.FluidTankCore;
+import cofh.thermalexpansion.block.machine.TileMachineBase;
+import cofh.thermalexpansion.block.machine.TileTransposer;
+import mod.acgaming.universaltweaks.config.UTConfigMods;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = TileTransposer.class, remap = false)
+public abstract class UTTransposerStuckMixin extends TileMachineBase {
+
+    @Shadow
+    public boolean extractMode;
+
+    @Shadow
+    private boolean hasFluidHandler;
+
+    @Shadow
+    private FluidTankCore tank;
+
+    @Shadow
+    protected abstract void transferHandler();
+
+    /**
+     * The center (in-process) slot is only emptied by transferHandler(), which is only reached from
+     * the active and finished path. If a fluid-handler item lands there that canStartHandler() can
+     * never satisfy, the idle branch never retries the move and the machine wedges until a player
+     * pulls the item out. This adds a flush to remove items during the machine's idle tick
+     * processing cycle. This doesn't prevent the problem, but it heals anything currently in the
+     * bad state. It's in a rarely hit code path, otherwise.
+     */
+    @Inject(method = "updateHandler", at = @At("TAIL"))
+    private void utTransposerUnstick(CallbackInfo ci) {
+        if (!UTConfigMods.THERMAL_EXPANSION.utTransposerStuckFixToggle || world.isRemote) {
+            return;
+        }
+        if (isActive || !hasFluidHandler || inventory[1].isEmpty() || !redstoneControlOrDisable()
+            || !timeCheckEighth()) {
+            return;
+        }
+        if (ut$isHandlerSpent()) {
+            // transferHandler() may re-fill the process slot from the input slot, so hasFluidHandler is
+            // not a reliable "did anything move" signal.
+            // However, the process slot reference only changes on a real transfer.
+            ItemStack processStack = inventory[1];
+            transferHandler();
+            if (inventory[1] != processStack) {
+                markChunkDirty();
+            }
+        }
+    }
+
+    /**
+     * True only when the item in the process slot can never be processed in the current mode
+     * (already full/wrong fluid in fill mode, empty container in extract mode) - not merely waiting
+     * on energy, output space, or tank state.
+     */
+    @Unique
+    private boolean ut$isHandlerSpent() {
+        IFluidHandlerItem handler = inventory[1].getCapability(
+            CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (handler == null) {
+            return false;
+        }
+        if (!extractMode) {
+            return tank.getFluidAmount() > 0
+                && handler.fill(new FluidStack(tank.getFluid(), Fluid.BUCKET_VOLUME), false) <= 0;
+        }
+        FluidStack drainStack = handler.drain(Fluid.BUCKET_VOLUME, false);
+        return tank.getSpace() > 0 && drainStack == null;
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.thermalexpansion.transposer.json
+++ b/src/main/resources/mixins/mods/mixins.thermalexpansion.transposer.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.thermalexpansion.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTTransposerStuckMixin"]
+}


### PR DESCRIPTION
Fixes the infamous Thermal Fluid Transposer becoming stuck when used in a passive style operation.

Primarily the problem is that it does not check for sufficient headroom for the recipe result in one of the branches in canStartHandler.

This comprises of two fixes. The bigger fix is the heal - this needs custom handling to repair any existing Transposers that got themselves into this state. 

The prevention fix then prevents any future Transposers from getting into this state by checking for space before operating.