### PR TITLE
Implement Locate Click to Teleport tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Connection Timeouts:** Allows configuring read/login timeouts
     * Helps slow clients log into a server of a large modpack
 * **Copy World Seed:** Enables clicking of `/seed` world seed in chat to copy to clipboard
+* **Locate Click to Teleport:** Enables clicking of `/locate` coordinates in chat to teleport to that location
 * **Coyote Time Jumping:** Lets the player jump a couple frames after stepping off a ledge, similar to jumping in many platformers
 * **Crafting Cache:** Adds an IRecipe cache to improve recipe performance in large modpacks
 * **Creeper Confetti:** Replaces deadly creeper explosions with delightful confetti (with a configurable chance)

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1916,6 +1916,15 @@ public class UTConfigTweaks
         public boolean utCopyWorldSeedToggle = true;
 
         @Config.RequiresMcRestart
+        @Config.Name("Locate Click to Teleport")
+        @Config.Comment
+            ({
+                "Enables clicking of `/locate` coordinates in chat to teleport to that location",
+                "Required on server AND client"
+            })
+        public boolean utLocateTeleportToggle = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Damage Tilt")
         @Config.Comment("Restores feature to tilt the camera when damaged")
         public boolean utDamageTiltToggle = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTLoadingPlugin.java
@@ -173,6 +173,7 @@ public class UTLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader
                 put("mixins/tweaks/mixins.misc.armorcurve.json", c -> !c.inDev() && UTConfigTweaks.MISC.ARMOR_CURVE.utArmorCurveToggle);
                 put("mixins/tweaks/mixins.misc.armorswap.json", c -> UTConfigTweaks.MISC.utArmorSwap);
                 put("mixins/tweaks/mixins.misc.bannerlayers.json", c -> UTConfigTweaks.MISC.utBannerLayers != 6);
+                put("mixins/tweaks/mixins.misc.commands.locate.json", c -> UTConfigTweaks.MISC.utLocateTeleportToggle);
                 put("mixins/tweaks/mixins.misc.commands.seed.json", c -> UTConfigTweaks.MISC.utCopyWorldSeedToggle);
                 put("mixins/tweaks/mixins.misc.commands.time.json", c -> UTConfigTweaks.MISC.TIME_COMMAND.utTimeCommandToggle);
                 put("mixins/tweaks/mixins.misc.difficulty.singleplayer.json", c -> true);

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/locate/mixin/UTFormatLocateMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/commands/locate/mixin/UTFormatLocateMixin.java
@@ -1,0 +1,53 @@
+package mod.acgaming.universaltweaks.tweaks.misc.commands.locate.mixin;
+
+import net.minecraft.command.CommandLocate;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.*;
+import net.minecraft.util.text.event.ClickEvent;
+import net.minecraft.util.text.event.HoverEvent;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mod.acgaming.universaltweaks.UniversalTweaks;
+import mod.acgaming.universaltweaks.config.UTConfigGeneral;
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(CommandLocate.class)
+public class UTFormatLocateMixin
+{
+    /**
+     * @author atferrys
+     * @reason Replaces the original "success" {@link ITextComponent} with one the player can
+     * click to teleport to that specific location. Also appends the distance to that structure.
+     */
+    @WrapOperation(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/ICommandSender;sendMessage(Lnet/minecraft/util/text/ITextComponent;)V"))
+    private void utFormatLocateMessage(ICommandSender sender, ITextComponent message, Operation<Void> original)
+    {
+        if (UTConfigTweaks.MISC.utLocateTeleportToggle)
+        {
+            if (UTConfigGeneral.DEBUG.utDebugToggle) UniversalTweaks.LOGGER.debug("UTFormatLocateMixin :: Format locate");
+
+            Object[] args = ((TextComponentTranslation) message).getFormatArgs();
+
+            String structureName = (String) args[0];
+            int x = (int) args[1];
+            int z = (int) args[2];
+
+            ITextComponent coordsComponent = new TextComponentString(String.format("[%d, ~, %d]", x, z));
+            Style coordsStyle = coordsComponent.getStyle();
+            coordsStyle.setColor(TextFormatting.GREEN);
+            coordsStyle.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentTranslation("cmd.universaltweaks.locate.tooltip")));
+            coordsStyle.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, String.format("/tp @s %d ~ %d", x, z)));
+
+            BlockPos senderPos = sender.getPosition();
+            int distance = (int) senderPos.getDistance(x, senderPos.getY(), z);
+
+            original.call(sender, new TextComponentTranslation("cmd.universaltweaks.locate", structureName, coordsComponent, distance));
+            return;
+        }
+        original.call(sender, message);
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -55,6 +55,10 @@ item.notreepunching:rock.basalt.name=Basalt Rock
 # TIME COMMAND
 cmd.universaltweaks.time.set=DIM %s: Set the time to %s
 
+# LOCATE COMMAND
+cmd.universaltweaks.locate=Located %s at %s (%s blocks away)
+cmd.universaltweaks.locate.tooltip=Click to teleport
+
 # VANILLA
 enchantment.level.11=XI
 enchantment.level.12=XII

--- a/src/main/resources/mixins/tweaks/mixins.misc.commands.locate.json
+++ b/src/main/resources/mixins/tweaks/mixins.misc.commands.locate.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.commands.locate.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTFormatLocateMixin"]
+}


### PR DESCRIPTION
Improves the `/locate` command, enabling the player to click on the coordinates to teleport to that structure's location. Also appends the number of blocks of distance like in newer versions:

<img width="2560" height="1440" alt="java_cH7osVaXpF" src="https://github.com/user-attachments/assets/b77b47a2-f1bc-4013-acd7-b77a6e7a43c8" />

All the messages can be translated via language keys