### PR TITLE
Make FTB button show on Handy Bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
     * **Fix Frequency Tracking:** Fixes storage frequencies being tracked multiple times
 * **Ender Utilities**
     * **Fix GUI Close Slot Crash:** Prevents crashes from processing slot hotkeys after closing Ender Utilities GUIs (e.g. handybag hotkey 1-9 crash)
+    * **Show FTB Utilities Buttons in Handy Bag:** Shows the configured FTB Utilities and FTB Library sidebar buttons in Handy Bags
 * **Epic Siege Mod**
     * **Disable Digger AI Debug:** Disables leftover debug logging inside the digger AI of the beta builds
 * **Extra Utilities 2**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -108,6 +108,8 @@ final def mod_dependencies = [
     'curse.maven:forge-backpacks-59143:2554237'                       : [debug_backpack],
     'curse.maven:forgemultipartcbe-258426:2755790'                    : [debug_forgemultipartcbe, debug_project_red],
     'curse.maven:fps-reducer-280294:3362160'                          : [debug_fps_reducer],
+    'curse.maven:ftb-utilities-forge-237102:3157548'                  : [debug_ftb_utilities],
+    'curse.maven:ftb-library-legacy-forge-237167:2985811'             : [debug_ftb_utilities],
     'curse.maven:gaiadimension-302529:2724738'                        : [debug_gaiadimension],
     'curse.maven:geckolib-388172:4020277'                             : [debug_cqrepoured],
     'curse.maven:guideapi-228832:2645992'                             : [debug_blood_magic],

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ debug_extreme_reactors = false
 debug_forestry = false
 debug_forgemultipartcbe = false
 debug_fps_reducer = false
+debug_ftb_utilities = false
 debug_gaiadimension = false
 debug_hammerlib = false
 debug_hwyla = false

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -929,6 +929,11 @@ public class UTConfigMods
         @Config.Name("Fix GUI Close Slot Crash")
         @Config.Comment("Prevents slot hotkeys from being processed after an Ender Utilities GUI has already been closed")
         public boolean utGuiCloseSlotCrashFixToggle = true;
+
+        @Config.RequiresMcRestart
+        @Config.Name("Show FTB Utilities Buttons in Handy Bag")
+        @Config.Comment("Shows FTB Utilities and FTB Library sidebar buttons in Ender Utilities Handy Bags")
+        public boolean utHandyBagFTBUtilitiesButtonsToggle = true;
     }
 
     public static class EpicSiegeModCategory

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -45,6 +45,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.electroblobswizardry.json", c -> c.isModPresent("ebwizardry") && c.isModPresent("conarm") && UTConfigMods.ELECTROBLOBS_WIZARDRY.utConstructsArmoryFixToggle);
                 put("mixins/mods/mixins.enderio.itemrender.json", c -> c.isModPresent("enderio") && UTConfigMods.ENDER_IO.utReplaceItemRenderer);
                 put("mixins/mods/mixins.enderutilities.json", c -> c.isModPresent("enderutilities") && UTConfigMods.ENDER_UTILITIES.utGuiCloseSlotCrashFixToggle);
+                put("mixins/mods/mixins.enderutilities.ftbutilities.json", c -> c.isModPresent("enderutilities") && c.isModPresent("ftblib") && c.isModPresent("ftbutilities") && UTConfigMods.ENDER_UTILITIES.utHandyBagFTBUtilitiesButtonsToggle);
                 put("mixins/mods/mixins.fpsreducer.json", c -> c.isModPresent("fpsreducer") && UTConfigMods.FPS_REDUCER.utCorrectFpsValue);
                 put("mixins/mods/mixins.hammerlib.color.json", c -> c.isModPresent("hammercore") && UTConfigMods.HAMMER_LIB.utOptimizeItemColorHelper);
                 put("mixins/mods/mixins.hammerlib.url.json", c -> c.isModPresent("hammercore") && UTConfigMods.HAMMER_LIB.utSkipURLCheck);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/client/UTGuiHandyBagSidebarButtonGroup.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/client/UTGuiHandyBagSidebarButtonGroup.java
