### PR TITLE
Backport Immersive Engineering Crusher process queue sync fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **HWYLA**
     * **Keybindings Fix:** Fixes crashes in all menus when changing HWYLA keybindings to unsupported values
 * **Immersive Engineering**
+    * **Crusher Process Queue Sync Fix:** Prevents Crushers from repeatedly synchronizing and reconstructing their full process queue on clients
     * **Tool Break Fire Event:** Fires the PlayerDestroyItemEvent when an Immersive Engineering tool breaks, fixing a number of cross-compatibility issues
     * **Tool Break Hand Replacement:** Fixes the tool breaking setting the main hand to empty regardless of what hand the tool is in
 * **In Control!**

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1072,11 +1072,11 @@ public class UTConfigMods
 
         @Config.RequiresMcRestart
         @Config.Name("Crusher Process Queue Sync Fix")
-        @Config.Comment
-            ({
-                "Prevents Immersive Engineering Crushers from synchronizing their full process queue to clients",
-                "Backports the later Immersive Engineering behavior of synchronizing only the render-active state"
-            })
+        @Config.Comment({
+            "Prevents Immersive Engineering Crushers from synchronizing their full process queue to clients",
+            "Synchronizes the Crusher's render-active state separately instead",
+            "This option must have the same value on the client and server for rendering and sound to work correctly"
+        })
         public boolean utCrusherSyncFix = true;
     }
 
@@ -1762,5 +1762,4 @@ public class UTConfigMods
             }
         }
     }
-
 }

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1069,6 +1069,15 @@ public class UTConfigMods
         @Config.Name("Tool Break Hand Replacement")
         @Config.Comment("Fixes the tool breaking setting the main hand to empty regardless of what hand the tool is in")
         public boolean utFixIncorrectHandReplacement = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Crusher Process Queue Sync Fix")
+        @Config.Comment
+            ({
+                "Prevents Immersive Engineering Crushers from synchronizing their full process queue to clients",
+                "Backports the later Immersive Engineering behavior of synchronizing only the render-active state"
+            })
+        public boolean utCrusherSyncFix = true;
     }
 
     public static class InControlCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -145,6 +145,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.forestry.extratrees.json", c -> c.isModPresent("extratrees") && UTConfigMods.FORESTRY.utFOGatherWindfallToggle);
                 put("mixins/mods/mixins.forestry.json", c -> c.isModPresent("forestry"));
                 put("mixins/mods/mixins.gaiadimension.restructurer.json", c -> c.isModPresent("gaiadimension") && UTConfigMods.GAIA_DIMENSION.utFixNPERestructurerRecipe);
