### PR TITLE
Fix immediate despawn on cursed earth when far

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Available in flavors [**Cleanroom**](https://www.curseforge.com/minecraft/modpac
 * **Extra Utilities 2**
     * **Catch Radar Exception:** Fixes the Radar feature (find in nearby inventories) entirely breaking when near some inventories
     * **Make Radar skip ungenerated chests:** Makes the Radar skip inventories when the loottable for it has not yet been generated
+    * **Cursed Earth Mob Persistence:** Prevents Cursed Earth mobs from despawning immediately when the player is far enough. This does not remove the despawn timer (which exists to prevent mob spawn runaway)
     * **Duplication Fixes:** Fixes various duplication exploits
     * **Fix Deep Dark Stats:** Fixes Mob Attack and Health Statistics being repeatedly doubled
     * **Mutable Machine Block Drops:** Fixes Machine Block drops being immutable, causing a crash on attempting to remove entries from the list.

--- a/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
+++ b/src/main/java/mod/acgaming/universaltweaks/config/UTConfigMods.java
@@ -992,6 +992,11 @@ public class UTConfigMods
         public boolean utRadarSkipsLoottables = false;
 
         @Config.RequiresMcRestart
+        @Config.Name("Cursed Earth Mob Persistence")
+        @Config.Comment("Prevents Cursed Earth mobs from despawning immediately when the player is far enough")
+        public boolean utCursedEarthMobPersistence = true;
+
+        @Config.RequiresMcRestart
         @Config.Name("Fix Deep Dark Stats")
         @Config.Comment("Fixes Mob Attack and Health Statistics being repeatedly doubled")
         public boolean utDeepDarkStats = true;

--- a/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
+++ b/src/main/java/mod/acgaming/universaltweaks/core/UTMixinLoader.java
@@ -138,6 +138,7 @@ public class UTMixinLoader implements ILateMixinLoader
                 put("mixins/mods/mixins.evilcraft.vengeancespirit.regex.json", c -> c.isModPresent("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritCache);
                 put("mixins/mods/mixins.evilcraft.vengeancespirit.random.json", c -> c.isModPresent("evilcraft") && UTConfigMods.EVIL_CRAFT.utVengeanceSpiritRandom);
                 put("mixins/mods/mixins.extrautilities.breakcreativemill.json", c -> c.isModPresent("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utFixCreativeMillHarvestability);
+                put("mixins/mods/mixins.extrautilities.cursedearth.json", c -> c.isModPresent("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utCursedEarthMobPersistence);
                 put("mixins/mods/mixins.extrautilities.deepdarkstats.json", c -> c.isModPresent("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDeepDarkStats);
                 put("mixins/mods/mixins.extrautilities.dupes.json", c -> c.isModPresent("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utDuplicationFixesToggle);
                 put("mixins/mods/mixins.extrautilities.mutabledrops.json", c -> c.isModPresent("extrautils2") && UTConfigMods.EXTRA_UTILITIES.utMutableBlockDrops);

--- a/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/cursedearth/mixin/UTCursedEarthMobPersistenceMixin.java
+++ b/src/main/java/mod/acgaming/universaltweaks/mods/extrautilities/cursedearth/mixin/UTCursedEarthMobPersistenceMixin.java
@@ -1,0 +1,22 @@
+package mod.acgaming.universaltweaks.mods.extrautilities.cursedearth.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+
+import com.rwtema.extrautils2.blocks.BlockCursedEarth;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = BlockCursedEarth.class, remap = false)
+public abstract class UTCursedEarthMobPersistenceMixin
+{
+    @Inject(method = "spawnMobAsCursed", at = @At("RETURN"), remap = false)
+    private static void ut$enableCursedEarthMobPersistence(Entity mob, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!cir.getReturnValueZ() || !(mob instanceof EntityLiving)) return;
+
+        ((EntityLiving) mob).enablePersistence();
+    }
+}

--- a/src/main/resources/mixins/mods/mixins.extrautilities.cursedearth.json
+++ b/src/main/resources/mixins/mods/mixins.extrautilities.cursedearth.json
@@ -1,0 +1,7 @@
+{
+  "package": "mod.acgaming.universaltweaks.mods.extrautilities.cursedearth.mixin",
+  "refmap": "universaltweaks.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": ["UTCursedEarthMobPersistenceMixin"]
+}


### PR DESCRIPTION
Due to vanilla rules, when above a certain distance in the same dimension (I think 128 blocks), the mobs generated by Cursed Earth instantly despawn, even if the chunk is chunkloaded. The only solution to this problem is staying near or in another dimension.
This PR toggles the persistence flag on every mob spawned by Cursed Earth, ensure they cannot despawn. Cursed earth already has a protection against runaway spawning, killing any mob after 60s from spawn, so this change is safe.

This was tested with and without the change, by tracking the accumulation of mob drops over time.