@@ -1,0 +1,232 @@
+package mod.acgaming.universaltweaks.mods.enderutilities.client;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.feed_the_beast.ftblib.client.FTBLibClientConfig;
+import com.feed_the_beast.ftblib.client.FTBLibClientEventHandler;
+import com.feed_the_beast.ftblib.client.SidebarButton;
+import com.feed_the_beast.ftblib.client.SidebarButtonGroup;
+import com.feed_the_beast.ftblib.client.SidebarButtonManager;
+import com.feed_the_beast.ftblib.lib.icon.Color4I;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+import org.lwjgl.input.Mouse;
+import org.lwjgl.opengl.GL11;
+
+// See {@code com.feed_the_beast.ftblib.client.FTBLibClientEventHandler.GuiButtonSidebarGroup}
+public class UTGuiHandyBagSidebarButtonGroup extends GuiButton
+{
+    private final GuiContainer gui;
+    private final List<SidebarButtonEntry> buttons;
+    private SidebarButtonEntry mouseOver;
+
+    public UTGuiHandyBagSidebarButtonGroup(GuiContainer gui)
+    {
+        super(495829, 0, 0, 0, 0, "");
+
+        this.gui = gui;
+        this.buttons = new ArrayList<>();
+    }
+
+    @Override
+    public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks)
+    {
+        this.buttons.clear();
+        this.mouseOver = null;
+        int buttonX;
+        int buttonY = 0;
+        boolean addedAny;
+        boolean top = FTBLibClientConfig.action_buttons.top() || !mc.player.getActivePotionEffects().isEmpty();
+
+        for (SidebarButtonGroup group : SidebarButtonManager.INSTANCE.groups)
+        {
+            buttonX = 0;
+            addedAny = false;
+
+            for (SidebarButton button : group.getButtons())
+            {
+                if (button.isActuallyVisible())
+                {
+                    this.buttons.add(new SidebarButtonEntry(buttonX, buttonY, button));
+                    buttonX++;
+                    addedAny = true;
+                }
+            }
+
+            if (addedAny)
+            {
+                buttonY++;
+            }
+        }
+
+        if (this.buttons.isEmpty())
+        {
+            this.visible = false;
+            FTBLibClientEventHandler.lastDrawnArea = new Rectangle();
+            return;
+        }
+
+        this.visible = true;
+        int guiLeft = this.gui.getGuiLeft();
+        int guiTop = this.gui.getGuiTop();
+
+        if (top)
+        {
+            for (SidebarButtonEntry button : this.buttons)
+            {
+                button.x = 1 + button.buttonX * 17;
+                button.y = 1 + button.buttonY * 17;
+            }
+        }
+        else
+        {
+            for (SidebarButtonEntry button : this.buttons)
+            {
+                button.x = guiLeft - 18 - button.buttonY * 17;
+                button.y = guiTop + 8 + button.buttonX * 17;
+            }
+        }
+
+        this.x = Integer.MAX_VALUE;
+        this.y = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+
+        for (SidebarButtonEntry button : this.buttons)
+        {
+            this.x = Math.min(this.x, button.x);
+            this.y = Math.min(this.y, button.y);
+            maxX = Math.max(maxX, button.x + 16);
+            maxY = Math.max(maxY, button.y + 16);
+
+            if (mouseX >= button.x && mouseY >= button.y && mouseX < button.x + 16 && mouseY < button.y + 16)
+            {
+                this.mouseOver = button;
+            }
+        }
+
+        this.x -= 2;
+        this.y -= 2;
+        maxX += 2;
+        maxY += 2;
+        this.width = maxX - this.x;
+        this.height = maxY - this.y;
+        this.zLevel = 0.0F;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(0.0F, 0.0F, 500.0F);
+
+        FontRenderer fontRenderer = mc.fontRenderer;
+
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+
+        for (SidebarButtonEntry button : this.buttons)
+        {
+            button.button.getIcon().draw(button.x, button.y, 16, 16);
+
+            if (button == this.mouseOver)
+            {
+                Color4I.WHITE.withAlpha(33).draw(button.x, button.y, 16, 16);
+            }
+
+            if (button.button.getCustomTextHandler() != null)
+            {
+                String text = button.button.getCustomTextHandler().get();
+
+                if (text.isEmpty() == false)
+                {
+                    int textWidth = fontRenderer.getStringWidth(text);
+                    Color4I.LIGHT_RED.draw(button.x + 16 - textWidth, button.y - 1, textWidth + 1, 9);
+                    fontRenderer.drawString(text, button.x + 17 - textWidth, button.y, 0xFFFFFFFF);
+                    GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+                }
+            }
+        }
+
+        if (this.mouseOver != null)
+        {
+            this.drawTooltip(fontRenderer, mouseX, mouseY);
+        }
+
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        GlStateManager.popMatrix();
+        this.zLevel = 0.0F;
+
+        FTBLibClientEventHandler.lastDrawnArea = new Rectangle(this.x, this.y, this.width, this.height);
+    }
+
+    private void drawTooltip(FontRenderer fontRenderer, int mouseX, int mouseY)
+    {
+        int tooltipX = mouseX + 10;
+        int tooltipY = Math.max(3, mouseY - 9);
+        List<String> tooltip = new ArrayList<>();
+        tooltip.add(I18n.format(this.mouseOver.button.getLangKey()));
+
+        if (this.mouseOver.button.getTooltipHandler() != null)
+        {
+            this.mouseOver.button.getTooltipHandler().accept(tooltip);
+        }
+
+        int tooltipWidth = 0;
+
+        for (String line : tooltip)
+        {
+            tooltipWidth = Math.max(tooltipWidth, fontRenderer.getStringWidth(line));
+        }
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(0.0F, 0.0F, 500.0F);
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        Color4I.DARK_GRAY.draw(tooltipX - 3, tooltipY - 2, tooltipWidth + 6, 2 + tooltip.size() * 10);
+
+        for (int i = 0; i < tooltip.size(); i++)
+        {
+            fontRenderer.drawString(tooltip.get(i), tooltipX, tooltipY + i * 10, 0xFFFFFFFF);
+        }
+
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        GlStateManager.popMatrix();
+    }
+
+    public void onClicked()
+    {
+        if (this.mouseOver == null)
+        {
+            return;
+        }
+
+        this.mouseOver.button.onClicked(GuiScreen.isShiftKeyDown());
+    }
+
+    @Override
+    public boolean mousePressed(Minecraft mc, int mouseX, int mouseY)
+    {
+        return Mouse.getEventDWheel() == 0 && super.mousePressed(mc, mouseX, mouseY);
+    }
+
+    private static class SidebarButtonEntry
+    {
+        private final int buttonX;
+        private final int buttonY;
+        private final SidebarButton button;
+        private int x;
+        private int y;
+
+        private SidebarButtonEntry(int buttonX, int buttonY, SidebarButton button)
+        {
+            this.buttonX = buttonX;
+            this.buttonY = buttonY;
+            this.button = button;
+        }
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/mixin/UTGuiHandyBagSidebarButtonsMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/enderutilities/mixin/UTGuiHandyBagSidebarButtonsMixin.java
@@ -1,0 +1,61 @@
+package mod.acgaming.universaltweaks.mods.enderutilities.mixin;
+
+import com.feed_the_beast.ftblib.client.EnumSidebarButtonPlacement;
+import com.feed_the_beast.ftblib.client.FTBLibClientConfig;
+import com.feed_the_beast.ftblib.client.SidebarButtonManager;
+import mod.acgaming.universaltweaks.mods.enderutilities.client.UTGuiHandyBagSidebarButtonGroup;
+import fi.dy.masa.enderutilities.gui.client.GuiHandyBag;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Container;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = GuiHandyBag.class, remap = false)
+public abstract class UTGuiHandyBagSidebarButtonsMixin extends GuiContainer
+{
+    @Unique
+    private GuiButton ut$sidebarButtons;
+
+    protected UTGuiHandyBagSidebarButtonsMixin(Container inventorySlotsIn)
+    {
+        super(inventorySlotsIn);
+    }
+
+    @Inject(method = "createButtons", at = @At("TAIL"), require = 1, remap = false)
+    private void ut$restoreSidebarButtons(CallbackInfo ci)
+    {
+        this.ut$addSidebarButtons();
+    }
+
+    @Inject(method = "actionPerformedWithButton", at = @At("TAIL"), require = 1, remap = false)
+    private void ut$clickSidebarButton(GuiButton button, int mouseButton, CallbackInfo ci)
+    {
+        if (button == this.ut$sidebarButtons && mouseButton == 0)
+        {
+            ((UTGuiHandyBagSidebarButtonGroup) this.ut$sidebarButtons).onClicked();
+        }
+    }
+
+    @Unique
+    private void ut$addSidebarButtons()
+    {
+        if (FTBLibClientConfig.action_buttons == EnumSidebarButtonPlacement.DISABLED || SidebarButtonManager.INSTANCE.groups.isEmpty())
+        {
+            return;
+        }
+
+        if (this.ut$sidebarButtons == null)
+        {
+            this.ut$sidebarButtons = new UTGuiHandyBagSidebarButtonGroup(this);
+        }
+
+        if (this.buttonList.contains(this.ut$sidebarButtons) == false)
+        {
+            this.buttonList.add(this.ut$sidebarButtons);
+        }
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.enderutilities.ftbutilities.json
+++ b/src/main/resources/mixins/mods/mixins.enderutilities.ftbutilities.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.enderutilities.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "client": ["UTGuiHandyBagSidebarButtonsMixin"]
+}


### PR DESCRIPTION
The FTB Utilities buttons (claim, trash, team) only show on the normal inventory, but the Handy Bag from Ender Utilities bypass the inventory and shows its own container. This PR aims to replicate the normal FTB Utilities behavior on the Handy Bag GUI.

Result :
<img width="958" height="1101" alt="2026-08-31_19 35 11" src="https://github.com/user-attachments/assets/a1852c9e-bec5-4a67-8ee2-7ae939e92700" />
