### PR TITLE
Fix GUI Close Slot Crash:** Prevents crashes from processing slot hotkeys after closing Ender Utilities GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
     * **Save Filter Cycle Buttons Properly:** Fixes an issue where Cycle Buttons for Damage do not report being clicked when in the Picker Overlay, preventing changing Damage values until clicked again
 * **Ender Storage**
     * **Fix Frequency Tracking:** Fixes storage frequencies being tracked multiple times
+* **Ender Utilities**
+    * **Fix GUI Close Slot Crash:** Prevents crashes from processing slot hotkeys after closing Ender Utilities GUIs (e.g. handybag hotkey 1-9 crash)
 * **Epic Siege Mod**
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -98,6 +98,7 @@ final def mod_dependencies = [
     'curse.maven:elementary-staffs-346007:2995593'                    : [debug_elementary_staffs],
     'curse.maven:elenaidodge2-442962:3343308'                         : [debug_elenai_dodge_2],
     'curse.maven:enderstorage-245174:2755787'                         : [debug_enderstorage],
+    'maven.modrinth:ALKGFBqb:6AWXd1S8'                                : [debug_enderutilities],
     'curse.maven:epic-siege-mod-229449:3356157'                       : [debug_epic_siege_mod],
     'curse.maven:evilcraft-74610:2811267'                             : [debug_evilcraft],
     'curse.maven:extrautilities-225561:2678374'                       : [debug_extra_utilities_2],

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,7 @@ debug_elementary_staffs = false
 debug_elenai_dodge_2 = false
 debug_enderio = false
 debug_enderstorage = false
+debug_enderutilities = false
 debug_epic_siege_mod = false
 debug_erebus = false
 debug_evilcraft = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -159,6 +159,10 @@ public class UTConfigMods
     @Config.Name("Ender Storage")
     public static final EnderStorageCategory ENDER_STORAGE = new EnderStorageCategory();
 
+    @Config.LangKey("cfg.universaltweaks.modintegration.enderutilities")
+    @Config.Name("Ender Utilities")
+    public static final EnderUtilitiesCategory ENDER_UTILITIES = new EnderUtilitiesCategory();
+
     @Config.LangKey("cfg.universaltweaks.modintegration.esm")
     @Config.Name("Epic Siege Mod")
     public static final EpicSiegeModCategory EPIC_SIEGE_MOD = new EpicSiegeModCategory();
@@ -900,6 +904,14 @@ public class UTConfigMods
         @Config.Name("Fix Frequency Tracking")
         @Config.Comment("Fixes storage frequencies being tracked multiple times")
         public boolean utFrequencyTrackFixToggle = true;
+    }
+
+    public static class EnderUtilitiesCategory
+    {
+        @Config.RequiresMcRestart
+        @Config.Name("Fix GUI Close Slot Crash")
+        @Config.Comment("Prevents slot hotkeys from being processed after an Ender Utilities GUI has already been closed")
+        public boolean utGuiCloseSlotCrashFixToggle = true;
     }
 
     public static class EpicSiegeModCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -44,6 +44,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.cyclic.enderbook.client.json", c -> c.isModPresent("cyclicmagic") && UTConfigMods.CYCLIC.utEnderBookPagination);
                 put("mixins/mods/mixins.electroblobswizardry.json", c -> c.isModPresent("ebwizardry") && c.isModPresent("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);
                 put("mixins/mods/mixins.enderio.itemrender.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
+                put("mixins/mods/mixins.enderutilities.json", c -> c.isModPresent("enderutilities") && UTConfigMods.ENDER_UTILITIES.utGuiCloseSlotCrashFixToggle);
                 put("mixins/mods/mixins.fpsreducer.json", c -> c.isModPresent("fpsreducer") && UTConfigMods.FPS_REDUCER.utCorrectFpsValue);
                 put("mixins/mods/mixins.hammerlib.color.json", c -> c.isModPresent("hammercore") && UTConfigMods.HAMMER_LIB.utOptimizeItemColorHelper);
                 put("mixins/mods/mixins.hammerlib.url.json", c -> c.isModPresent("hammercore") && UTConfigMods.HAMMER_LIB.utSkipURLCheck);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/mixin/UTGuiEnderUtilitiesMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/mixin/UTGuiEnderUtilitiesMixin.java
@@ -1,0 +1,28 @@
+package mod.acgaming.universaltweaks.mods.enderutilities.mixin;
+
+import fi.dy.masa.enderutilities.gui.client.base.GuiEnderUtilities;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.input.Keyboard;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = GuiEnderUtilities.class, remap = false)
+public abstract class UTGuiEnderUtilitiesMixin
+{
+    /**
+     * @reason Stop processing slot hotkeys after the GUI has been closed.
+     */
+    @Inject(method = "keyTyped", at = @At("HEAD"), cancellable = true, require = 0, remap = true)
+    private void utStopKeyHandlingAfterClose(char typedChar, int keyCode, CallbackInfo ci)
+    {
+        Minecraft mc = Minecraft.getMinecraft();
+
+        if (keyCode == Keyboard.KEY_ESCAPE || mc.gameSettings.keyBindInventory.isActiveAndMatches(keyCode))
+        {
+            mc.player.closeScreen();
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/assets/universaltweaks/lang/en_us.lang
+++ b/src/main/resources/assets/universaltweaks/lang/en_us.lang
@@ -120,6 +120,7 @@ cfg.universaltweaks.modintegration.elementarystaffs=Elementary Staffs
 cfg.universaltweaks.modintegration.elenaidodge2=Elenai Dodge 2
 cfg.universaltweaks.modintegration.enderio=Ender IO
 cfg.universaltweaks.modintegration.enderstorage=Ender Storage
+cfg.universaltweaks.modintegration.enderutilities=Ender Utilities
 cfg.universaltweaks.modintegration.erebus=The Erebus
 cfg.universaltweaks.modintegration.evilcraft=EvilCraft
 cfg.universaltweaks.modintegration.esm=Epic Siege Mod

--- a/src/main/resources/mixins/mods/mixins.enderutilities.json
+++ b/src/main/resources/mixins/mods/mixins.enderutilities.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderutilities.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiEnderUtilitiesMixin"]
+}


### PR DESCRIPTION
Fixes an Ender Utilities GUI crash where closing the GUI can still allow the same key event to continue into hotbar slot handling, causing stale high slot IDs to be used against the 46-slot player container.