### PR TITLE
Implement Fast Ladder Climbing tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Explosion Block Drop Chance:** Determines the numerator of the block drop formula on explosions
 * **Falling Block Lifespan:** Determines how long falling blocks remain in ticks until they are dropped under normal circumstances
 * **Fast Dye Blending:** Replaces color lookup for sheep to check a predefined table rather than querying the recipe registry
+* **Fast Ladder Climbing:** Allows customization of up and down speeds when climbing ladders
 * **Fast Leaf Decay:** Makes leaves decay faster when trees are chopped
 * **Fast Prefix Checking:** Optimizes Forge's ID prefix checking and removes prefix warnings impacting load time
 * **Fast World Loading:** Skips garbage collection to speed up world loading

--- a/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/UniversalTweaks.java
@@ -1,5 +1,6 @@
 package mod.acgaming.universaltweaks;
 
+import mod.acgaming.universaltweaks.tweaks.blocks.fastladderclimbing.UTFastLadderClimbing;
 import mod.acgaming.universaltweaks.tweaks.blocks.paths.UTDirtToPath;
 import mod.acgaming.universaltweaks.tweaks.entities.villagerharvest.UTVillagerHarvestUtils;
 
@@ -277,6 +278,7 @@ public class UniversalTweaks
             if (UTConfigTweaks.BLOCKS.FINITE_WATER.utFiniteWaterToggle) MinecraftForge.EVENT_BUS.register(UTFiniteWater.class);
             if (UTConfigTweaks.BLOCKS.utBetterHarvestToggle) MinecraftForge.EVENT_BUS.register(UTBetterHarvest.class);
             if (UTConfigTweaks.BLOCKS.utDirtToPath) MinecraftForge.EVENT_BUS.register(UTDirtToPath.class);
+            if (UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utFastLadderClimbingToggle) MinecraftForge.EVENT_BUS.register(UTFastLadderClimbing.class);
             if (UTConfigTweaks.BLOCKS.utSlimeBlockProjectiles) MinecraftForge.EVENT_BUS.register(UTSlimeBlockProjectiles.class);
             if (UTConfigTweaks.ENTITIES.CHICKEN_SHEDDING.utChickenSheddingToggle) MinecraftForge.EVENT_BUS.register(UTChickenShedding.class);
             if (UTConfigTweaks.ENTITIES.EASY_BREEDING.utEasyBreedingToggle) MinecraftForge.EVENT_BUS.register(UTEasyBreeding.class);

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -163,6 +163,10 @@ public class UTConfigTweaks
         @Config.Name("Sapling Behavior")
         public final SaplingBehaviorCategory SAPLING_BEHAVIOR = new SaplingBehaviorCategory();
 
+        @Config.LangKey("cfg.universaltweaks.tweaks.blocks.fastladderclimbing")
+        @Config.Name("Fast Ladder Climbing")
+        public final FastLadderClimbingCategory FAST_LADDER_CLIMBING = new FastLadderClimbingCategory();
+
         @Config.RequiresMcRestart
         @Config.Name("Better Rail Placement")
         @Config.Comment("Implements an improved system that makes rails face the player when placed")
@@ -514,6 +518,32 @@ public class UTConfigTweaks
                 })
             @Config.RangeDouble(min = 0.0D, max = 1.0D)
             public double utSaplingGrowthChance = 0.125D;
+        }
+
+        public static class FastLadderClimbingCategory
+        {
+            @Config.RequiresMcRestart
+            @Config.Name("[1] Fast Ladder Climbing Toggle")
+            @Config.Comment("Allows customization of up and down speeds when climbing ladders")
+            public boolean utFastLadderClimbingToggle = false;
+
+            @Config.Name("[2] Enable Fast Ascent")
+            @Config.Comment("Enables the custom speed increment when going up a ladder")
+            public boolean utEnableFastAscent = true;
+
+            @Config.Name("[3] Ascent Speed Modifier")
+            @Config.Comment("Increments the speed of going up a ladder")
+            @Config.RangeDouble(min = 0.0D, max = 1.0D)
+            public double utAscentSpeedModifier = 0.3D;
+
+            @Config.Name("[4] Enable Fast Descent")
+            @Config.Comment("Enables the custom speed increment when going down a ladder")
+            public boolean utEnableFastDescent = true;
+
+            @Config.Name("[5] Descent Speed Modifier")
+            @Config.Comment("Increments the speed of going down a ladder")
+            @Config.RangeDouble(min = 0.0D, max = 1.0D)
+            public double utDescentSpeedModifier = 0.3D;
         }
     }
 

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/fastladderclimbing/UTFastLadderClimbing.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/blocks/fastladderclimbing/UTFastLadderClimbing.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.tweaks.blocks.fastladderclimbing;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+
+import net.minecraft.entity.MoverType;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class UTFastLadderClimbing
+{
+    @SubscribeEvent
+    public static void utOnPlayerClimb(LivingEvent.LivingUpdateEvent event) {
+
+        if(!(event.getEntityLiving() instanceof EntityPlayer)) return;
+
+        EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+
+        if(!player.isOnLadder() || player.isSneaking()) return;
+
+        if(UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utEnableFastAscent && player.rotationPitch < 0 && player.moveForward > 0)
+        {
+            player.move(MoverType.SELF, 0, verticalMovement(player, UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utAscentSpeedModifier), 0);
+        }
+        else if(UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utEnableFastDescent && player.rotationPitch > 0 && player.moveForward == 0)
+        {
+            player.move(MoverType.SELF, 0, -verticalMovement(player, UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utDescentSpeedModifier), 0);
+        }
+
+    }
+
+    private static double verticalMovement(EntityPlayer player, double speedModifier) {
+        return Math.abs(player.rotationPitch / 90.0D) * speedModifier;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
+++ b/src/main/java/mod/acgaming/universaltweaks/util/compat/UTObsoleteModsHandler.java
@@ -173,6 +173,7 @@ public class UTObsoleteModsHandler
                 put("unridekeybind", () -> UTConfigTweaks.MISC.utUseSeparateDismountKey);
                 put("voidfog", () -> UTConfigTweaks.WORLD.VOID_FOG.utVoidFogToggle);
                 put("watercontrolextreme", () -> UTConfigTweaks.BLOCKS.FINITE_WATER.utFiniteWaterToggle);
+                put("fasterladderclimbing", () -> UTConfigTweaks.BLOCKS.FAST_LADDER_CLIMBING.utFastLadderClimbingToggle);
             }
 
             put("bedpatch", () -> true); // Fix integrated in Forge 14.23.2.2643 (#4784)

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -190,6 +190,7 @@ cfg.universaltweaks.tweaks.blocks.finitewater=Finite Water
 cfg.universaltweaks.tweaks.blocks.overhaulbeacon=Overhaul Beacon
 cfg.universaltweaks.tweaks.blocks.piston=Piston
 cfg.universaltweaks.tweaks.blocks.sapling=Sapling Behavior
+cfg.universaltweaks.tweaks.blocks.fastladderclimbing=Fast Ladder Climbing
 cfg.universaltweaks.tweaks.entities.arrowlayers=Arrow Layers
 cfg.universaltweaks.tweaks.entities.attributes=Attributes
 cfg.universaltweaks.tweaks.entities.betterburning=Better Burning


### PR DESCRIPTION
Allows customization of ascent and descent speeds when climbing ladders (and looking in the appropriate direction). Disabled by default.

This tweak deprecates [Faster Ladder Climbing](https://www.curseforge.com/minecraft/mc-mods/faster-ladder-climbing).

Closes https://github.com/ACGaming/UniversalTweaks/discussions/606