### PR TITLE
Remove position NBT from dropped drawers

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
     * **Sky of Old Dimension Fix:** Fixes a Stack Overflow crash when entering the Sky of Old Dimension
 * **Storage Drawers**
     * **Item Voiding Fix:** Prevents voiding of items when near capacity limits
+    * **Remove Position from Drops:** Removes position data from drawers that keep their contents when broken, allowing them to stack with each other
     * **Render Range:** Approximate range in blocks at which drawers render contained items
 * **Tardis**
     * **Memory Leak Fix:** Fixes a client-side memory leak associated with EntityPlayer

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -1531,6 +1531,11 @@ public class UTConfigMods
         public boolean utSDItemVoidingFixToggle = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Remove Position from Drops")
+        @Config.Comment("Removes position data from drawers that keep their contents when broken")
+        public boolean utSDRemoveDropCoordinatesToggle = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Render Range")
         @Config.Comment
             ({

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -198,6 +198,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.simpledifficulty.raincollector.json", c -> c.isModPresent("simpledifficulty") && UTConfigMods.SIMPLE_DIFFICULTY.utRainCollectorCanteenToggle);
                 put("mixins/mods/mixins.spiceoflife.dupes.json", c -> c.isModPresent("spiceoflife") && UTConfigMods.SPICE_OF_LIFE.utDuplicationFixesToggle);
                 put("mixins/mods/mixins.steamworld.json", c -> c.isModPresent("steamworld") && UTConfigMods.STEAMWORLD.utSkyOfOldFixToggle);
+                put("mixins/mods/mixins.storagedrawers.dropposition.json", c -> c.isModPresent("storagedrawers") && UTConfigMods.STORAGE_DRAWERS.utSDRemoveDropCoordinatesToggle);
                 put("mixins/mods/mixins.storagedrawers.json", c -> c.isModPresent("storagedrawers") && UTConfigMods.STORAGE_DRAWERS.utSDItemVoidingFixToggle);
                 put("mixins/mods/mixins.tconstruct.json", c -> regularTConLoaded());
                 put("mixins/mods/mixins.tconstruct.oredictcache.json", c -> regularTConLoaded() && UTConfigMods.TINKERS_CONSTRUCT.utTConOreDictCacheToggle);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawersDropMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawersDropMixin.java
@@ -1,0 +1,39 @@
+package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.Constants;
+
+import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Remove the position data from the dropped item so that it stacks with others
+@Mixin(value = BlockDrawers.class, remap = false)
+public abstract class UTDrawersDropMixin
+{
+
+    @Inject(method = "getDrops", at = @At("TAIL"))
+    private void utRemoveDropPosition(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos,
+                                      IBlockState state, int fortune, CallbackInfo ci)
+    {
+        if (drops.isEmpty()) return;
+
+        ItemStack drop = drops.get(drops.size() - 1);
+        if (!drop.hasTagCompound()) return;
+
+        NBTTagCompound data = drop.getTagCompound();
+        if (!data.hasKey("tile", Constants.NBT.TAG_COMPOUND)) return;
+
+        NBTTagCompound tileData = data.getCompoundTag("tile");
+        tileData.removeTag("x");
+        tileData.removeTag("y");
+        tileData.removeTag("z");
+    }
+}

--- a/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawersDropMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/storagedrawers/mixin/UTDrawersDropMixin.java
@@ -1,39 +1,38 @@
 package mod.acgaming.universaltweaks.mods.storagedrawers.mixin;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.Constants;
 
 import com.jaquadro.minecraft.storagedrawers.block.BlockDrawers;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // Remove the position data from the dropped item so that it stacks with others
 @Mixin(value = BlockDrawers.class, remap = false)
 public abstract class UTDrawersDropMixin
 {
 
-    @Inject(method = "getDrops", at = @At("TAIL"))
-    private void utRemoveDropPosition(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos,
-                                      IBlockState state, int fortune, CallbackInfo ci)
+    @ModifyExpressionValue(
+        method = "getDrops",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/jaquadro/minecraft/storagedrawers/block/BlockDrawers;getMainDrop(Lnet/minecraft/world/IBlockAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/item/ItemStack;"
+        )
+    )
+    private ItemStack utRemoveDropPosition(ItemStack original)
     {
-        if (drops.isEmpty()) return;
+        if (!original.hasTagCompound()) return original;
 
-        ItemStack drop = drops.get(drops.size() - 1);
-        if (!drop.hasTagCompound()) return;
-
-        NBTTagCompound data = drop.getTagCompound();
-        if (!data.hasKey("tile", Constants.NBT.TAG_COMPOUND)) return;
+        NBTTagCompound data = original.getTagCompound();
+        if (!data.hasKey("tile", Constants.NBT.TAG_COMPOUND)) return original;
 
         NBTTagCompound tileData = data.getCompoundTag("tile");
         tileData.removeTag("x");
         tileData.removeTag("y");
         tileData.removeTag("z");
+
+        return original;
     }
 }

--- a/src/main/resources/mixins/mods/mixins.storagedrawers.dropposition.json
+++ b/src/main/resources/mixins/mods/mixins.storagedrawers.dropposition.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.storagedrawers.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTDrawersDropMixin"]
+}


### PR DESCRIPTION
When breaking a Storage Drawer with Tape or "Keep Contents", the full tile is written to NBT, including the position. This causes drawers to not stack if they were not broken at the exact same place. This PR removes the x,y,z at the exact point the drops for breaking are generated, stripping this extra NBT.