### PR TITLE
Running the build with Java 21, mod still compiled with Java 8 as per toolchain

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: |
+            21
           cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
Looks like Cloudflare was blocking the user agent if it was run from Java 8.