+                put("mixins/mods/mixins.immersiveengineering.crushersync.json", c -> c.isModPresent("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utCrusherSyncFix);
                 put("mixins/mods/mixins.immersiveengineering.toolevent.json", c -> c.isModPresent("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utFireBreakEvent);
                 put("mixins/mods/mixins.immersiveengineering.toolhand.json", c -> c.isModPresent("immersiveengineering") && UTConfigMods.IMMERSIVE_ENGINEERING.utFixIncorrectHandReplacement);
                 put("mixins/mods/mixins.incontrol.rule.json", c -> regularInControlLoaded() && UTConfigMods.INCONTROL.utStatsFixToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/crushersync/mixin/UTIECrusherSyncMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/immersivenegineering/crushersync/mixin/UTIECrusherSyncMixin.java
@@ -1,0 +1,208 @@
+package mod.acgaming.universaltweaks.mods.immersivenegineering.crushersync.mixin;
+
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCrusher;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMultiblockMetal;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Collections;
+import java.util.List;
+
+@Mixin(
+    value = TileEntityMultiblockMetal.class,
+    remap = false
+)
+@SuppressWarnings("rawtypes")
+public abstract class UTIECrusherSyncMixin
+{
+    /*
+     Description-packet-only field.
+     This is deliberately not written to world-save NBT. On load, the
+     server recalculates it from the authoritative process state.
+     */
+    @Unique
+    private static final String ut$RENDER_ACTIVE_NBT =
+        "ut_ie_crusher_render_active";
+
+
+    //Shared empty list used only while reading Crusher description packets.
+    @Unique
+    private static final NBTTagList ut$EMPTY_PROCESS_QUEUE =
+        new NBTTagList();
+
+    /*
+     Conservative default for a not-yet-synchronized Crusher.
+     Server: last synchronized active state.
+     Client: active state received from the server.
+     */
+    @Unique
+    private boolean ut$crusherRenderActive;
+
+    @Unique
+    private boolean ut$isCrusher()
+    {return (Object) this instanceof TileEntityCrusher;}
+
+    @Unique
+    private boolean ut$isCrusherDescriptionPacket(boolean descPacket)
+    {return descPacket && ut$isCrusher();}
+
+     //Omit the Crusher process queue from description packets.
+     //World-save NBT uses descPacket == false and remains unchanged.
+    @ModifyExpressionValue(
+        method =
+            "writeCustomNBT" + "(Lnet/minecraft/nbt/NBTTagCompound;Z)V",
+        at = @At(
+            value = "FIELD",
+            target = "Lblusunrize/immersiveengineering/common/blocks/"
+                    + "metal/TileEntityMultiblockMetal;"
+                    + "processQueue:Ljava/util/List;",
+            opcode = Opcodes.GETFIELD,
+            remap = false
+        ),
+        remap = false,
+        require = 1
+    )
+    private List ut$omitCrusherQueueFromDescriptionPacket(
+        List original,
+        NBTTagCompound nbt,
+        boolean descPacket
+    )
+    {
+        if (ut$isCrusherDescriptionPacket(descPacket))
+        {return Collections.emptyList();}
+        return original;
+    }
+
+    //Prevent the client from reconstructing Crusher processes and recipes
+    //from description-packet NBT.
+    @ModifyExpressionValue(
+        method =
+            "readCustomNBT"
+                + "(Lnet/minecraft/nbt/NBTTagCompound;Z)V",
+        at = @At(
+            value = "INVOKE",
+            target =
+                "Lnet/minecraft/nbt/NBTTagCompound;"
+                    + "getTagList(Ljava/lang/String;I)"
+                    + "Lnet/minecraft/nbt/NBTTagList;",
+            remap = true
+        ),
+        remap = false,
+        require = 1
+    )
+    private NBTTagList ut$ignoreCrusherQueueFromDescriptionPacket(
+        NBTTagList original,
+        NBTTagCompound nbt,
+        boolean descPacket
+    )
+    {
+        if (ut$isCrusherDescriptionPacket(descPacket))
+        {return ut$EMPTY_PROCESS_QUEUE;}
+        return original;
+    }
+
+    //Add the compact render-active state to Crusher description packets.
+    @Inject(
+        method =
+            "writeCustomNBT"
+                + "(Lnet/minecraft/nbt/NBTTagCompound;Z)V",
+        at = @At("RETURN"),
+        remap = false,
+        require = 1
+    )
+    private void ut$writeCrusherRenderState(
+        NBTTagCompound nbt,
+        boolean descPacket,
+        CallbackInfo ci
+    )
+    {
+        if (ut$isCrusherDescriptionPacket(descPacket))
+        {
+            nbt.setBoolean(
+                ut$RENDER_ACTIVE_NBT,
+                ut$crusherRenderActive
+            );
+        }
+    }
+
+
+    //Receive the render-active state from Crusher description packets.
+    @Inject(
+        method =
+            "readCustomNBT"
+                + "(Lnet/minecraft/nbt/NBTTagCompound;Z)V",
+        at = @At("RETURN"),
+        remap = false,
+        require = 1
+    )
+    private void ut$readCrusherRenderState(
+        NBTTagCompound nbt,
+        boolean descPacket,
+        CallbackInfo ci
+    )
+    {
+        if (ut$isCrusherDescriptionPacket(descPacket))
+        {
+            ut$crusherRenderActive =
+                nbt.getBoolean(ut$RENDER_ACTIVE_NBT);
+        }
+    }
+
+    //Synchronize changes in IE's original shouldRenderAsActive() result.
+    @Inject(
+        method = "update()V",
+        at = @At("HEAD"),
+        remap = true,
+        require = 1
+    )
+    private void ut$syncCrusherRenderState(CallbackInfo ci)
+    {
+        if (!ut$isCrusher())
+        {return;}
+
+        TileEntityMultiblockMetal self =
+            (TileEntityMultiblockMetal) (Object) this;
+
+        World world = self.getWorld();
+        if (world == null || world.isRemote || self.isDummy())
+        {return;}
+
+        boolean renderActive = self.shouldRenderAsActive();
+        if (ut$crusherRenderActive == renderActive)
+        {return;}
+        ut$crusherRenderActive = renderActive;
+        self.updateMasterBlock(null, true);
+    }
+
+    //The client queue is intentionally empty, so use the state synchronized
+    //by the server instead of deriving rendering state from processQueue.
+    @Inject(
+        method = "shouldRenderAsActive()Z",
+        at = @At("HEAD"),
+        cancellable = true,
+        remap = false,
+        require = 1
+    )
+    private void ut$useSyncedCrusherRenderState(
+        CallbackInfoReturnable<Boolean> cir
+    )
+    {
+        if (!ut$isCrusher())
+        {return;}
+        TileEntityMultiblockMetal self =
+            (TileEntityMultiblockMetal) (Object) this;
+
+        World world = self.getWorld();
+        if (world != null && world.isRemote)
+        {cir.setReturnValue(ut$crusherRenderActive);}
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.immersiveengineering.crushersync.json
+++ b/src/main/resources/mixins/mods/mixins.immersiveengineering.crushersync.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.immersivenegineering.crushersync.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTIECrusherSyncMixin"]
+}


### PR DESCRIPTION
Backports the later Immersive Engineering Crusher synchronization fix to Minecraft 1.12.2.

IE 0.12-98 synchronizes the Crusher's full process queue to clients. The client then reconstructs every queued process and resolves its recipe from NBT, causing substantial client-thread load in large modpacks.

This patch:

- stops Crushers from syncing their full process queue to clients;
- keeps the full queue for world saves;
- syncs only the render-active state;
- leaves processing, recipes, energy, redstone, inputs and outputs unchanged.

## Upstream fixes

Original fix, on the newer 1.18 codebase:  
[`7d76b1c` — Allow multiblocks to opt out of syncing the process queue to the client, and sync active state independently](https://github.com/BluSunrize/ImmersiveEngineering/commit/7d76b1c5b2e675f8558277d8276fc45a85fc33f1)

Official 1.16.5 backport:  
[`68816c8` — Backport: Allow multiblocks to opt out of syncing the process queue to the client, and sync active state independently](https://github.com/BluSunrize/ImmersiveEngineering/commit/68816c893ac1422ce32a5ff6eeef73f997e6d245)

Both close the original report:

[Issue #5077 — Degraded FPS when crushers are being overloaded with items](https://github.com/BluSunrize/ImmersiveEngineering/issues/5077)

## Profiling
same conditions, multiple profiles. 
`/sparkc profiler --interval 1 --timeout 60`

Before:

<img width="1003" height="479" alt="fked" src="https://github.com/user-attachments/assets/cd59379a-25a5-466a-8c1c-4b867f5557f1" />

After:
<img width="1169" height="247" alt="fixed" src="https://github.com/user-attachments/assets/937aa7e3-7f08-4c0e-ab5f-43c59bf4a057" />
