### PR TITLE
Set fake player context in Cyclic memory leak fix

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -111,7 +111,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.compactmachines.spawns.json", c -> c.isModPresent("compactmachines3") && UTConfigMods.COMPACT_MACHINES.utAllowedSpawnsImprovementToggle);
                 put("mixins/mods/mixins.cookingforblockheads.json", c -> c.isModPresent("cookingforblockheads") && UTConfigMods.COOKING_FOR_BLOCKHEADS.utOvenFixToggle);
                 put("mixins/mods/mixins.cqrepoured.json", c -> c.isModPresent("cqrepoured"));
-                put("mixins/mods/mixins.cyclic.json", c -> c.isModPresent("cyclicmagic") && UTConfigMods.CYCLIC.utMemoryLeakFixToggle);
+                put("mixins/mods/mixins.cyclic.memory.json", c -> c.isModPresent("cyclicmagic") && UTConfigMods.CYCLIC.utMemoryLeakFixToggle);
                 put("mixins/mods/mixins.dankstorage.json", c -> c.isModPresent("dankstorage"));
                 put("mixins/mods/mixins.divinerpg.aquamarine.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixAquamarineStackSize);
                 put("mixins/mods/mixins.divinerpg.armorset.json", c -> c.isModPresent("divinerpg") && UTConfigMods.DIVINE_RPG.utFixArmorSetCleanup);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/UTFakePlayerContext.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/UTFakePlayerContext.java
@@ -1,0 +1,90 @@
+package mod.acgaming.universaltweaks.mods.cyclic.memory;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import javax.annotation.Nonnull;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.util.FakePlayer;
+
+import com.google.common.base.Preconditions;
+
+import org.jetbrains.annotations.Nullable;
+
+public class UTFakePlayerContext extends WeakReference<FakePlayer>
+{
+    @Nullable
+    private final WeakReference<WorldServer> worldRef;
+    @Nonnull
+    private final BlockPos pos;
+
+    private UTFakePlayerContext(FakePlayer referent)
+    {
+        super(referent);
+        worldRef = null;
+        pos = BlockPos.ORIGIN;
+    }
+
+    private UTFakePlayerContext(FakePlayer referent, ReferenceQueue<? super FakePlayer> q)
+    {
+        super(referent, q);
+        worldRef = null;
+        pos = BlockPos.ORIGIN;
+    }
+
+    private UTFakePlayerContext(FakePlayer referent, @Nonnull WorldServer world, @Nonnull BlockPos pos)
+    {
+        super(referent);
+        this.worldRef = new WeakReference<>(world);
+        this.pos = pos;
+    }
+
+    /**
+     * Wraps a weak reference to a fake player with world context.
+     *
+     * @param fakePlayer the weak reference to the fake player
+     * @param world      the world
+     * @param pos        position in the world
+     * @return A weak reference to the fake player that sets the world context when calling {@link #get()}.
+     */
+    public static UTFakePlayerContext wrap(WeakReference<FakePlayer> fakePlayer, World world, BlockPos pos)
+    {
+        Preconditions.checkArgument(world instanceof WorldServer);
+
+        return new UTFakePlayerContext(fakePlayer.get(), (WorldServer) world, pos);
+    }
+
+    @Nullable
+    @Override
+    public FakePlayer get()
+    {
+        FakePlayer fakePlayer = super.get();
+        if (fakePlayer != null && worldRef != null)
+        {
+            WorldServer world = worldRef.get();
+            if (world != null)
+            {
+                setContext(fakePlayer, world, pos);
+            }
+        }
+        return fakePlayer;
+    }
+
+    /**
+     * Set the world context for a fake player.
+     * Always call this before using the fake player.
+     *
+     * @param world the world
+     * @param pos   position in the world
+     */
+    public static void setContext(FakePlayer fakePlayer, WorldServer world, BlockPos pos)
+    {
+        fakePlayer.setWorld(world);
+        fakePlayer.interactionManager.setWorld(world);
+        fakePlayer.posX = pos.getX();
+        fakePlayer.posY = pos.getY();
+        fakePlayer.posZ = pos.getZ();
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTBlockSpikesRetractableMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTBlockSpikesRetractableMixin.java
@@ -1,0 +1,35 @@
+package mod.acgaming.universaltweaks.mods.cyclic.memory.mixin;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.util.FakePlayer;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.lothrazar.cyclicmagic.block.BlockSpikesRetractable;
+import mod.acgaming.universaltweaks.mods.cyclic.memory.UTFakePlayerContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = BlockSpikesRetractable.class)
+public class UTBlockSpikesRetractableMixin
+{
+    @Definition(id = "causePlayerDamage", method = "Lnet/minecraft/util/DamageSource;causePlayerDamage(Lnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/util/DamageSource;")
+    @Expression("causePlayerDamage(@(?))")
+    @ModifyExpressionValue(method = "onEntityCollision", at = @At(value = "MIXINEXTRAS:EXPRESSION"))
+    private EntityPlayer utSetFakePlayerContext(EntityPlayer original, World worldIn, BlockPos pos)
+    {
+        Preconditions.checkArgument(worldIn instanceof WorldServer);
+
+        if (original instanceof FakePlayer)
+        {
+            // Set context directly because fake player is transient
+            UTFakePlayerContext.setContext((FakePlayer) original, (WorldServer) worldIn, pos);
+        }
+        return original;
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTileEntityBlockMinerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTileEntityBlockMinerMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.cyclic.memory.mixin;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.FakePlayer;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.lothrazar.cyclicmagic.block.miner.TileEntityBlockMiner;
+import mod.acgaming.universaltweaks.mods.cyclic.memory.UTFakePlayerContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = TileEntityBlockMiner.class)
+public class UTTileEntityBlockMinerMixin extends TileEntity
+{
+    @ModifyExpressionValue(method = "update", at = @At(value = "INVOKE", target = "Lcom/lothrazar/cyclicmagic/util/UtilFakePlayer;initFakePlayer(Lnet/minecraft/world/WorldServer;Ljava/util/UUID;Ljava/lang/String;)Ljava/lang/ref/WeakReference;", remap = false))
+    private WeakReference<FakePlayer> utSetFakePlayerContext(WeakReference<FakePlayer> original)
+    {
+        return UTFakePlayerContext.wrap(original, getWorld(), getPos());
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTileEntityUserMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTileEntityUserMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.cyclic.memory.mixin;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.FakePlayer;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.lothrazar.cyclicmagic.block.autouser.TileEntityUser;
+import mod.acgaming.universaltweaks.mods.cyclic.memory.UTFakePlayerContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = TileEntityUser.class, remap = false)
+public class UTTileEntityUserMixin extends TileEntity
+{
+    @ModifyExpressionValue(method = "setupBeforeTrigger", at = @At(value = "INVOKE", target = "Lcom/lothrazar/cyclicmagic/util/UtilFakePlayer;initFakePlayer(Lnet/minecraft/world/WorldServer;Ljava/util/UUID;Ljava/lang/String;)Ljava/lang/ref/WeakReference;"))
+    private WeakReference<FakePlayer> utSetFakePlayerContext(WeakReference<FakePlayer> original)
+    {
+        return UTFakePlayerContext.wrap(original, getWorld(), getPos());
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTilesVerifyingFakePlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTTilesVerifyingFakePlayerMixin.java
@@ -1,0 +1,32 @@
+package mod.acgaming.universaltweaks.mods.cyclic.memory.mixin;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.FakePlayer;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.lothrazar.cyclicmagic.block.buildershape.TileEntityStructureBuilder;
+import com.lothrazar.cyclicmagic.block.buildplacer.TileEntityPlacer;
+import com.lothrazar.cyclicmagic.block.controlledminer.TileEntityControlledMiner;
+import com.lothrazar.cyclicmagic.block.fluiddrain.TileEntityFluidDrain;
+import com.lothrazar.cyclicmagic.block.forester.TileEntityForester;
+import mod.acgaming.universaltweaks.mods.cyclic.memory.UTFakePlayerContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = {
+    TileEntityStructureBuilder.class,
+    TileEntityPlacer.class,
+    TileEntityControlledMiner.class,
+    TileEntityFluidDrain.class,
+    TileEntityForester.class
+}, remap = false)
+public class UTTilesVerifyingFakePlayerMixin extends TileEntity
+{
+    @ModifyExpressionValue(method = "verifyFakePlayer", at = @At(value = "INVOKE", target = "Lcom/lothrazar/cyclicmagic/util/UtilFakePlayer;initFakePlayer(Lnet/minecraft/world/WorldServer;Ljava/util/UUID;Ljava/lang/String;)Ljava/lang/ref/WeakReference;"))
+    private WeakReference<FakePlayer> utSetFakePlayerContext(WeakReference<FakePlayer> original)
+    {
+        return UTFakePlayerContext.wrap(original, getWorld(), getPos());
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTUtilFakePlayerMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/cyclic/memory/mixin/UTUtilFakePlayerMixin.java
@@ -1,4 +1,4 @@
-package mod.acgaming.universaltweaks.mods.cyclic.mixin;
+package mod.acgaming.universaltweaks.mods.cyclic.memory.mixin;
 
 import java.util.UUID;
 
@@ -18,8 +18,12 @@ public class UTUtilFakePlayerMixin
     @Unique
     private static final GameProfile ut$CYCLIC_PROFILE = new GameProfile(UUID.nameUUIDFromBytes(Const.MODID.getBytes()), "[Cyclic]");
 
+    /**
+     * Use shared profile for fake players. World context (dimension, position) must be set each time before use by the caller.
+     */
     @Redirect(method = "initFakePlayer", at = @At(value = "NEW", target = "(Ljava/util/UUID;Ljava/lang/String;)Lcom/mojang/authlib/GameProfile;"))
-    private static GameProfile utUseSharedProfile(UUID id, String name) {
+    private static GameProfile utUseSharedProfile(UUID id, String name)
+    {
         return ut$CYCLIC_PROFILE;
     }
 }

--- a/src/main/resources/mixins/mods/mixins.cyclic.json
+++ b/src/main/resources/mixins/mods/mixins.cyclic.json
@@ -1,7 +1,0 @@
-{
-  "package": "mod.acgaming.universaltweaks.mods.cyclic.mixin",
-  "refmap": "universaltweaks.refmap.json",
-  "minVersion": "0.8",
-  "compatibilityLevel": "JAVA_8",
-  "mixins": ["UTUtilFakePlayerMixin"]
-}

--- a/src/main/resources/mixins/mods/mixins.cyclic.memory.json
+++ b/src/main/resources/mixins/mods/mixins.cyclic.memory.json
@@ -1,0 +1,10 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.cyclic.memory.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
+  "mixins": ["UTBlockSpikesRetractableMixin", "UTTileEntityBlockMinerMixin", "UTTileEntityUserMixin", "UTTilesVerifyingFakePlayerMixin", "UTUtilFakePlayerMixin"]
+}


### PR DESCRIPTION
Fixes #903. Still uses a shared fake player, but sets world/position context before using it for the respective tiles/blocks.