### PR TITLE
Allow JEI to shrink-wrap tinkers' GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
     * **Disable Rendering Items in Smeltery:** Disables rendering items in the world when they are inside the Smeltery to prevent lag while rendering
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Gaseous Fluids:** Excludes gaseous fluids from being transferable via faucets
+    * **JEI Bounds:** Allows JEI to wrap the tinkers' GUIs instead of leaving large empty spaces
     * **Material Blacklist:** Hides tool/bow materials in the 'Materials and You' book
     * **Offhand Shuriken:** Suppresses special abilities of long swords and rapiers when shurikens are wielded in the offhand
     * **Ore Dictionary Cache:** Caches all ore dictionary smelting recipes to speed up game loading

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1586,6 +1586,11 @@ public class UTConfigMods
     public static class TinkersConstructCategory
     {
         @Config.RequiresMcRestart
+        @Config.Name("JEI Bounds")
+        @Config.Comment("Allows JEI to wrap the tinkers' GUIs instead of leaving large empty spaces")
+        public boolean utTConJEIBoundsToggle = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Gaseous Fluids")
         @Config.Comment("Excludes gaseous fluids from being transferable via faucets")
         public boolean utTConGaseousFluidsToggle = false;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -54,6 +54,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.roost.json", c -> c.isModPresent("roost") && c.isModPresent("contenttweaker"));
                 put("mixins/mods/mixins.storagedrawers.client.json", c -> c.isModPresent("storagedrawers"));
                 put("mixins/mods/mixins.tconstruct.client.json", c -> regularTConLoaded() && UTConfigMods.TINKERS_CONSTRUCT.utParticleFixesToggle);
+                put("mixins/mods/mixins.tconstruct.multimodulejeibounds.client.json", c -> c.isModPresent("tconstruct") && c.isModPresent("jei") && UTConfigMods.TINKERS_CONSTRUCT.utTConJEIBoundsToggle);
             }
             if (UTConfigGeneral.MASTER_SWITCHES.utMasterSwitchTweaks)
             {

--- a/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/UTMantleMultiModuleJEIBoundsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/tconstruct/mixin/UTMantleMultiModuleJEIBoundsMixin.java
@@ -1,0 +1,165 @@
+package mod.acgaming.universaltweaks.mods.tconstruct.mixin;
+
+import java.awt.Rectangle;
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Container;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import slimeknights.mantle.client.gui.GuiModule;
+import slimeknights.mantle.client.gui.GuiMultiModule;
+
+/**
+ * Keeps JEI's main GUI bounds on Mantle's central panel while preserving input
+ * handling for any side modules. This allows JEI wrapping nicely around Mantle's
+ * GUIs, instead of squashing it to the sides and leaving a lot of empty space.
+ */
+@Mixin(value = GuiMultiModule.class, remap = false)
+public abstract class UTMantleMultiModuleJEIBoundsMixin extends GuiContainer
+{
+    protected UTMantleMultiModuleJEIBoundsMixin(Container inventorySlotsIn)
+    {
+        super(inventorySlotsIn);
+    }
+
+    @Shadow
+    protected List<GuiModule> modules;
+    @Shadow
+    public int cornerX;
+    @Shadow
+    public int cornerY;
+    @Shadow
+    public int realWidth;
+    @Shadow
+    public int realHeight;
+
+    @Unique
+    private int ut$savedGuiLeft;
+    @Unique
+    private int ut$savedGuiTop;
+    @Unique
+    private int ut$savedXSize;
+    @Unique
+    private int ut$savedYSize;
+    @Unique
+    private boolean ut$moduleBoundsExpanded;
+
+    @Unique
+    private void ut$resetToRealBounds()
+    {
+        guiLeft = cornerX;
+        guiTop = cornerY;
+        xSize = realWidth;
+        ySize = realHeight;
+    }
+
+    @Unique
+    private void ut$expandToModuleBounds()
+    {
+        if (ut$moduleBoundsExpanded) return;
+
+        ut$savedGuiLeft = guiLeft;
+        ut$savedGuiTop = guiTop;
+        ut$savedXSize = xSize;
+        ut$savedYSize = ySize;
+        ut$moduleBoundsExpanded = true;
+
+        int minX = cornerX;
+        int minY = cornerY;
+        int maxX = cornerX + realWidth;
+        int maxY = cornerY + realHeight;
+        for (GuiModule module : modules)
+        {
+            minX = Math.min(minX, module.guiLeft);
+            minY = Math.min(minY, module.guiTop);
+            maxX = Math.max(maxX, module.guiRight());
+            maxY = Math.max(maxY, module.guiBottom());
+        }
+
+        guiLeft = minX;
+        guiTop = minY;
+        xSize = maxX - minX;
+        ySize = maxY - minY;
+    }
+
+    @Unique
+    private void ut$restoreBoundsAfterMouse()
+    {
+        if (!ut$moduleBoundsExpanded) return;
+
+        guiLeft = ut$savedGuiLeft;
+        guiTop = ut$savedGuiTop;
+        xSize = ut$savedXSize;
+        ySize = ut$savedYSize;
+        ut$moduleBoundsExpanded = false;
+    }
+
+    @Inject(method = "updateSubmodule", at = @At("TAIL"))
+    private void ut$keepRealBoundsAfterModuleUpdates(GuiModule module, CallbackInfo ci)
+    {
+        ut$resetToRealBounds();
+    }
+
+    @Inject(method = "initGui", at = @At("TAIL"))
+    private void ut$keepRealBoundsAfterInit(CallbackInfo ci)
+    {
+        ut$resetToRealBounds();
+    }
+
+    @Inject(method = "setWorldAndResolution", at = @At("TAIL"))
+    private void ut$keepRealBoundsAfterResolution(Minecraft mc, int width, int height, CallbackInfo ci)
+    {
+        ut$resetToRealBounds();
+    }
+
+    @Inject(method = "onResize", at = @At("TAIL"))
+    private void ut$keepRealBoundsAfterResize(Minecraft mc, int width, int height, CallbackInfo ci)
+    {
+        ut$resetToRealBounds();
+    }
+
+    @Inject(method = "mouseClicked", at = @At("HEAD"))
+    private void ut$expandBoundsBeforeMouseClick(int mouseX, int mouseY, int mouseButton, CallbackInfo ci)
+    {
+        ut$expandToModuleBounds();
+    }
+
+    @Inject(method = "mouseClicked", at = @At("RETURN"))
+    private void ut$restoreBoundsAfterMouseClick(int mouseX, int mouseY, int mouseButton, CallbackInfo ci)
+    {
+        ut$restoreBoundsAfterMouse();
+    }
+
+    @Inject(method = "mouseClickMove", at = @At("HEAD"))
+    private void ut$expandBoundsBeforeMouseDrag(int mouseX, int mouseY, int clickedMouseButton, long timeSinceLastClick, CallbackInfo ci)
+    {
+        ut$expandToModuleBounds();
+    }
+
+    @Inject(method = "mouseClickMove", at = @At("RETURN"))
+    private void ut$restoreBoundsAfterMouseDrag(int mouseX, int mouseY, int clickedMouseButton, long timeSinceLastClick, CallbackInfo ci)
+    {
+        ut$restoreBoundsAfterMouse();
+    }
+
+    @Inject(method = "mouseReleased", at = @At("HEAD"))
+    private void ut$expandBoundsBeforeMouseRelease(int mouseX, int mouseY, int state, CallbackInfo ci)
+    {
+        ut$expandToModuleBounds();
+    }
+
+    @Inject(method = "mouseReleased", at = @At("RETURN"))
+    private void ut$restoreBoundsAfterMouseRelease(int mouseX, int mouseY, int state, CallbackInfo ci)
+    {
+        ut$restoreBoundsAfterMouse();
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.tconstruct.multimodulejeibounds.client.json
+++ b/src/main/resources/mixins/mods/mixins.tconstruct.multimodulejeibounds.client.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.tconstruct.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTMantleMultiModuleJEIBoundsMixin"]
+}


### PR DESCRIPTION
At the moment, Tinkers Construct's GUIs expand their size with each module, which can cause JEI to be very squished or even disappear altogether in some narrow aspect ratios :
<img width="958" height="1101" alt="2026-08-25_23 52 25" src="https://github.com/user-attachments/assets/51c6caea-18c5-4f47-aab2-54a9762d8ef3" />

This PR mixins into Mantle directly to prevent modules from resizing the main GUI and rely instead on the already-existing JEI exclusion areas to do the job (wonder why modules needed to extend the GUI, really). This allows JEI to wrap around the modules without being squished, while preserving all click/hover/etc behavior :
<img width="958" height="1101" alt="2026-08-26_00 54 54" src="https://github.com/user-attachments/assets/273feb30-2239-4165-a356-092544fda327" />

I have not found any fork of Mantle to contribute this fix to, so this will live here for now.