### PR TITLE
Fix Bewitchment altar property remapping

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/mods/bewitchment/mixin/UTTileEntityWitchesAltarMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/bewitchment/mixin/UTTileEntityWitchesAltarMixin.java
@@ -21,7 +21,7 @@ public class UTTileEntityWitchesAltarMixin
      * See <a href="https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.12.x/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLeavesTFC.java#L59">BlockLeavesTFC.java</a>
      */
     @SuppressWarnings("MixinExtrasOperationParameters")
-    @WrapOperation(method = "convert", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/IBlockState;withProperty(Lnet/minecraft/block/properties/IProperty;Ljava/lang/Comparable;)Lnet/minecraft/block/state/IBlockState;"))
+    @WrapOperation(method = "convert", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/state/IBlockState;withProperty(Lnet/minecraft/block/properties/IProperty;Ljava/lang/Comparable;)Lnet/minecraft/block/state/IBlockState;", remap = true))
     private <T extends Comparable<T>, V extends T> IBlockState utCheckPropertyExists(IBlockState instance, IProperty<T> property, V value, Operation<IBlockState> original)
     {
         if (instance.getPropertyKeys().contains(property)) return original.call(instance, property, value);


### PR DESCRIPTION
Fixes #880.

The Bewitchment mixin targets a mod class with `remap = false`. Because the nested `@At` targets Minecraft's `IBlockState.withProperty`, it inherited that false value. This prevented the generated refmap from mapping the call to its SRG name, and the wrapper missed every `withProperty` call in production.

This change enables remapping for that nested `@At` only. The refmap now links `withProperty` to `func_177226_a`. Other Bewitchment targets remain unchanged.

I tested this with stock Bewitchment and a copy of the world from the report:

- Official Universal Tweaks 1.20.1 reproduced the `randomthings:spectrelog` crash five seconds after startup.
- The patched build wrapped all four `withProperty` calls in the exported runtime class.
- Five cold starts and a ten-minute soak finished without the altar crash.
- Forge registries, player data, advancements, statistics, dimensions, and region count were unchanged.
- Gradle passed on Java 21 while keeping the project's Java 8 target.

Testing ran in network-isolated local containers. The live server stayed online and wasn't used for reproduction.

Thanks to @jchung01 for identifying the missing remap override in #880.
