### PR TITLE
tweak(perf): skip fluid registration checks for FluidStack constructors

### DIFF
--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigTweaks.java
@@ -1964,6 +1964,11 @@ public class UTConfigTweaks
         @Config.Comment("Restores feature to tilt the camera when damaged")
         public boolean utDamageTiltToggle = true;
 
+        @Config.RequiresMcRestart
+        @Config.Name("Unsafe FluidStack Constructor")
+        @Config.Comment("Skips the registration check for fluid in FluidStack construtcors")
+        public boolean utUnsafeFluidStackConstructorToggle = true;
+
         @Config.Name("Default Difficulty")
         @Config.Comment("Sets the default difficulty for newly generated worlds")
         public EnumDifficulty utDefaultDifficulty = EnumDifficulty.NORMAL;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -218,6 +218,7 @@ public class UTMixinLoader implements ILateMixinLoader
             if (UTConfigGeneral.MASTER_SWITCHES.utMasterSwitchTweaks)
             {
                 put("mixins/tweaks/mixins.blocks.enchantmenttable.bookshelf.json", c -> c.isModPresent("bookshelf") && UTConfigTweaks.BLOCKS.utEnchantmentTableObstructionToggle);
+                put("mixins/tweaks/mixins.misc.unsafefluidstack.json", c -> UTConfigTweaks.MISC.utUnsafeFluidStackConstructorToggle);
             }
         }
     });

--- a/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fluidstackconstructor/mixin/UTUnsafeFluidStackMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/tweaks/misc/fluidstackconstructor/mixin/UTUnsafeFluidStackMixin.java
@@ -1,0 +1,20 @@
+package mod.acgaming.universaltweaks.tweaks.misc.fluidstackconstructor.mixin;
+
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import mod.acgaming.universaltweaks.config.UTConfigTweaks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = FluidStack.class, remap = false)
+public class UTUnsafeFluidStackMixin
+{
+    @Redirect(method = "<init>(Lnet/minecraftforge/fluids/Fluid;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fluids/FluidRegistry;isFluidRegistered(Lnet/minecraftforge/fluids/Fluid;)Z"))
+    public boolean utUnsafeFluidStackConstructor(Fluid fluid)
+    {
+        return UTConfigTweaks.MISC.utUnsafeFluidStackConstructorToggle;
+    }
+}

--- a/src/main/resources/mixins/tweaks/mixins.misc.unsafefluidstack.json
+++ b/src/main/resources/mixins/tweaks/mixins.misc.unsafefluidstack.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.tweaks.misc.fluidstackconstructor.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTUnsafeFluidStackMixin"]
+}


### PR DESCRIPTION
This should reduce a lot of lag for bases with massive fluid I/O.